### PR TITLE
[1pt] PR: Tool to collate catchment attributes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## v3.0.25.00 - 2022-02-18 - [PR #542](https://github.com/NOAA-OWP/cahaba/pull/542)
+
+`collate_catchment_attributes.py` is located in tools. It is a simple script to assemble desired attributes for further study. The code loops through huc directories and pulls out static (does not change with stage) attributes by `HydroID`. It then links to sierra test metrics via `location_id` and `HydroID`.
+
+## Additions
+
+-`/tools/collate_catchment_attributes.py`: New tool to collate catchment attributes
+
+<br/><br/>
+
 ## v3.0.24.16 - 2022-02-07 - [PR #534](https://github.com/NOAA-OWP/cahaba/pull/534)
 
 Updated the evaluation tools to accept `ras2fim` test_cases.

--- a/tools/collate_catchment_attributes.py
+++ b/tools/collate_catchment_attributes.py
@@ -5,10 +5,7 @@ import re
 import geopandas as gpd
 
 
-
-
 def aggregate_hydro_tables(root_dir):
-
 
     #loops through huc dircectories and appends hydrotable.csv from each one. Drops duplicates on hydroID so that this code ignores stage changes, and only assembles one row per hydroID.
     aggregate_df = pd.DataFrame()
@@ -26,14 +23,12 @@ def aggregate_hydro_tables(root_dir):
 
 def assemble_sierra_test(geoPackagePath):
 
-
     #uses geopandas to injest sierra test geopackage into a geodataframe
     sierra_test_results = gpd.read_file(geoPackagePath)
     return sierra_test_results
     
 
 def import_link_table(link_table_path):
-
 
     #link table necesary for maintaining uniqueness of hydroID. Used to link hydrotable to sierra test metrics.
     link_df = pd.read_csv(link_table_path,dtype = {'location_id':str,'HydroID':int})
@@ -43,7 +38,6 @@ def import_link_table(link_table_path):
     
 
 def perform_merge(sierra_test_results,link_df,aggregate_df):
-
 
     #function to merge the hydrotables to the sierra test via the link table. Also defines the columns/fields desired in final csv result.
     filter_list = ['HydroID','SLOPE','AREASQKM','LENGTHKM','LakeID','order_','sinuosity','nws_lid','location_id','HUC8','name','states','curve','mainstem','nrmse','mean_abs_y_diff_ft','mean_y_diff_ft','percent_bias','2','5','10','25','50','100','action','minor','moderate','major','geometry']
@@ -55,7 +49,6 @@ def perform_merge(sierra_test_results,link_df,aggregate_df):
 
 def out_file_dest(aggregate_df,outFile):
 
-    
     #defines the destination of csv output
     aggregate_df.to_csv(outFile, encoding='utf-8', index=False) 
   

--- a/tools/collate_catchment_attributes.py
+++ b/tools/collate_catchment_attributes.py
@@ -1,0 +1,38 @@
+import argparse
+import pandas as pd
+
+
+
+
+
+def collate_catchment_attributes(fim_directory,sierra_test_input,output_csv_destination):
+    root_dir = '/data/outputs/calebs_run'
+
+    aggregate_df = pd.DataFrame()
+
+    for huc_dir in os.listdir(root_dir):
+        hydroTable = pd.read_csv(os.path.join(root_dir, huc_dir, "hydroTable.csv"))
+        aggregate_df.append(hydroTable)
+
+
+
+
+if __name__ == '__main__':
+    """
+    decription of file
+    TODO
+    """
+
+    parser = argparse.ArgumentParser(description='collates catchment attributes from determined source')
+    
+    parser.add_argument('-d','--fim-directory',help='Parent directory of FIM-required datasets.',required=True)
+    parser.add_argument('-s', '--sierra-test-input', help='Optional:layer containing sierra test by hydroId',required=False)
+    parser.add_argument('-o','--output-csv-destination',help='location and name for output csv',required=True)
+    
+    args = vars(parser.parse_args())
+
+    fim_directory = args['fim_directory']
+    sierra_test_input = args['sierra_test_input']
+    output_csv_destination = args['output_csv_destination']
+    
+    collate_catchment_attributes(fim_directory,sierra_test_input,output_csv_destination)

--- a/tools/collate_catchment_attributes.py
+++ b/tools/collate_catchment_attributes.py
@@ -1,20 +1,16 @@
 import argparse
 import pandas as pd
-
-
-
+import os
 
 
 def collate_catchment_attributes(fim_directory,sierra_test_input,output_csv_destination):
-    root_dir = '/data/outputs/calebs_run'
+    
+    aggregate_df = pd.DataFrame()  #here describes the line
 
-    aggregate_df = pd.DataFrame()
-
-    for huc_dir in os.listdir(root_dir):
-        hydroTable = pd.read_csv(os.path.join(root_dir, huc_dir, "hydroTable.csv"))
+    #comment
+    for huc_dir in os.listdir(fim_directory):
+        hydroTable = pd.read_csv(os.path.join(fim_directory, huc_dir, "hydroTable.csv"))
         aggregate_df.append(hydroTable)
-
-
 
 
 if __name__ == '__main__':

--- a/tools/collate_catchment_attributes.py
+++ b/tools/collate_catchment_attributes.py
@@ -8,6 +8,7 @@ import geopandas as gpd
 
 
 def aggregate_hydro_tables(root_dir):
+    #loops through huc dircectories and appends hydrotable.csv from each one. Drops duplicates on hydroID so that this code ignores stage changes, and only assembles one row per hydroID.
     aggregate_df = pd.DataFrame()
     dtype_dict_py ={'HydroID': int,'feature_id':int, 'SLOPE':float, 'AREASQKM':float, 'order_':int,'LENGTHKM':float,'LakeID':int, 'orig_ManningN':float}
     for huc_dir in os.listdir(root_dir):    
@@ -22,11 +23,13 @@ def aggregate_hydro_tables(root_dir):
 
 
 def assemble_sierra_test(geoPackagePath):
+    #uses geopandas to injest sierra test geopackage into a geodataframe
     sierra_test_results = gpd.read_file(geoPackagePath)
     return sierra_test_results
     
 
 def import_link_table(link_table_path):
+    #link table necesary for maintaining uniqueness of hydroID. Used to link hydrotable to sierra test metrics.
     link_df = pd.read_csv(link_table_path,dtype = {'location_id':str,'HydroID':int})
     link_df = link_df.dropna(subset=['location_id'])
     link_df = link_df.filter(['HydroID','location_id'])
@@ -34,6 +37,7 @@ def import_link_table(link_table_path):
     
 
 def perform_merge(sierra_test_results,link_df,aggregate_df,):
+    #function to merge the hydrotables to the sierra test via the link table. Also defines the columns/fields desired in final csv result.
     filter_list = ['HydroID','SLOPE','AREASQKM','LENGTHKM','LakeID','order_','sinuosity','nws_lid','location_id','HUC8','name','states','curve','mainstem','nrmse','mean_abs_y_diff_ft','mean_y_diff_ft','percent_bias','2','5','10','25','50','100','action','minor','moderate','major','geometry']
     sierra_test_merged = sierra_test_results.merge(link_df, on='location_id')
     aggregate_df_merged = aggregate_df.merge(sierra_test_merged, on='HydroID')
@@ -42,6 +46,7 @@ def perform_merge(sierra_test_results,link_df,aggregate_df,):
 
 
 def out_file_dest(aggregate_df,outFile):
+    #defines the destination of csv output
     aggregate_df.to_csv(outFile, encoding='utf-8', index=False) 
   
 

--- a/tools/collate_catchment_attributes.py
+++ b/tools/collate_catchment_attributes.py
@@ -8,6 +8,8 @@ import geopandas as gpd
 
 
 def aggregate_hydro_tables(root_dir):
+
+
     #loops through huc dircectories and appends hydrotable.csv from each one. Drops duplicates on hydroID so that this code ignores stage changes, and only assembles one row per hydroID.
     aggregate_df = pd.DataFrame()
     dtype_dict_py ={'HydroID': int,'feature_id':int, 'SLOPE':float, 'AREASQKM':float, 'order_':int,'LENGTHKM':float,'LakeID':int, 'orig_ManningN':float}
@@ -23,12 +25,16 @@ def aggregate_hydro_tables(root_dir):
 
 
 def assemble_sierra_test(geoPackagePath):
+
+
     #uses geopandas to injest sierra test geopackage into a geodataframe
     sierra_test_results = gpd.read_file(geoPackagePath)
     return sierra_test_results
     
 
 def import_link_table(link_table_path):
+
+
     #link table necesary for maintaining uniqueness of hydroID. Used to link hydrotable to sierra test metrics.
     link_df = pd.read_csv(link_table_path,dtype = {'location_id':str,'HydroID':int})
     link_df = link_df.dropna(subset=['location_id'])
@@ -36,7 +42,9 @@ def import_link_table(link_table_path):
     return link_df
     
 
-def perform_merge(sierra_test_results,link_df,aggregate_df,):
+def perform_merge(sierra_test_results,link_df,aggregate_df):
+
+
     #function to merge the hydrotables to the sierra test via the link table. Also defines the columns/fields desired in final csv result.
     filter_list = ['HydroID','SLOPE','AREASQKM','LENGTHKM','LakeID','order_','sinuosity','nws_lid','location_id','HUC8','name','states','curve','mainstem','nrmse','mean_abs_y_diff_ft','mean_y_diff_ft','percent_bias','2','5','10','25','50','100','action','minor','moderate','major','geometry']
     sierra_test_merged = sierra_test_results.merge(link_df, on='location_id')
@@ -46,6 +54,8 @@ def perform_merge(sierra_test_results,link_df,aggregate_df,):
 
 
 def out_file_dest(aggregate_df,outFile):
+
+    
     #defines the destination of csv output
     aggregate_df.to_csv(outFile, encoding='utf-8', index=False) 
   

--- a/tools/collate_catchment_attributes.py
+++ b/tools/collate_catchment_attributes.py
@@ -81,6 +81,6 @@ if __name__ == '__main__':
     output_csv_destination = args['output_csv_destination']
     link_elev_table = args['link_elev_table']
     
-    aggregate_df = performMerge(assembleSierraTest(sierra_test_input),importLinkTable(),aggregateHydroTables(fim_directory))
+    aggregate_df = performMerge(assembleSierraTest(sierra_test_input),importLinkTable(link_elev_table),aggregateHydroTables(fim_directory))
     outFileDest(aggregate_df,output_csv_destination)
     

--- a/tools/collate_catchment_attributes.py
+++ b/tools/collate_catchment_attributes.py
@@ -3,32 +3,84 @@ import pandas as pd
 import os
 
 
-def collate_catchment_attributes(fim_directory,sierra_test_input,output_csv_destination):
-    
-    aggregate_df = pd.DataFrame()  #here describes the line
+import os
+import pandas as pd
+import re
+import geopandas as gpd
 
-    #comment
-    for huc_dir in os.listdir(fim_directory):
-        hydroTable = pd.read_csv(os.path.join(fim_directory, huc_dir, "hydroTable.csv"))
-        aggregate_df.append(hydroTable)
+
+
+
+def aggregateHydroTables(root_dir):
+    aggregate_df = pd.DataFrame()
+    dtype_dict_py ={'HydroID': int,'feature_id':int, 'SLOPE':float, 'AREASQKM':float, 'order_':int,'LENGTHKM':float,'LakeID':int, 'orig_ManningN':float}
+    for huc_dir in os.listdir(root_dir):
+    
+        if not re.search("^\d{6,8}$",huc_dir):
+        
+            continue 
+    
+        hydroTable = pd.read_csv(os.path.join(root_dir, huc_dir, "hydroTable.csv"),dtype = dtype_dict_py)
+
+        hydroTable = hydroTable.filter(['HydroID',"feature_id", 'SLOPE', 'AREASQKM','LENGTHKM','LakeID', 'order_', 'orig_ManningN', 'sinuosity'])
+
+        aggregate_df = aggregate_df.append(hydroTable)
+        
+    aggregate_df = aggregate_df.drop_duplicates(subset=['HydroID'], keep='first')
+    return aggregate_df
+
+
+def assembleSierraTest(geoPackagePath):
+    sierra_test_results = gpd.read_file(geoPackagePath)
+    
+    #sierra_test_results.location_id = sierra_test_results.location_id.astype(str)
+    print(type(sierra_test_results.location_id.loc[0]))
+    return sierra_test_results
+    
+def importLinkTable(link_table_path):
+    link_df = pd.read_csv(link_table_path,dtype = {'location_id':str,'HydroID':int})
+    link_df = link_df.dropna(subset=['location_id'])
+    link_df = link_df.filter(['HydroID','location_id'])
+    print(link_df)
+    return link_df
+    
+def performMerge(sierra_test_results,link_df,aggregate_df,):
+    filter_list = ['HydroID','SLOPE','AREASQKM','LENGTHKM','LakeID','order_','sinuosity','nws_lid','location_id','HUC8','name','states','curve','mainstem','nrmse','mean_abs_y_diff_ft','mean_y_diff_ft','percent_bias','2','5','10','25','50','100','action','minor','moderate','major','geometry']
+    sierra_test_merged = sierra_test_results.merge(link_df, on='location_id')
+    aggregate_df = aggregate_df.merge(sierra_test_merged, on='HydroID')
+    aggregate_df = aggregate_df.filter(filter_list)
+    
+    return aggregate_df
+def outFileDest(aggregate_df,outFile):
+    aggregate_df.to_csv(outFile, encoding='utf-8', index=False) 
+  
 
 
 if __name__ == '__main__':
     """
-    decription of file
+    collate catchment attributes. loops through huc directories in defined fim directory. assembles needed attibutes into csv.
+    
+    recomended current sierra test: "/data/tools/sierra_test/official_versions/fim_3_0_24_14_ms/usgs_gages_stats.gpkg" 
+    recomended current elev link table: "/data/tools/sierra_test/official_versions/fim_3_0_24_14_ms/agg_usgs_elev_table.csv"
+    recomended current fim directory: "/data/previous_fim/fim_3_0_24_14_ms/"
+    
     TODO
     """
 
     parser = argparse.ArgumentParser(description='collates catchment attributes from determined source')
     
     parser.add_argument('-d','--fim-directory',help='Parent directory of FIM-required datasets.',required=True)
-    parser.add_argument('-s', '--sierra-test-input', help='Optional:layer containing sierra test by hydroId',required=False)
+    parser.add_argument('-s', '--sierra-test-input', help='layer containing sierra test by hydroId',required=True)
     parser.add_argument('-o','--output-csv-destination',help='location and name for output csv',required=True)
+    parser.add_argument('-l','--link-elev-table',help='elev table for linking sierra tests to hydrotable on locationid and hydroid',required=True)
     
     args = vars(parser.parse_args())
 
     fim_directory = args['fim_directory']
     sierra_test_input = args['sierra_test_input']
     output_csv_destination = args['output_csv_destination']
+    link_elev_table = args['link_elev_table']
     
-    collate_catchment_attributes(fim_directory,sierra_test_input,output_csv_destination)
+    aggregate_df = performMerge(assembleSierraTest(sierra_test_input),importLinkTable(),aggregateHydroTables(fim_directory))
+    outFileDest(aggregate_df,output_csv_destination)
+    

--- a/tools/collate_catchment_attributes.py
+++ b/tools/collate_catchment_attributes.py
@@ -37,7 +37,7 @@ def perform_merge(sierra_test_results,link_df,aggregate_df,):
     filter_list = ['HydroID','SLOPE','AREASQKM','LENGTHKM','LakeID','order_','sinuosity','nws_lid','location_id','HUC8','name','states','curve','mainstem','nrmse','mean_abs_y_diff_ft','mean_y_diff_ft','percent_bias','2','5','10','25','50','100','action','minor','moderate','major','geometry']
     sierra_test_merged = sierra_test_results.merge(link_df, on='location_id')
     aggregate_df_merged = aggregate_df.merge(sierra_test_merged, on='HydroID')
-    aggregate_df_merged = aggregate_df.filter(filter_list)    
+    aggregate_df_merged = aggregate_df_merged.filter(filter_list)    
     return aggregate_df_merged
 
 


### PR DESCRIPTION
`collate_catchment_attributes.py` is located in tools. It is a simple script to assemble desired attributes for further study. The code loops through huc directories and pulls out static (does not change with stage) attributes by hydroid. It then links to sierra test metrics via location id and hydro id. 

## Additions

-new tool to collate catchment attributes
-`/tools/collate_catchment_attributes.py`


## Testing

these are the files I used to test the code, will run much faster
sierra_test = `"/data/outputs/carson_test1/sierra_test_sinuosity/usgs_gages_stats.gpkg"`
elev_link_table =`"/data/outputs/carson_test1/sierra_test/agg_usgs_elev_table.csv"`
hydrotable_directory =`"/data/outputs/carson_test1"`

`python collate_catchment_attributes.py -d "/data/outputs/carson_test1" -s "/data/outputs/carson_test1/sierra_test_sinuosity/usgs_gages_stats.gpkg" -o "/data/temp/caleb/test_collate_date.csv" -l "/data/outputs/carson_test1/sierra_test/agg_usgs_elev_table.csv"`

## Screenshots



## Notes

code to run the file with current inputs `python collate_catchment_attributes.py -d "/data/previous_fim/fim_3_0_24_14_ms/" -s "/data/tools/sierra_test/official_versions/fim_3_0_24_14_ms/usgs_gages_stats.gpkg" -o "/data/temp/caleb/218collate.csv" -l "/data/tools/sierra_test/official_versions/fim_3_0_24_14_ms/agg_usgs_elev_table.csv"`


the script is called `collate_catchment_attributes.py`
the inputs for the command are `collate_catchment_attributes(fim_directory, sierra_test_input, output_csv_destination, link_elev_table)`

the recommended fim directory at this time is `"/data/tools/sierra_test/official_versions/fim_3_0_24_14_ms/usgs_gages_stats.gpkg"`

the recommended sierra_test_input at this time is `/data/tools/sierra_test/official_versions/fim_3_0_24_14_ms/usgs_gages_stats.gpkg"`

the recommended link_elev_table at this time is `"/data/previous_fim/fim_3_0_24_14_ms/"`


## Todos

-



