### PR TITLE
[1pt] PR: Fix to suppress unit tests warnings

### DIFF
--- a/unit_tests/__example_nws_data_unittests.py
+++ b/unit_tests/__example_nws_data_unittests.py
@@ -6,6 +6,7 @@ import sys
 
 import argparse
 import json
+import warnings
 import unittest
 
 import unit_tests_utils as helpers
@@ -22,6 +23,8 @@ class test_get_huc8_by_nws_lid(unittest.TestCase):
     @classmethod
     def setUpClass(self):
 
+        warnings.simplefilter('ignore')
+        
         params_file_path = '/foss_fim/unit_tests/nws_data_params.json'
     
         with open(params_file_path) as params_file:

--- a/unit_tests/__template_unittests.py
+++ b/unit_tests/__template_unittests.py
@@ -6,6 +6,7 @@ import sys
 
 import argparse
 import json
+import warnings
 import unittest
 
 import unit_tests_utils as helpers
@@ -23,6 +24,8 @@ class test_<Your original source python file name>(unittest.TestCase):
     '''
     @classmethod
     def setUpClass(self):
+
+        warnings.simplefilter('ignore')
 
         params_file_path = '/foss_fim/unit_tests/<Your original source python file name>_params.json'
     

--- a/unit_tests/clip_vectors_to_wbd_unittests.py
+++ b/unit_tests/clip_vectors_to_wbd_unittests.py
@@ -6,6 +6,7 @@ import sys
 
 import argparse
 import json
+import warnings
 import unittest
 
 import unit_tests_utils as helpers
@@ -23,6 +24,8 @@ class test_clip_vectors_to_wbd(unittest.TestCase):
     '''
     @classmethod
     def setUpClass(self):
+
+        warnings.simplefilter('ignore')
 
         params_file_path = '/foss_fim/unit_tests/clip_vectors_to_wbd_params.json'
     

--- a/unit_tests/gms/derive_level_paths_unittests.py
+++ b/unit_tests/gms/derive_level_paths_unittests.py
@@ -3,9 +3,11 @@
 import inspect
 import os
 import sys
-import unittest
 
+import argparse
 import json
+import warnings
+import unittest
 
 # importing python folders in other direcories
 sys.path.append('/foss_fim/unit_tests/')
@@ -26,6 +28,8 @@ class test_Derive_level_paths(unittest.TestCase):
     @classmethod
     def setUpClass(self):
     
+        warnings.simplefilter('ignore')
+        
         params_file_path = '/foss_fim/unit_tests/gms/derive_level_paths_params.json'    
     
         with open(params_file_path) as params_file:


### PR DESCRIPTION
A quick fix to help suppress unit test warnings. They were creating a lot of output making readability more difficult.

# The Fix:

- Added: import warnings
- Added: warnings.simplefilter('ignore') to the top of each def setUpClass(self) method (a method that the unit test engine itself 
uses)

This fix was applied to the following files:
- unit_tests/clip_vectors_to_wbd_unittests.py
- unit_tests/__template_unittests.py
- unit_tests/__example_nws_data_unittests.py
- unit_tests/gms/derive_level_paths_unittests.py

# Testing
The following actual usable unit tests were re-run:
- unit_tests/clip_vectors_to_wbd_unittests.py
- unit_tests/gms/derive_level_paths_unittests.py

Note: The branch can be deleted when completed.
