### PR TITLE
[1pt] PR: Hotfix to address catchment aggregation with "src_calibrated" field

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,6 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-Implemented changes to `inundate_nation.py` to allow more flexibility in choosing which FIM outputs to generate. Created new tool (`inundation_mosaic_vrt.py`) to ingest multiple HUC inundation extent rasters, converts them to boolean (0 or 1), and mosaic them together for easier qualitative QA/QC.
-
 
 ## v3.0.28.1 - 2022-03-23 - [PR #570](https://github.com/NOAA-OWP/cahaba/pull/570)
 
@@ -15,6 +13,8 @@ Hotfix to address error with mismatched HUC8 catchment attributes when aggregati
 <br/><br/>
 
 ## v3.0.28.0 - 2022-03-22 - [PR #565](https://github.com/NOAA-OWP/cahaba/pull/565)
+
+Implemented changes to `inundate_nation.py` to allow more flexibility in choosing which FIM outputs to generate. Created new tool (`inundation_mosaic_vrt.py`) to ingest multiple HUC inundation extent rasters, converts them to boolean (0 or 1), and mosaic them together for easier qualitative QA/QC.
 
 ## Additions
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## v3.0.27.1 - 2022-03-23 - [PR #570](https://github.com/NOAA-OWP/cahaba/pull/570)
+
+Hotfix to address error with mismatched HUC8 catchment attributes when aggregating/appending. Added a check to create "src_calibrated" field if it doesn't exist for a HUC prior to appending. 
+
+## Changes
+
+- `src/aggregate_fim_outputs.py`: Added check to create "src_calibrated" field with "null" entries if the field doesn't exist for a HUC8. This address an error when appending catchment layers that have the field (HUC8 with calibration performed) with HUCs that do not have the field.
+
+<br/><br/>
 
 ## v3.0.27.0 - 2022-03-18 - [PR #568](https://github.com/NOAA-OWP/cahaba/pull/568)
 

--- a/src/aggregate_fim_outputs.py
+++ b/src/aggregate_fim_outputs.py
@@ -88,6 +88,8 @@ def aggregate_fim_outputs(args):
 
             # Open catchments
             catchments = gpd.read_file(catchments_filename)
+            if 'src_calibrated' not in catchments.columns:
+                catchments['src_calibrated'] = pd.NA
 
             # Write/append aggregate catchments
             if aggregate_catchments.exists():


### PR DESCRIPTION
Hotfix to address error with mismatched HUC8 catchment attributes when aggregating/appending. Added a check to create "src_calibrated" field if it doesn't exist for a HUC prior to appending. Address #567 

## Changes

- `src/aggregate_fim_outputs.py`: Added check to create "src_calibrated" field with "null" entries if the field doesn't exist for a HUC8. This address an error when appending catchment layers that have the field (HUC8 with calibration performed) with HUCs that do not have the field.

## Testing

1. Confirmed fix on HUC6 170501 (prior error in MS BED run). Usage: `fim_run.sh -u "17050101 17050102 17050103 17050104" -e MS -c foss_fim/config/params_template.env -n ryan_temp/bug_fix_catch_attrib -j 4 -v`

