### PR TITLE
[2pts] PR: New Feature to remove stream orders 1 and 2 if desired via command arg

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,26 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## v4.0.2.0 - 2022-03-02 - [PR #548](https://github.com/NOAA-OWP/inundation-mapping/pull/548)
+
+Added a new optional system which allows an argument to be added to the `gms_run_unit.sh` command line to filter out stream orders 1 and 2 when calculating branches. 
+
+## Changes
+
+- `gms_run_unit.sh`: Add the new optional `-s` command line argument. Inclusion of this argument means "drop stream orders 1 and 2".
+
+- `src/gms`
+   - `run_by_unit.sh`: Capture and forward the drop stream orders flag to `derive_level_paths.py`
+	
+	- `derive_level_paths.py`: Capture the drop stream order flag and working with `stream_branches.py` to include/not include loading nwm stream with stream orders 1 and 2.
+	
+	- `stream_branchs.py`: A correction was put in place to allow for the filter of branch attributes and values to be excluded. The `from_file` method has the functionality but was incomplete. This was corrected and how could accept the values from `derive_level_paths.py` to use the branch attribute of "order_" (gkpg field) and values excluded of [1,2] when optionally desired.
+
+- `unit_tests/gms`
+	- `derive_level_paths_unittests.py` and `derive_level_paths_params.py`: Updated for testing for the new "drop stream orders 1 and 2" feature. Upgrades were also made to earlier existing incomplete test methods to test more output conditions.
+	
+<br/><br/>
+
 ## v4.0.1.0 - 2022-02-02 - [PR #525](https://github.com/NOAA-OWP/cahaba/pull/525)
 
 The addition of a very simple and evolving unit test system which has two unit tests against two py files.  This will set a precendence and will grow over time and may be automated, possibly during git check-in triggered. The embedded README.md has more details of what we currently have, how to use it, how to add new unit tests, and expected future enhancements.

--- a/gms_run_unit.sh
+++ b/gms_run_unit.sh
@@ -3,7 +3,8 @@
 usage ()
 {
     echo 'Produce GMS hydrofabric datasets for unit scale. Run after fim_run.sh but before gms_run_branch.sh'
-    echo 'Usage : gms_run_unit.sh [REQ: -u <hucs> -c <config file> -n <run name> ] [OPT: -h -j <job limit>]'
+    echo 'Usage : gms_run_unit.sh [REQ: -u <hucs> -c <config file> -n <run name> ]'
+    echo '  	 						 [OPT: -h -j <job limit>] -o -r -d <deny list file> -s ]'
     echo ''
     echo 'REQUIRED:'
     echo '  -u/--hucList    : HUC 4,6,or 8 to run or multiple passed in quotes. Line delimited file'
@@ -13,12 +14,14 @@ usage ()
     echo ''
     echo 'OPTIONS:'
     echo '  -h/--help       : help file'
-    echo '  -j/--jobLimit   : max number of concurrent jobs to run. Default 1 job at time. 1 outputs'
+    echo '  -j/--jobLimit   : max number of concurrent jobs to run. Default 1 job at time.'
     echo '                    stdout and stderr to terminal and logs. With >1 outputs progress and logs the rest'
     echo '  -o/--overwrite  : overwrite outputs if already exist'
     echo '  -r/--retry      : retries failed jobs'
     echo '  -d/--denylist   : file with line delimited list of files in huc directories to remove upon completion'
     echo '                   (see config/deny_gms_unit_default.lst for a starting point)'
+	 echo '  -s/--dropStreamOrder_1_2 : If this flag is included, the system will leave out stream orders 1 and 2 at the very'
+	 echo	'                     top initial load of the nwm_subset_streams'
     exit
 }
 
@@ -62,6 +65,9 @@ in
         shift
         deny_gms_unit_list=$1
         ;;
+	 -s|--dropLowStreamOrders)
+		  dropLowStreamOrders=1
+		  ;;
     *) ;;
     esac
     shift
@@ -92,6 +98,10 @@ if [ -z "$retry" ]
 then
     retry=""
 fi
+if [ -z "$dropLowStreamOrders" ]
+then
+    dropLowStreamOrders=0
+fi
 
 ## SOURCE ENV FILE AND FUNCTIONS ##
 source $envFile
@@ -105,7 +115,10 @@ fi
 ## Define Outputs Data Dir & Log File##
 export outputRunDataDir=$outputDataDir/$runName
 logFile=$outputRunDataDir/logs/unit/summary_gms_unit.log
+
+## Set misc global variables
 export overwrite=$overwrite
+export dropLowStreamOrders=$dropLowStreamOrders
 
 ## Define inputs
 export input_WBD_gdb=$inputDataDir/wbd/WBD_National.gpkg

--- a/src/gms/derive_level_paths.py
+++ b/src/gms/derive_level_paths.py
@@ -6,18 +6,18 @@ from utils.shared_functions import get_fossid_from_huc8
 import geopandas as gpd
 
 
-def Derive_level_paths(in_stream_network, out_stream_network,branch_id_attribute,
-                       out_stream_network_dissolved=None,huc_id=None,
-                       headwaters_outfile=None,catchments=None,
+def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribute,
+                       out_stream_network_dissolved=None, huc_id=None,
+                       headwaters_outfile=None, catchments=None,
                        catchments_outfile=None,
                        branch_inlets_outfile=None,
-                       toNode_attribute='To_Node',fromNode_attribute='From_Node',
-                       reach_id_attribute='HydroID',verbose=False
-                       ):
-
+                       toNode_attribute='To_Node', fromNode_attribute='From_Node',
+                       reach_id_attribute='HydroID', verbose=False,
+                       drop_low_stream_orders=False ):
+    
     # getting foss_id of huc8
     #foss_id = get_fossid_from_huc8(huc8_id=huc_id,foss_id_attribute='fossid',
-                                   #hucs_layerName='WBDHU8')
+                                   #hucs_layerName='WBDHU8')    
     
     if verbose:
         print("Deriving level paths ...")
@@ -25,7 +25,11 @@ def Derive_level_paths(in_stream_network, out_stream_network,branch_id_attribute
     # load file
     if verbose:
         print("Loading stream network ...")
-    stream_network = StreamNetwork.from_file(in_stream_network)
+        
+    # adding drop-low-stream-orders param is not optimal but functional. A true solution
+    # would have been to assign it as part of some of the other attributes, but it had down code stream affects.
+    stream_network = StreamNetwork.from_file(filename=in_stream_network,
+                                             drop_low_stream_orders=drop_low_stream_orders)
 
     inlets_attribute = 'inlet_id'
     outlets_attribute = 'outlet_id'
@@ -152,15 +156,16 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Create stream network level paths')
     parser.add_argument('-i','--in-stream-network', help='Input stream network', required=True)
     parser.add_argument('-b','--branch-id-attribute', help='Name of the branch attribute desired', required=True)
-    parser.add_argument('-u','--huc-id', help='Current HUC ID', required=False,default=None)
-    parser.add_argument('-r','--reach-id-attribute', help='Reach ID attribute to use in source file', required=False,default='HydroID')
+    parser.add_argument('-u','--huc-id', help='Current HUC ID', required=False, default=None)
+    parser.add_argument('-r','--reach-id-attribute', help='Reach ID attribute to use in source file', required=False, default='HydroID')
     parser.add_argument('-c','--catchments', help='NWM catchments to append level path data to', required=False, default=None)
     parser.add_argument('-t','--catchments-outfile', help='NWM catchments outfile with appended level path data', required=False, default=None)
-    parser.add_argument('-n','--branch_inlets_outfile', help='Output level paths inlets', required=False,default=None)
-    parser.add_argument('-o','--out-stream-network', help='Output stream network', required=False,default=None)
-    parser.add_argument('-e','--headwaters-outfile', help='Output stream network headwater points', required=False,default=None)
-    parser.add_argument('-d','--out-stream-network-dissolved', help='Dissolved output stream network', required=False,default=None)
-    parser.add_argument('-v','--verbose', help='Verbose output', required=False,default=False,action='store_true')
+    parser.add_argument('-n','--branch_inlets_outfile', help='Output level paths inlets', required=False, default=None)
+    parser.add_argument('-o','--out-stream-network', help='Output stream network', required=False, default=None)
+    parser.add_argument('-e','--headwaters-outfile', help='Output stream network headwater points', required=False, default=None)
+    parser.add_argument('-d','--out-stream-network-dissolved', help='Dissolved output stream network', required=False, default=None)
+    parser.add_argument('-v','--verbose', help='Verbose output', required=False, default=False, action='store_true')
+    parser.add_argument('-s','--drop-low-stream-orders', help='Drop stream orders 1 and 2', type=int, required=False, default=False)
     
     args = vars(parser.parse_args())
 

--- a/src/gms/derive_level_paths.py
+++ b/src/gms/derive_level_paths.py
@@ -26,11 +26,14 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
     if verbose:
         print("Loading stream network ...")
         
-    # adding drop-low-stream-orders param is not optimal but functional. A true solution
-    # would have been to assign it as part of some of the other attributes, but it had down code stream affects.
-    stream_network = StreamNetwork.from_file(filename=in_stream_network,
-                                             drop_low_stream_orders=drop_low_stream_orders)
-
+    if (drop_low_stream_orders):
+        stream_network = StreamNetwork.from_file(filename=in_stream_network,
+                                                 branch_id_attribute="order_",
+                                                 values_excluded=[1,2]
+                                                 )
+    else:
+        stream_network = StreamNetwork.from_file(filename=in_stream_network)
+                                                 
     inlets_attribute = 'inlet_id'
     outlets_attribute = 'outlet_id'
     outlet_linestring_index = -1

--- a/src/gms/run_by_unit.sh
+++ b/src/gms/run_by_unit.sh
@@ -67,7 +67,7 @@ Tcount
 echo -e $startDiv"Generating Level Paths for $hucNumber"$stopDiv
 date -u
 Tstart
-$srcDir/gms/derive_level_paths.py -i $outputHucDataDir/nwm_subset_streams.gpkg -b $branch_id_attribute -r "ID" -o $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg -d $outputHucDataDir/nwm_subset_streams_levelPaths_dissolved.gpkg -e $outputHucDataDir/nwm_headwaters.gpkg -c $outputHucDataDir/nwm_catchments_proj_subset.gpkg -t $outputHucDataDir/nwm_catchments_proj_subset_levelPaths.gpkg -n $outputHucDataDir/nwm_subset_streams_levelPaths_dissolved_headwaters.gpkg -v
+$srcDir/gms/derive_level_paths.py -i $outputHucDataDir/nwm_subset_streams.gpkg -b $branch_id_attribute -r "ID" -o $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg -d $outputHucDataDir/nwm_subset_streams_levelPaths_dissolved.gpkg -e $outputHucDataDir/nwm_headwaters.gpkg -c $outputHucDataDir/nwm_catchments_proj_subset.gpkg -t $outputHucDataDir/nwm_catchments_proj_subset_levelPaths.gpkg -n $outputHucDataDir/nwm_subset_streams_levelPaths_dissolved_headwaters.gpkg -v -s $dropLowStreamOrders
 Tcount
 
 ## STREAM BRANCH POLYGONS

--- a/src/gms/stream_branches.py
+++ b/src/gms/stream_branches.py
@@ -39,7 +39,8 @@ class StreamNetwork(gpd.GeoDataFrame):
 
 
     @classmethod
-    def from_file(cls,filename,branch_id_attribute=None,values_excluded=None,attribute_excluded=None, verbose=False,*args,**kwargs):
+    def from_file(cls, filename, branch_id_attribute=None,values_excluded=None, 
+                  attribute_excluded=None, verbose=False, drop_low_stream_orders=False, *args, **kwargs):
 
         """ loads stream network from file to streamnetwork geopandas """
 
@@ -56,8 +57,22 @@ class StreamNetwork(gpd.GeoDataFrame):
             
         if verbose: 
             print('Loading file')
+            
+        dataframe = gpd.read_file(filename,*args,**kwargs)
+        filtered_df = gpd.GeoDataFrame()
         
-        return(cls(gpd.read_file(filename,*args,**kwargs),**inputs))
+        if (drop_low_stream_orders) and ("nwm_subset_streams" in filename):
+             filtered_df = dataframe[dataframe["order_"] > 2]
+        else:
+             filtered_df = dataframe
+            
+        #filtered_df = dataframe            
+        
+        if verbose:         
+             print("======" + filename)
+             print("Number of df rows = " + str(filtered_df.shape[0]))
+        
+        return(cls(filtered_df,**inputs))
 
 
     def write(self,fileName,layer=None,index=True,verbose=False):

--- a/unit_tests/gms/derive_level_paths_params.json
+++ b/unit_tests/gms/derive_level_paths_params.json
@@ -10,7 +10,8 @@
 		"catchments_outfile": "/data/outputs/gms_example_unit_tests/05030104/nwm_catchments_proj_subset_levelPaths.gpkg",
 		"branch_inlets_outfile": "/data/outputs/gms_example_unit_tests/05030104/nwm_subset_streams_levelPaths_dissolved_headwaters.gpkg",
 		"reach_id_attribute": "ID",
-		"verbose": false
+		"verbose": false,
+		"drop_low_stream_orders": false
 	}
 }
 

--- a/unit_tests/gms/derive_level_paths_unittests.py
+++ b/unit_tests/gms/derive_level_paths_unittests.py
@@ -16,6 +16,7 @@ import unit_tests_utils as helpers
 # importing python folders in other direcories
 sys.path.append('/foss_fim/src/gms/')
 import derive_level_paths
+import stream_branches
 
 
 # NOTE: This goes directly to the function.
@@ -36,15 +37,11 @@ class test_Derive_level_paths(unittest.TestCase):
             self.params = json.load(params_file)
 
 
-    # MUST start with the name of "test_"
-    def test_Derive_level_paths_success(self):
 
+    def test_Derive_level_paths_success_all_params(self):
+    
         '''
-        This NEEDS be upgraded to check the output, as well as the fact that all of the output files exist as expected.
-        Most of the output test and internal tests with this function will test a wide variety of conditions.
-        For subcalls to other py classes will not exist in this file, but the unittest file for the other python file.
-        Only the basic return output value shoudl be tested to ensure it is as expected.
-        For now, we are adding the very basic "happy path" test.
+        This test includes all params with many optional parms being set to the default value of the function
         '''
        
         # makes output readability easier and consistant with other unit tests       
@@ -56,7 +53,8 @@ class test_Derive_level_paths(unittest.TestCase):
         # huc_ids no longer used, so it is not submitted
         # other params such as toNode_attribute and fromNode_attribute are defaulted and not passed into __main__, so I will
         # skip them here.
-        actual = derive_level_paths.Derive_level_paths(in_stream_network = params["in_stream_network"],
+        # returns GeoDataframe (the nwm_subset_streams_levelPaths_dissolved.gpkg)
+        actual_df = derive_level_paths.Derive_level_paths(in_stream_network = params["in_stream_network"],
                                                        out_stream_network = params["out_stream_network"],
                                                        branch_id_attribute = params["branch_id_attribute"],
                                                        out_stream_network_dissolved = params["out_stream_network_dissolved"],
@@ -65,24 +63,147 @@ class test_Derive_level_paths(unittest.TestCase):
                                                        catchments_outfile = params["catchments_outfile"],
                                                        branch_inlets_outfile = params["branch_inlets_outfile"],
                                                        reach_id_attribute = params["reach_id_attribute"],
-                                                       verbose = params["verbose"] )
+                                                       verbose = params["verbose"],
+                                                       drop_low_stream_orders=params["drop_low_stream_orders"])
+
+        # -----------
+        # test data type being return is as expected. Downstream code might to know that type
+        self.assertIsInstance(actual_df, stream_branches.StreamNetwork)
         
-        #print(actual)
+        # -----------
+        #**** NOTE: Based on 05030104         
+        # Test row count for dissolved level path GeoDataframe which is returned.
+        actual_row_count = len(actual_df) 
+        expected_row_count = 58
+        self.assertEqual(actual_row_count, expected_row_count)
         
-        # Later, we should check here that the files outputed to the file system, exist and are valid and those do not have to be new "test_" methods.
-        # We can start using unit test "asserts" as we go as well.
+        # -----------
+        # Test that output files exist as expected
+        if os.path.exists(params["out_stream_network"]) == False:
+            raise Exception(params["out_stream_network"] + " does not exist")
+            
+        if os.path.exists(params["out_stream_network_dissolved"]) == False:
+            raise Exception(params["out_stream_network_dissolved"] + " does not exist")
+
+        if os.path.exists(params["headwaters_outfile"]) == False:
+            raise Exception(params["headwaters_outfile"] + " does not exist")
+
+        #if os.path.exists(params["catchments_outfile"]) == False:
+        #    raise Exception(params["catchments_outfile"] + " does not exist")
+
+        if os.path.exists(params["catchments_outfile"]) == False:
+            raise Exception(params["catchments_outfile"] + " does not exist")
+
+        if os.path.exists(params["branch_inlets_outfile"]) == False:
+            raise Exception(params["branch_inlets_outfile"] + " does not exist")
+       
         
         print(f"Test Success: {inspect.currentframe().f_code.co_name}")
         print("*************************************************************")        
 
+
+    def test_Derive_level_paths_success_drop_low_stream_orders_not_submitted(self):
     
-    # Invalid Input stream
-    # MUST start with the name of "test_"    
+        '''
+        This test includes most params but does not submit a drop_low_stream_orders param
+        and it should default to "false", meaning no filtering out of stream orders 1 and 2.
+        Note: Most path tests done in test_Derive_level_paths_success_all_params 
+        and are not repeated here.
+        '''
+        
+        # makes output readability easier and consistant with other unit tests       
+        helpers.print_unit_test_function_header()
+        
+        params = self.params["valid_data"].copy()
+
+        # Function Notes:
+        # huc_ids no longer used, so it is not submitted
+        # other params such as toNode_attribute and fromNode_attribute are defaulted and not passed into __main__, so I will
+        # skip them here.
+        # returns GeoDataframe (the nwm_subset_streams_levelPaths_dissolved.gpkg)
+        actual_df = derive_level_paths.Derive_level_paths(in_stream_network = params["in_stream_network"],
+                                                       out_stream_network = params["out_stream_network"],
+                                                       branch_id_attribute = params["branch_id_attribute"],
+                                                       out_stream_network_dissolved = params["out_stream_network_dissolved"],
+                                                       headwaters_outfile = params["headwaters_outfile"],
+                                                       catchments = params["catchments"],
+                                                       catchments_outfile = params["catchments_outfile"],
+                                                       branch_inlets_outfile = params["branch_inlets_outfile"],
+                                                       reach_id_attribute = params["reach_id_attribute"],
+                                                       verbose = params["verbose"])
+
+        # -----------
+        # test data type being return is as expected. Downstream code might to know that type
+        self.assertIsInstance(actual_df, stream_branches.StreamNetwork)
+        
+        # -----------
+        #**** NOTE: Based on 05030104         
+        # Test row count for dissolved level path GeoDataframe which is returned.
+        actual_row_count = len(actual_df) 
+        expected_row_count = 58    # should still be 58 with no filtering
+        self.assertEqual(actual_row_count, expected_row_count)
+        
+        print(f"Test Success: {inspect.currentframe().f_code.co_name}")
+        print("*************************************************************")        
+        
+        
+
+    def test_Derive_level_paths_success_drop_low_stream_orders_is_true(self):
+    
+        '''
+        This test includes most params but does not submit a drop_low_stream_orders param
+        and it should default to "false", meaning no filtering out of stream orders 1 and 2.
+        Note: Most path tests done in test_Derive_level_paths_success_all_params 
+        and are not repeated here.
+        '''
+        
+        # makes output readability easier and consistant with other unit tests       
+        helpers.print_unit_test_function_header()
+        
+        params = self.params["valid_data"].copy()
+
+        params["drop_low_stream_orders"] = True
+
+        # Function Notes:
+        # huc_ids no longer used, so it is not submitted
+        # other params such as toNode_attribute and fromNode_attribute are defaulted and not passed into __main__, so I will
+        # skip them here.
+        # returns GeoDataframe (the nwm_subset_streams_levelPaths_dissolved.gpkg)
+        actual_df = derive_level_paths.Derive_level_paths(in_stream_network = params["in_stream_network"],
+                                                       out_stream_network = params["out_stream_network"],
+                                                       branch_id_attribute = params["branch_id_attribute"],
+                                                       out_stream_network_dissolved = params["out_stream_network_dissolved"],
+                                                       headwaters_outfile = params["headwaters_outfile"],
+                                                       catchments = params["catchments"],
+                                                       catchments_outfile = params["catchments_outfile"],
+                                                       branch_inlets_outfile = params["branch_inlets_outfile"],
+                                                       reach_id_attribute = params["reach_id_attribute"],
+                                                       verbose = params["verbose"],
+                                                       drop_low_stream_orders=params["drop_low_stream_orders"])
+
+        # -----------
+        # test data type being return is as expected. Downstream code might to know that type
+        self.assertIsInstance(actual_df, stream_branches.StreamNetwork)
+        
+        # -----------
+        #**** NOTE: Based on 05030104         
+        # Test row count for dissolved level path GeoDataframe which is returned.
+        actual_row_count = len(actual_df) 
+        expected_row_count = 4
+        self.assertEqual(actual_row_count, expected_row_count)
+
+        print(f"Test Success: {inspect.currentframe().f_code.co_name}")
+        print("*************************************************************")        
+
+    
+    # Invalid Input stream for demo purposes. Normally, you would not have this basic of a test (input validation).
     def test_Derive_level_paths_invalid_input_stream_network(self):
 
         # makes output readability easier and consistant with other unit tests 
         helpers.print_unit_test_function_header()
         
+        # NOTE: As we are expecting an exception, this MUST have a try catch.
+        #   for "success" tests (as above functions), they CAN NOT have a try/catch
         try:
         
             params = self.params["valid_data"].copy()


### PR DESCRIPTION
By optionally including a "-s" command arg into `gms_run_unit.sh`, you can block loading any nwm stream records where the stream orders are 1 or 2.  By not including the "-s" arg, all stream orders will be loaded as gms was originally designed.

## Additions

- None

## Removals

- None

## Changes

- `gms_run_unit.sh`:  Addition of an optional -s switch, which if included will block GMS from loading nwm streams with stream orders of 1 and 2.
- `src/gms`
    - `run_by_unit.sh`:  Forwarding of optional new -s switch (dropLowStreamOrders) to 'derive_level_paths.py'.
    - `derive_level_paths.py`:  Added optional -s (drop_low_stream_orders variable). When not submitted, it defaults to "False" meaning all stream orders will be included. When "True", this flag is forwarded to 'stream_branches.py' to filter the streams.
    - `stream_branches.py`:  Added an optional argument to the `from_file` method called drop_low_stream_orders. When this is set to True, and the file being loaded into a GeoDataframe has the name "nwm_subset_streams" in it, it will filter out records with stream orders of 1 and 2.
- `unit_tests/gms`
   - derive_level_paths_params.json`: Added new drop_low_stream_orders input variable.
   - `derive_level_paths_unittests.py`:  
       - Upgraded: `test_Derive_level_paths_success` to include new param and also add more tests to validate success
               such as validating the correct record count return, and validating that output files were added to the file
               system as expected.
       - Added: two new unit tests methods:
             - One  for verifying that when the drop_low_stream_orders is not submitted, the system defaults to "False", aka.. no 
             filtering.
            - One for verifying that when submitting drop_low_stream_orders as true, that the number of resulting dissolved stream orders is reduced to the correct number.

## Testing

- Tested `gms_run_unit.sh` with the new -s (dropStreamOrderparam) command line argument being included (meaning drop the stream orders 1 and 2). Also tested with the '-s' arg not being submitted in command arguments, which resulted with no filtering took place as expected. For both scenarios, the files of nwm_subset_streams.gpkg, nwm_subset_streams_levelPaths.gpkg, nwm_subset_streams_levelPaths_dissolved.gpkg were loading into QGIS to validate record counts. This include manually filtering out stream orders against the full nwm_subset_streams in QGIS to validate new record counts.

- The adjustments to the 'derive_level_paths_unittests.py` inherently validate some inputs and outputs. All tests in this unit test file were successful, based on its twin "params.json" file.

