### PR TITLE
[1pt] PR: Updated evaluation code to accept ras2fim test cases

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,20 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## v3.0.24.16 - 2022-02-07 - [PR #534](https://github.com/NOAA-OWP/cahaba/pull/534)
+
+Updated the evaluation tools to accept `ras2fim` test_cases.
+
+## Changes
+
+- `/tools/tools_shared_variables.py`: Added `ras2fim` benchmark magnitudes.
+- `/tools/synthesize_test_cases.py`: Added `ras2fim` recognition.
+- `/tools_eval_plots.py`: Included `ras2fim` in the test case categories to include in plotting.
+- `/tools/tools_shared_functions.py`: Added a validity check before the calculation of PND.
+
+<br/><br/>
+
 ## v3.0.24.15 - 2022-02-03 - [PR #529](https://github.com/NOAA-OWP/cahaba/pull/529)
 
 Hotfix to updated `vary_mannings_n_composite.py` to use the same cleanup structure as `output_cleanup.py`. This addresses an issue with a hard-coded file delete step that was removing necessary csv files (i.e. `usgs_elev_table.csv`).

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -487,7 +487,7 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
             all_datasets[(benchmark_source, extent_configuration)] = filter_dataframe(ahps_metrics, base_resolution)
 
         # If source is 'ble', set base_resolution and append ble dataset to all_datasets dictionary
-        elif benchmark_source in ['ble', 'ifc']:
+        elif benchmark_source in ['ble', 'ifc', 'ras2fim']:
 
             # Set the base processing unit for ble runs
             base_resolution = 'huc'
@@ -513,6 +513,9 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
             base_resolution = 'huc'
         elif dataset_name == 'ifc':
             magnitude_order = ['2yr','5yr','10yr','25yr','50yr','100yr','200yr','500yr']
+            base_resolution = 'huc'
+        elif dataset_name == 'ras2fim':
+            magnitude_order = ['2yr','5yr','10yr','25yr','50yr','100yr']
             base_resolution = 'huc'
         elif dataset_name in ['usgs','nws']:
             magnitude_order = ['action','minor','moderate','major']
@@ -631,11 +634,13 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
         ################################################################
         #This section joins ble (FR) metrics to a spatial layer of HUCs.
         ################################################################
-        if all_datasets.get(('ble','FR')) and all_datasets.get(('ifc','FR')):
+        if all_datasets.get(('ble','FR')) and all_datasets.get(('ifc','FR')) and all_datasets.get(('ras2fim','FR')):
             #Select BLE, FR dataset.
             ble_dataset, sites = all_datasets.get(('ble','FR'))
             ifc_dataset, sites = all_datasets.get(('ifc','FR'))
+            ras2fim_dataset, sites = all_datasets.get(('ras2fim','FR'))
             huc_datasets = ble_dataset.append(ifc_dataset)
+            huc_datasets = huc_datasets.append(ras2fim_dataset)
             #Read in HUC spatial layer
             wbd_gdf = gpd.read_file(Path(WBD_LAYER), layer = 'WBDHU8')
             #Join metrics to HUC spatial layer
@@ -648,7 +653,7 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
             #Write out to file
             wbd_with_metrics.to_file(Path(workspace) / 'fim_performance_polys.shp')
         else:
-            print('BLE/IFC FR datasets not analyzed, no spatial data created.\nTo produce spatial data analyze a FR version')
+            print('BLE/IFC/RAS2FIM FR datasets not analyzed, no spatial data created.\nTo produce spatial data analyze a FR version')
 #######################################################################
 if __name__ == '__main__':
     # Parse arguments

--- a/tools/synthesize_test_cases.py
+++ b/tools/synthesize_test_cases.py
@@ -79,14 +79,11 @@ def create_master_metrics_csv(master_metrics_csv_output, dev_versions_to_include
     else:
         iteration_list = ['official']
 
-    for benchmark_source in ['ble', 'nws', 'usgs', 'ifc']:
+    for benchmark_source in ['ble', 'nws', 'usgs', 'ifc', 'ras2fim']:
         benchmark_test_case_dir = os.path.join(TEST_CASES_DIR, benchmark_source + '_test_cases')
-        if benchmark_source in ['ble', 'ifc']:
+        if benchmark_source in ['ble', 'ifc', 'ras2fim']:
             
-            if benchmark_source == 'ble':
-                magnitude_list = MAGNITUDE_DICT['ble']
-            if benchmark_source == 'ifc':
-                magnitude_list = MAGNITUDE_DICT['ifc']
+            magnitude_list = MAGNITUDE_DICT[benchmark_source]
             test_cases_list = os.listdir(benchmark_test_case_dir)
 
             for test_case in test_cases_list:
@@ -220,7 +217,6 @@ def process_alpha_test(args):
     
     """
     
-    
     fim_run_dir = args[0]
     version = args[1]
     test_id = args[2]
@@ -327,8 +323,7 @@ if __name__ == '__main__':
                             # If a user supplies a special_string (-s), then add it to the end of the created dirs.
                             if special_string != "":
                                 version = version + '_' + special_string
-
-            
+                                
                             # Define the magnitude lists to use, depending on test_id.
                             benchmark_type = test_id.split('_')[1]
                             magnitude = MAGNITUDE_DICT[benchmark_type]

--- a/tools/tools_shared_functions.py
+++ b/tools/tools_shared_functions.py
@@ -368,8 +368,11 @@ def compute_stats_from_contingency_table(true_negatives, false_negatives, false_
     except ZeroDivisionError:
         F1_score = "NA"
 
-    PND = 1.0 - TPR  # Probability Not Detected (PND)
-
+    if TPR == 'NA':
+        PND = 'NA'
+    else:
+        PND = 1.0 - TPR  # Probability Not Detected (PND)
+    
     stats_dictionary = {'true_negatives_count': int(true_negatives),
                         'false_negatives_count': int(false_negatives),
                         'true_positives_count': int(true_positives),

--- a/tools/tools_shared_variables.py
+++ b/tools/tools_shared_variables.py
@@ -10,8 +10,9 @@ FR_BENCHMARK_CATEGORIES = ['ble', 'ifc']
 BLE_MAGNITUDE_LIST = ['100yr', '500yr']
 IFC_MAGNITUDE_LIST = ['2yr', '5yr', '10yr', '25yr', '50yr', '100yr', '200yr', '500yr']
 AHPS_MAGNITUDE_LIST = ['action', 'minor', 'moderate', 'major']
+RAS2FIM_MAGNITUDE_LIST = ['2yr', '5yr', '10yr', '25yr', '50yr', '100yr']
 
-MAGNITUDE_DICT = {'ble': BLE_MAGNITUDE_LIST, 'ifc': IFC_MAGNITUDE_LIST, 'usgs': AHPS_MAGNITUDE_LIST, 'nws': AHPS_MAGNITUDE_LIST}
+MAGNITUDE_DICT = {'ble': BLE_MAGNITUDE_LIST, 'ifc': IFC_MAGNITUDE_LIST, 'usgs': AHPS_MAGNITUDE_LIST, 'nws': AHPS_MAGNITUDE_LIST, 'ras2fim': RAS2FIM_MAGNITUDE_LIST}
 PRINTWORTHY_STATS = ['CSI', 'TPR', 'TNR', 'FAR', 'MCC', 'TP_area_km2', 'FP_area_km2', 'TN_area_km2', 'FN_area_km2', 'contingency_tot_area_km2', 'TP_perc', 'FP_perc', 'TN_perc', 'FN_perc']
 GO_UP_STATS = ['CSI', 'TPR', 'MCC', 'TN_area_km2', 'TP_area_km2', 'TN_perc', 'TP_perc', 'TNR']
 GO_DOWN_STATS = ['FAR', 'FN_area_km2', 'FP_area_km2', 'FP_perc', 'FN_perc', 'PND']


### PR DESCRIPTION
I updated the evaluation tools to accept ras2fim test_cases. This will need to be performed for FIM4, as well. This addresses #511 and #533.


## Changes

- `/tools/tools_shared_variables.py`: Added ras2fim benchmark magnitudes.
- `/tools/synthesize_test_cases.py`: Added ras2fim recognition.
- `/tools_eval_plots.py`: Included ras2fim in the test case categories to include in plotting.
- `/tools/tools_shared_functions.py`: Added a validity check before the calculation of PND.

## Testing

1. Run `synthesize_test_cases.py` for a version and ensure that ras2fim metrics are in the master metrics CSV file.
2. Run `eval_plots.py` and confirm that ras2fim is included in the plots.

Alternatively, you can double check my outputs to make sure they look alright.

Master metrics CSV location: `/data/test_cases/metrics_library/all_official_versions.py`
Example plots location `/data/temp/brad/ras2fim_eval_plots2/ras2fim`

## Screenshots

Example ras2fim Probability Not Detected plot
![pnd_ras2fim_fr](https://user-images.githubusercontent.com/69594899/152808253-357e56b6-aba7-4c90-a5e8-126652a0d403.png)

Example ras2fim Critical Success Index  (aggregate) plot
![csi_aggr_ras2fim_fr](https://user-images.githubusercontent.com/69594899/152810523-654ba49d-dd7a-4ea3-be3d-291f011e3917.png)


Example ras2fim Critical Success Index box plot

![csi_ras2fim_fr](https://user-images.githubusercontent.com/69594899/152809429-026ddd92-9db0-4d6a-83e9-113ce3edc209.png)



## ToDo

- I need to cache the metrics for all of the previous versions once this is merged in.
- There are over 30 more HUCs in Iowa that have RAS models. Once these are run, they can be added to this test dataset.

