### PR TITLE
[1pt] PR: Consistent hydroTable variables

### DIFF
--- a/src/add_crosswalk.py
+++ b/src/add_crosswalk.py
@@ -224,6 +224,13 @@ def add_crosswalk(input_catchments_fileName,input_flows_fileName,input_srcbase_f
     output_hydro_table.rename(columns={'Stage' : 'stage','Discharge (m3s-1)':'discharge_cms'},inplace=True)
     output_hydro_table['barc_on'] = False # set barc_on attribute to Fasle (default) --> will be overwritten if BARC module runs
     output_hydro_table['vmann_on'] = False # set vmann_on attribute to Fasle (default) --> will be overwritten if variable roughness module runs
+    output_hydro_table['adjust_src_on'] = False
+    output_hydro_table['last_updated'] = pd.NA
+    output_hydro_table['submitter'] = pd.NA
+    output_hydro_table['adjust_ManningN'] = pd.NA
+    output_hydro_table['obs_source'] = pd.NA
+    output_hydro_table['default_discharge_cms'] = pd.NA
+    output_hydro_table['default_ManningN'] = pd.NA
 
 
     if output_hydro_table.HydroID.dtype != 'str': output_hydro_table.HydroID = output_hydro_table.HydroID.astype(str)

--- a/src/aggregate_fim_outputs.py
+++ b/src/aggregate_fim_outputs.py
@@ -46,7 +46,14 @@ def aggregate_fim_outputs(args):
         if len(huc)> 6:
 
             # Open hydrotable
-            hydrotable = pd.read_csv(hydrotable_filename)
+            hydrotable_read = pd.read_csv(hydrotable_filename)
+
+            # Filter hydrotable to subset list of variables
+            filtered_vars = ['HydroID','feature_id','order_','HUC','LakeID','barc_on','vmann_on','adjust_src_on','stage','discharge_cms']
+            for var in filtered_vars:
+                if var not in hydrotable_read.columns:
+                    hydrotable_read[var] = pd.NA
+            hydrotable = hydrotable_read[filtered_vars]
 
             # Write/append aggregate hydrotable
             if aggregate_hydrotable.exists():
@@ -253,3 +260,4 @@ if __name__ == '__main__':
     print(f"aggregating {len(huc_list)} hucs to HUC6 scale using {number_of_jobs} jobs")
     with Pool(processes=number_of_jobs) as pool:
         pool.map(aggregate_fim_outputs, procs_list)
+    print('Aggregation finished')

--- a/src/aggregate_fim_outputs.py
+++ b/src/aggregate_fim_outputs.py
@@ -46,14 +46,7 @@ def aggregate_fim_outputs(args):
         if len(huc)> 6:
 
             # Open hydrotable
-            hydrotable_read = pd.read_csv(hydrotable_filename)
-
-            # Filter hydrotable to subset list of variables
-            filtered_vars = ['HydroID','feature_id','order_','HUC','LakeID','barc_on','vmann_on','adjust_src_on','stage','discharge_cms']
-            for var in filtered_vars:
-                if var not in hydrotable_read.columns:
-                    hydrotable_read[var] = pd.NA
-            hydrotable = hydrotable_read[filtered_vars]
+            hydrotable = pd.read_csv(hydrotable_filename, usecols=['HydroID','feature_id','order_','HUC','LakeID','barc_on','vmann_on','adjust_src_on','stage','discharge_cms'])
 
             # Write/append aggregate hydrotable
             if aggregate_hydrotable.exists():

--- a/src/src_adjust_spatial_obs.py
+++ b/src/src_adjust_spatial_obs.py
@@ -157,9 +157,8 @@ def ingest_points_layer(points_layer, fim_directory, wbd_path, scale, job_number
     for huc in huc_list:
         ## Check to make sure the HUC directory exists in the current fim_directory
         if not os.path.exists(os.path.join(fim_directory, huc)):
-            print("FIM Directory for huc: " + str(huc) + " does not exist --> skipping SRC adjustments for this HUC")
+            log_file.write("FIM Directory for huc: " + str(huc) + " does not exist --> skipping SRC adjustments for this HUC (obs points found)\n")
             continue
-        print(huc)
         ## Define paths to HAND raster, catchments raster, and synthetic rating curve JSON.
         if scale == 'HUC8':
             hand_path = os.path.join(fim_directory, huc, 'rem_zeroed_masked.tif')

--- a/src/src_roughness_optimization.py
+++ b/src/src_roughness_optimization.py
@@ -66,13 +66,13 @@ def update_rating_curve(fim_directory, water_edge_median_df, htable_path, output
     df_nvalues = df_nvalues[df_nvalues.hydroid.notnull()] # remove null entries that do not have a valid hydroid
 
     ## Read in the hydroTable.csv and check wether it has previously been updated (rename default columns if needed)
-    df_htable = pd.read_csv(htable_path, dtype={'HUC': object, 'last_updated':object, 'submitter':object})
+    df_htable = pd.read_csv(htable_path, dtype={'HUC': object, 'last_updated':object, 'submitter':object, 'obs_source':object})
     df_prev_adj = pd.DataFrame() # initialize empty df for populating/checking later
-    if df_htable['default_discharge_cms'].isnull().values.any():
+    if df_htable['default_discharge_cms'].isnull().values.any(): # check if there are not valid values in the column (True = no previous calibration outputs)
         df_htable['default_discharge_cms'] = df_htable['discharge_cms'].values
         df_htable['default_ManningN'] = df_htable['ManningN'].values
 
-    if merge_prev_adj and not df_htable['adjust_ManningN'].isnull().all():
+    if merge_prev_adj and not df_htable['adjust_ManningN'].isnull().all(): # check if the merge_prev_adj setting is True and there are valid 'adjust_ManningN' values from previous calibration outputs
         # Create a subset of hydrotable with previous adjusted SRC attributes
         df_prev_adj_htable = df_htable.copy()[['HydroID','submitter','last_updated','adjust_ManningN','obs_source']] 
         df_prev_adj_htable.rename(columns={'submitter':'submitter_prev','last_updated':'last_updated_prev','adjust_ManningN':'adjust_ManningN_prev','obs_source':'obs_source_prev'}, inplace=True)
@@ -80,10 +80,9 @@ def update_rating_curve(fim_directory, water_edge_median_df, htable_path, output
         # Only keep previous USGS rating curve adjustments (previous spatial obs adjustments are not retained)
         df_prev_adj = df_prev_adj_htable[df_prev_adj_htable['obs_source_prev'].str.contains("usgs_rating", na=False)] 
         log_text += str(huc) + ': found previous hydroTable calibration attributes --> retaining previous calb attributes for blending...\n'
-    # Delete previous adj columns to prevent duplicate issues (if src_roughness_optimization.py was previously applied)
+    # Delete previous adj columns to prevent duplicate variable issues (if src_roughness_optimization.py was previously applied)
     df_htable.drop(['ManningN','discharge_cms','submitter','last_updated','adjust_ManningN','adjust_src_on','obs_source'], axis=1, inplace=True) 
     df_htable.rename(columns={'default_discharge_cms':'discharge_cms','default_ManningN':'ManningN'}, inplace=True)
-    
 
     ## loop through the user provided point data --> stage/flow dataframe row by row
     for index, row in df_nvalues.iterrows():


### PR DESCRIPTION
Modifications to enforce consistent hydroTable.csv column dimensions for all HUCs. Addresses #576 

## Changes

- src/add_crosswalk.py: Modified to create the placeholder calibration variables (filled with nan values): `adjust_src_on`, `last_updated`, `submitter`, `adjust_ManningN`, `obs_source`, `default_discharge_cms`, and `default_ManningN`
- src/aggregate_fim_outputs.py: Modified to only read in a subset of the HUC8 hydroTable variables that will be included in the HUC6 hydroTables
- src/src_adjust_spatial_obs.py: Modified to move print statement to write to the log file
- src/src_adjust_usgs_rating.py: Modified to check for an empty `agg_crosswalk_df` without returning an assert error. The workflow now skips the USGS rating curve calibration routine when USGS rating data is not available.
- src/src_roughness_optimization.py: Modified workflow to check if calibration variables contain valid data and remove/replace columns as needed prior to performing calibration routine.

## Testing

1. Successful completion of a BED fim_run.sh (MS & FR) and alpha evaluation

## Screenshots
The screenshot below summarizes the issue this PR addresses. List of hydroTable variables without calibration (left column) and with calibration (right).
![image](https://user-images.githubusercontent.com/69868854/162051254-ccc976eb-3bcf-414a-89d9-9ef2610a9b2b.png) 

## Todos

- Update changelog