### PR TITLE
Dev levelpath patch

### DIFF
--- a/lib/snap_and_clip_to_nhd.py
+++ b/lib/snap_and_clip_to_nhd.py
@@ -115,7 +115,7 @@ def subset_vector_layers(hucCode,nwm_streams_fileName,nhd_streams_fileName,nhd_s
             if len(toNode.unique()) == 1:
                 toNode = toNode.iloc[0]
                 downstream_ids = nhd_streams.loc[nhd_streams['FromNode'] == toNode,:].index.tolist()
-        #Edit by TSG to strip out extra stream segments
+        #If multiple downstream_ids are returned select the ids that are along the main flow path (i.e. exclude segments that are diversions)
         if len(downstream_ids)>1:
             relevant_ids = [segment for segment in downstream_ids if DnLevelPat == nhd_streams.loc[segment,'LevelPathI']]
         else:


### PR DESCRIPTION
adding VAA attributes to nhd streams to deal with diverging stream segments

## Additions

-

## Removals

-

## Changes

- One of the objectives in snap_and_clip_to_nhd.py is to reduce the stream density of the NHDPlus HR stream network to match the stream network of the National Water Model. The current method identifies NHDPlus HR stream segments closest to NWM headwater streams and then uses the 'FromNode' and 'ToNode' attributes to identify relevant downstream segments. The method works most of the time but creates issues when there are divergent stream segments. This pull request addresses issue (#15) by adding additional attributes 'DnLevelPat' and 'LevelPathI' from the VAA attribute layer to deal with diverging stream segments. This pull request also partially solves a subtask of issue #4.

## Testing

1. Six ble sites were used to test the pull request. All but one site showed no change or an improved CSI compared to the current dev for 100 and 500 year flood events. The 11130304_ble CSI showed a 0.2% regression for the 100 year flood event.

## Screenshots
![image](https://user-images.githubusercontent.com/20129718/93937293-1e0f7680-fced-11ea-8bed-4c214807462e.png)
![image](https://user-images.githubusercontent.com/20129718/93937334-31badd00-fced-11ea-8b2a-5878a5db69bb.png)
![image](https://user-images.githubusercontent.com/20129718/93937156-e4d70680-fcec-11ea-935f-7a6ea4f7095a.png)
![image](https://user-images.githubusercontent.com/20129718/93937221-ff10e480-fcec-11ea-91f7-401fc6eab24c.png)

## Notes

-  For more details on evaluation, see slide deck: Github Issue #15: Extra Lines in NHDPlusBurnLineEvent 

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
