### PR TITLE
[1pt] PR: Hotfix to address file cleanup in vary_mannings_n_composite.py

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,8 +7,8 @@ Hotfix to updated `vary_mannings_n_composite.py` to use the same cleanup structu
 
 ## Changes
 
-- `fim_run.sh`: Passing `-v`, `-p`, and `-whitelist` arguments to `vary_mannings_n_composite.py`
-- `src/output_cleanup.py`: Fixed an arg name in used in the `output_cleanup` function
+- `fim_run.sh`: Passing `-v`, `-p`, and `-whitelist` arguments to `vary_mannings_n_composite.py`.
+- `src/output_cleanup.py`: Fixed an arg name in used in the `output_cleanup` function.
 - `src/vary_mannings_n_composite.py`: Replace the previous file cleanup code to call the `output_cleanup` function from `output_cleanup.py`. Upon completion of the SRC variable roughness workflow, the script will perform a file cleanup using the existing `output_cleanup.py` whitelist and removal process.
 
 <br/><br/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.24.15 - 2022-02-03 - [PR #529](https://github.com/NOAA-OWP/cahaba/pull/529)
+
+Hotfix to updated `vary_mannings_n_composite.py` to use the same cleanup structure as `output_cleanup.py`. This addresses an issue with a hard-coded file delete step that was removing necessary csv files (i.e. `usgs_elev_table.csv`).
+
+## Changes
+
+- `fim_run.sh`: Passing `-v`, `-p`, and `-whitelist` arguments to `vary_mannings_n_composite.py`
+- `src/output_cleanup.py`: Fixed an arg name in used in the `output_cleanup` function
+- `src/vary_mannings_n_composite.py`: Replace the previous file cleanup code to call the `output_cleanup` function from `output_cleanup.py`. Upon completion of the SRC variable roughness workflow, the script will perform a file cleanup using the existing `output_cleanup.py` whitelist and removal process.
+
+<br/><br/>
 
 ## v3.0.24.14 - 2022-01-31 - [PR #515](https://github.com/NOAA-OWP/cahaba/pull/515)
 

--- a/fim_run.sh
+++ b/fim_run.sh
@@ -164,14 +164,17 @@ fi
 
 echo -e $startDiv"Estimating bankfull stage in SRCs"$stopDiv
 if [ "$src_bankfull_toggle" = "True" ]; then
-    # Run BARC routine
+    # Run SRC bankfull estimation routine routine
     time python3 /foss_fim/src/identify_src_bankfull.py -fim_dir $outputRunDataDir -flows $bankfull_flows_file -j $jobLimit -plots $src_bankfull_plot_option
 fi
 
 echo -e $startDiv"Applying variable roughness in SRCs"$stopDiv
 if [ "$src_vrough_toggle" = "True" ]; then
-    # Run BARC routine
-    time python3 /foss_fim/src/vary_mannings_n_composite.py -fim_dir $outputRunDataDir -mann $vmann_input_file -bc $bankfull_attribute -suff $vrough_suffix -j $jobLimit -plots $src_vrough_plot_option -viz_clean $viz
+    # Run SRC Variable Roughness routine
+    [[ ! -z "$whitelist" ]] && args+=( "-w$whitelist" )
+    (( production == 1 )) && args+=( '-p' )
+    (( viz == 1 )) && args+=( '-v' )
+    time python3 /foss_fim/src/vary_mannings_n_composite.py -fim_dir $outputRunDataDir -mann $vmann_input_file -bc $bankfull_attribute -suff $vrough_suffix -j $jobLimit -plots $src_vrough_plot_option "${args[@]}"
 fi
 
 echo "$viz"

--- a/src/output_cleanup.py
+++ b/src/output_cleanup.py
@@ -5,7 +5,7 @@ from utils.shared_functions import mem_profile
 
 
 @mem_profile
-def output_cleanup(huc_number, output_folder_path, additional_whitelist, is_production, viz_post_processing):
+def output_cleanup(huc_number, output_folder_path, additional_whitelist, is_production, is_viz_post_processing):
     '''
     Processes all the final output files to cleanup and add post-processing
 

--- a/src/vary_mannings_n_composite.py
+++ b/src/vary_mannings_n_composite.py
@@ -111,38 +111,19 @@ def variable_mannings_calc(args):
         else:
             df_htable.drop(['discharge_cms'], axis=1, inplace=True) # drop the previously modified discharge column to be replaced with updated version
         df_htable = df_htable.merge(df_src_trim, how='left', left_on=['HydroID','stage'], right_on=['HydroID','stage'])
+        df_htable.to_csv(htable_filename,index=False)
 
         # Delete intermediate CSVs outputs for -p or -v runs
         htable_parent_dir = os.path.split(htable_filename)[0]
         if is_production or is_viz_post_processing: # Remove intermediate SRC adjust csv files if using either -p or -v flags
             output_cleanup('00000000', htable_parent_dir, additional_whitelist, is_production, is_viz_post_processing)
-        '''
-        # Delete intermediate CSVs outputs. Todo delete this block later.
-        htable_parent_dir = os.path.split(htable_filename)[0]
-        # List all CSVs.
-        file_list = os.listdir(htable_parent_dir)
-        for f in file_list:
-            if debug_mode == True: # if using the viz flag then delete all intermediate csv files
-                if '.csv' in f:
-                    if f != 'hydroTable.csv' and f != 'usgs_elev_table.csv':
-                        os.remove(os.path.join(htable_parent_dir, f))
-            else:
-                keep_files = ['usgs_elev_table.csv', 'src_base.csv', 'small_segments.csv']
-                if '.csv' in f:
-                    if f not in keep_files:
-                        os.remove(os.path.join(htable_parent_dir, f))
-        '''
 
-        df_htable.to_csv(htable_filename,index=False)
-
-        log_text += 'Completed: ' + str(huc)
-
-        ## plot rating curves
+        ## Optional: plot rating curves
         if src_plot_option == 'True':
             if isdir(huc_output_dir) == False:
                 os.mkdir(huc_output_dir)
             generate_src_plot(df_src, huc_output_dir)
-
+        log_text += 'Completed: ' + str(huc)
     return(log_text)
 
 def generate_src_plot(df_src, plt_out_dir):

--- a/src/vary_mannings_n_composite.py
+++ b/src/vary_mannings_n_composite.py
@@ -14,6 +14,7 @@ import shutil
 import warnings
 from pathlib import Path
 import datetime as dt
+from output_cleanup import output_cleanup
 sns.set_theme(style="whitegrid")
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
@@ -42,11 +43,13 @@ def variable_mannings_calc(args):
     channel_ratio_src_column    = args[1]
     df_mann                     = args[2]
     huc                         = args[3]
-    out_src_vmann_filename   = args[4]
+    out_src_vmann_filename      = args[4]
     htable_filename             = args[5]
     src_plot_option             = args[6]
     huc_output_dir              = args[7]
-    viz_clean_flag              = args[8]
+    additional_whitelist        = args[8]
+    is_production               = args[9]
+    is_viz_post_processing      = args[10]
 
     ## Read the src_full_crosswalked.csv
     log_text = 'Calculating: ' + str(huc) + '\n'
@@ -109,20 +112,26 @@ def variable_mannings_calc(args):
             df_htable.drop(['discharge_cms'], axis=1, inplace=True) # drop the previously modified discharge column to be replaced with updated version
         df_htable = df_htable.merge(df_src_trim, how='left', left_on=['HydroID','stage'], right_on=['HydroID','stage'])
 
+        # Delete intermediate CSVs outputs for -p or -v runs
+        htable_parent_dir = os.path.split(htable_filename)[0]
+        if is_production or is_viz_post_processing: # Remove intermediate SRC adjust csv files if using either -p or -v flags
+            output_cleanup('00000000', htable_parent_dir, additional_whitelist, is_production, is_viz_post_processing)
+        '''
         # Delete intermediate CSVs outputs. Todo delete this block later.
         htable_parent_dir = os.path.split(htable_filename)[0]
         # List all CSVs.
         file_list = os.listdir(htable_parent_dir)
         for f in file_list:
-            if viz_clean_flag == 1: # if using the viz flag then delete all intermediate csv files
+            if debug_mode == True: # if using the viz flag then delete all intermediate csv files
                 if '.csv' in f:
-                    if f != 'hydroTable.csv':
+                    if f != 'hydroTable.csv' and f != 'usgs_elev_table.csv':
                         os.remove(os.path.join(htable_parent_dir, f))
             else:
                 keep_files = ['usgs_elev_table.csv', 'src_base.csv', 'small_segments.csv']
                 if '.csv' in f:
                     if f not in keep_files:
                         os.remove(os.path.join(htable_parent_dir, f))
+        '''
 
         df_htable.to_csv(htable_filename,index=False)
 
@@ -190,7 +199,9 @@ if __name__ == '__main__':
     parser.add_argument('-suff','--output-suffix',help="Suffix to append to the output log file (e.g. '_global_06_011')",required=True,type=str)
     parser.add_argument('-j','--number-of-jobs',help='number of workers',required=False,default=1,type=int)
     parser.add_argument('-plots','--src-plot-option',help='Optional (True or False): use this flag to create src plots for all hydroids. WARNING - long runtime',required=False,default='False',type=str)
-    parser.add_argument('-viz_clean','--viz-clean',help='Optional (Viz flag): pass the viz flag (0 or 1) to delete intermediate csv files',required=False,default=0,type=int)
+    parser.add_argument('-w', '--additional_whitelist', type=str, help='List of additional files to keep in a production run')
+    parser.add_argument('-p', '--is_production', help='Keep only white-listed files for production runs', action='store_true')
+    parser.add_argument('-v', '--is_viz_post_processing', help='Formats output files to be useful for Viz', action='store_true')
 
     args = vars(parser.parse_args())
 
@@ -200,7 +211,9 @@ if __name__ == '__main__':
     output_suffix = args['output_suffix']
     number_of_jobs = args['number_of_jobs']
     src_plot_option = args['src_plot_option']
-    viz_clean_flag = args['viz_clean']
+    additional_whitelist = args['additional_whitelist']
+    is_production = args['is_production']
+    is_viz_post_processing = args['is_viz_post_processing']
     procs_list = []
 
     print('Writing progress to log file here: ' + str(join(fim_dir,'log_composite_n' + output_suffix + '.log')))
@@ -232,7 +245,7 @@ if __name__ == '__main__':
 
                     if isfile(in_src_bankfull_filename):
                         print(str(huc))
-                        procs_list.append([in_src_bankfull_filename, channel_ratio_src_column, df_mann, huc, out_src_vmann_filename, htable_filename, src_plot_option, huc_plot_output_dir,viz_clean_flag])
+                        procs_list.append([in_src_bankfull_filename, channel_ratio_src_column, df_mann, huc, out_src_vmann_filename, htable_filename, src_plot_option, huc_plot_output_dir,additional_whitelist, is_production, is_viz_post_processing])
                     else:
                         print(str(huc) + '\nWARNING --> can not find the src_full_crosswalked_bankfull.csv in the fim output dir: ' + str(join(fim_dir,huc)) + ' - skipping this HUC!!!\n')
 


### PR DESCRIPTION
Hotfix to updated `vary_mannings_n_composite.py` to use the same cleanup structure as `output_cleanup.py`. This addresses an issue with a hard-coded file delete step that was removing necessary csv files (i.e. `usgs_elev_table.csv`). Address #528 

## Changes

- `fim_run.sh`: Passing `-v`, `-p`, and `-whitelist` arguments to `vary_mannings_n_composite.py`
- `src/output_cleanup.py`: Fixed an arg name in used in the output_cleanup function
- `src/vary_mannings_n_composite.py`: Replace the previous file cleanup code to call the `output_cleanup` function from `output_cleanup.py`. Upon completion of the SRC variable roughness workflow, the script will perform a file cleanup using the existing `output_cleanup.py` whitelist and removal process.

## Testing

1. Tested on single huc using 1) `-p` flag 2) `-v` flag 3) neither cleanup flags. Example: `fim_run.sh -u 05030102 -e MS -c foss_fim/config/params_template.env -n ryan_temp/test_05030102_fix_final_viz -v`
2. Tested on multiple hucs using 1) `-p` flag 2) `-v` flag 3) neither cleanup flags. Example: `fim_run.sh -u "02040203 02020005" -c /foss_fim/config/params_template.env -n ryan_temp/multi_huc_test_cleanup -e MS -v -j 2`

## Screenshots
Example output huc directory when using the `-v` flag within `fim_run.sh`:
![image](https://user-images.githubusercontent.com/69868854/152447071-c8d44e7f-a1e8-4375-b10d-926e46a67551.png)

Example output huc directory when using the `-p` flag within `fim_run.sh`:
![image](https://user-images.githubusercontent.com/69868854/152447160-52c5d7ca-1133-46a7-bde7-230f9f99be17.png)

## Todos

- Reviewers: Please test using `-v` cleanup flag on a 1) single huc and 2) a multi-huc fim_run
