### PR TITLE
[1pt] PR: New tools and adjustments for bulk gms processing for alpha tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,31 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## v4.0.4.1 - 2022-05-02 - [PR #587](https://github.com/NOAA-OWP/inundation-mapping/pull/587)
+
+While testing GMS against evaluation and inundation data, we discovered some challenges for running alpha testing at full scale. Part of it was related to the very large output volume for GMS which resulted in outputs being created on multiple servers and folders. Considering the GMS volume and processing, a tool was required to extract out the ~215 HUC's that we have evaluation data for. Next, we needed isolate valid HUC output folders from original 2,188 HUC's and its 100's of thousands of branches. The first new tool allows us to point to the `test_case` data folder and create a list of all HUC's that we have validation for.
+
+Now that we have a list of relavent HUC's, we need to consolidate output folders from the previously processed full CONUS+ output data. The new `copy_test_case_folders.py` tool extracts relavent HUC (gms unit) folders, based on the list created above, into a consolidated folder. The two tools combine result in significantly reduced overall processing time for running alpha tests at scale.
+
+`gms_run_unit.sh` and `aggregated_branch_lists.py` were adjusted to make a previously hardcoded file path and file name to be run-time parameters. By adding the two new arguments, the file could be used against the new `copy_test_case_folders.py`. `copy_test_case_folders.py` and `gms_run_unit.sh` can now call `aggregated_branch_lists.py` to create a key input file called `gms_inputs.csv` which is a key file required for alpha testing.
+
+A few other small adjustments were made for readability and traceability as well as a few small fixes discovered when running at scale.
+
+## Additions
+
+- `tools/find_test_case_folders.py`: A new tool for creating a list of HUC's that we have test/evaluation data for.
+- `tools/copy_test_case_folders.py`: A new tool for using the list created above, to scan through other fully processed output folders and extract only the HUC's (gms units) and it's branches into a consolidated folder, ready for alpha test processing (or other needs).
+
+## Changes
+
+- `src/gms/aggregate_branch_lists.py`: Adjusted to allow two previously hardcoded values to now be incoming arguments. Now this file can be used by both `gms_run_unit.sh` and `copy_test_case_folders.py`.
+- `tools/synthesize_test_cases.py`: Adjustments for readability and progress status. The embedded progress bars are not working and will be addressed later.
+- `tools/run_test_case.py`: A print statement was added to help with processing progess was added.
+- `gms_run_unit.sh`: This was adjusted to match the new input parameters for `aggregate_branch_lists.py` as well as additions for progress status. It now will show the entire progress period start datetime, end datetime and duration. 
+- `gms_run_branch.sh`: Also was upgraded to show the entire progress period start datetime, end datetime and duration.
+
+<br/><br/>
+
 ## v4.0.4.0 - 2022-04-12 - [PR #557](https://github.com/NOAA-OWP/inundation-mapping/pull/557)
 
 During large scale testing of the new **filtering out stream orders 1 and 2** feature [PR #548](https://github.com/NOAA-OWP/inundation-mapping/pull/548), a bug was discovered with 14 HUCS that had no remaining streams after removing stream orders 1 and 2. This resulted in a number of unmanaged and unclear exceptions. An exception may be still raised will still be raised in this fix for logging purposes, but it is now very clear what happened. Other types of events are logged with clear codes to identify what happened.

--- a/src/gms/aggregate_branch_lists.py
+++ b/src/gms/aggregate_branch_lists.py
@@ -7,24 +7,29 @@ from os.path import join
 from glob import glob
 
 
-def aggregate_inputs_for_gms(hucList):
+def aggregate_inputs_for_gms(huc_list, output_dir, output_file_name):
 
+    # bash will send huclist in as a colletion and not a string
+    if isinstance(huc_list, list):
+        huc_list_file = huc_list[0]
+    else:
+        huc_list_file = huc_list
+    print(huc_list_file)
     try:
-        hucList = pd.read_csv(hucList[0],header=None,dtype=str).loc[:,0].tolist()
+        huc_list = pd.read_csv(huc_list_file,header=None,dtype=str).loc[:,0].tolist()
     except FileNotFoundError:
         pass
 
-    hucList = set(hucList)
+    hucs = set(huc_list)
 
     # get branch lists
-    outputRunDataDir = environ['outputRunDataDir']
-    branch_id_files = glob(join(outputRunDataDir,'*','branch_id.lst'))
+    branch_id_files = glob(join(output_dir,'*','branch_id.lst'))
 
     all_huc_numbers,all_bids = [],[]
     for bid_file in branch_id_files:
         huc_number = bid_file.split('/')[-2]
         
-        if huc_number in hucList:
+        if huc_number in hucs:
             bids = pd.read_csv(bid_file,header=None).loc[:,0].tolist()
             huc_number_list = [huc_number] * len(bids)
 
@@ -36,15 +41,16 @@ def aggregate_inputs_for_gms(hucList):
                             'branch' : all_bids
                           })
     
-    output.to_csv(join(outputRunDataDir,'gms_inputs.csv'),index=False,header=False)
+    output.to_csv(join(output_dir, output_file_name),index=False,header=False)
 
 
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Aggregate GMS Inputs')
-    parser.add_argument('-l','--hucList', help='huc list', required=True,nargs='+')
-    #parser.add_argument('-a','--input-flows-fileName', help='DEM derived streams', required=True)
+    parser.add_argument('-d','--output_dir', help='output run data directory', required=True)
+    parser.add_argument('-f','--output_file_name', help='output file name', required=True)
+    parser.add_argument('-l','--huc_list', help='huc list', required=True,nargs='+')
 
     args = vars(parser.parse_args())
 

--- a/tools/copy_test_case_folders.py
+++ b/tools/copy_test_case_folders.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import shutil
+
+def copy_folders(folder_name_list,
+                source_dir,
+                target_dir,
+                overwrite=False):
+
+    '''
+    Summary: Scans the source_directory looking for huc values from the huc list. Once found,
+        the huc directory is copied to the target directory. All recusive files/folders wil be copied.
+        
+        Line items each be on a new line  (ie "\n")
+        
+        ***** Note: The tool will still work, if the list is not a list of hucs. 
+              It can be just a list of folder names.
+    Input:
+        - folder_name_list: A file and path to a .txt or .lst file with a list of line delimited huc numbers.
+        - source_dir: The root folder where the huc (or named) folders reside.
+        - target_dir: The root folder where the huc folders will be copied to. Note. All contents of 
+             each huc folder, including branch folders if applicable, will be copied, in the extact
+             structure as the source directory. Note: The target folder need not pre-exist. 
+        - overwrite:  if this value is set to true, the entire target_directory will be emptied of its
+             contents as this process starts if the folder exists. 
+    Output:
+        - A copy of huc directories (or named folders) as listed in the folder_name_list.
+    '''
+
+    if (not os.path.exists(folder_name_list)):
+        raise FileNotFoundError(f"Sorry. The file {folder_name_list} does not exist")
+
+    if (not os.path.exists(source_dir)):
+        raise NotADirectoryError(f"Sorry. Source folder of {source_dir} does not exist")
+
+    if os.path.exists(target_dir) and os.path.isdir(target_dir) and (overwrite == True):
+        shutil.rmtree(target_dir)
+        os.mkdir(target_dir)        
+
+    with open(folder_name_list, "r") as fp:
+        raw_folder_names = fp.read().split("\n")
+
+    # split on new line can add an extra row of a blank value if a newline char exists on the end.
+    # Some lines may have extra spaces, or dups. It is ok if the value is not necessarily a huc
+    folder_names = set() # this will ensure unique names
+    for folder_name in raw_folder_names:
+        folder_name = folder_name.strip()
+        if (folder_name) != '':
+            folder_names.add(folder_name)
+
+    sorted_folder_names = sorted(folder_names)
+
+    print(f"{str(len(sorted_folder_names))} folders to be copied")
+    ctr = 0
+    
+    for folder_name in sorted_folder_names:
+        src_folder = os.path.join(source_dir, folder_name)
+        if not os.path.exists(src_folder):
+            print(f"source folder not found: {src_folder}")
+        else:
+            target_folder = os.path.join(target_dir, folder_name)
+            print(f"coping folder : {target_folder}")
+            shutil.copytree(src_folder, target_folder, dirs_exist_ok=True)
+            ctr+=1
+
+    print(f"{str(ctr)} folders have been copied to {target_dir}")
+    
+
+if __name__ == '__main__':
+
+# Sample Usage: python /foss_fim/tools/copy_test_case_folders.py  -f /data/inputs/huc_lists/huc_list_for_alpha_tests_22020420.lst -s  /outputs/gms_set_1/ -t /data/outputs_fim_share_maas/220421_test_case_hucs -o
+
+    parser = argparse.ArgumentParser(description='Based on the huc list parameter, ' \
+                        'find and copy the full huc (or other) directories.')
+    parser.add_argument('-f','--folder_name_list',
+                            help='file and path to the huc list. Note: The list does not ' \
+                                'necessarily be a list of huc, just a list of unique values',
+                            required=True)                            
+    parser.add_argument('-s','--source_dir', 
+                            help='Source folder to be scanned for unique folders',
+                            required=True)
+    parser.add_argument('-t','--target_dir',
+                            help='Target folder where the folders will be copied to',
+                            required=True)
+
+    parser.add_argument('-o','--overwrite', 
+                            help='Overwrite the target folders if already existing? (default false)',
+                            action='store_true' )
+
+    args = vars(parser.parse_args())
+
+    copy_folders(**args)

--- a/tools/copy_test_case_folders.py
+++ b/tools/copy_test_case_folders.py
@@ -3,10 +3,16 @@
 import os
 import argparse
 import shutil
+import sys
+
+# importing python folders in other direcories
+sys.path.append('/foss_fim/src/gms/')
+import aggregate_branch_lists as agg
 
 def copy_folders(folder_name_list,
                 source_dir,
                 target_dir,
+                create_gms_input_list=False,
                 overwrite=False):
 
     '''
@@ -23,6 +29,10 @@ def copy_folders(folder_name_list,
         - target_dir: The root folder where the huc folders will be copied to. Note. All contents of 
              each huc folder, including branch folders if applicable, will be copied, in the extact
              structure as the source directory. Note: The target folder need not pre-exist. 
+        - create_gms_input_list: If this flag is set to True, after coping the folders, the 
+            "aggregate_branch_lists.py" file will be called in order to make the gms_input.csv file.
+            The gms_input.csv is required for futher processing such as reprocessing branchs or set up
+            for test cases.
         - overwrite:  if this value is set to true, the entire target_directory will be emptied of its
              contents as this process starts if the folder exists. 
     Output:
@@ -34,10 +44,6 @@ def copy_folders(folder_name_list,
 
     if (not os.path.exists(source_dir)):
         raise NotADirectoryError(f"Sorry. Source folder of {source_dir} does not exist")
-
-    if os.path.exists(target_dir) and os.path.isdir(target_dir) and (overwrite == True):
-        shutil.rmtree(target_dir)
-        os.mkdir(target_dir)        
 
     with open(folder_name_list, "r") as fp:
         raw_folder_names = fp.read().split("\n")
@@ -66,14 +72,29 @@ def copy_folders(folder_name_list,
             ctr+=1
 
     print(f"{str(ctr)} folders have been copied to {target_dir}")
+
+    if create_gms_input_list == True:
+        # call this code, which scans each huc (unit) directory looking for the branch_id.lst
+        # and adds them together to create the gms_inputs.csv file
+        # Note: folder_name_list needs to be a huc list to work)
+        agg.aggregate_inputs_for_gms(folder_name_list, target_dir, "gms_inputs.csv")
+        print("gms_inputs.csv created")
     
 
 if __name__ == '__main__':
 
-# Sample Usage: python /foss_fim/tools/copy_test_case_folders.py  -f /data/inputs/huc_lists/huc_list_for_alpha_tests_22020420.lst -s  /outputs/gms_set_1/ -t /data/outputs_fim_share_maas/220421_test_case_hucs -o
+# Remember: This is for pulling out only folders that are related to a huc list (such as an alpha test list)
+#   and it has to be run on each root folder, one at a time (for now. aka.. no wildcards)
+
+# Sample Usage: 
+#python /foss_fim/tools/copy_test_case_folders.py -f /data/inputs/huc_lists/huc_list_for_alpha_tests_22020420.lst -s /outputs/rob_gms_test_synth/ -t /data/outputs/rob_gms_test_synth_combined -a
+
+#  NOTE the 'a' at the end meaning go ahead create the gms_input.csv. This is normally
+# left for the last folder to be copied over.
 
     parser = argparse.ArgumentParser(description='Based on the huc list parameter, ' \
                         'find and copy the full huc (or other) directories.')
+
     parser.add_argument('-f','--folder_name_list',
                             help='file and path to the huc list. Note: The list does not ' \
                                 'necessarily be a list of huc, just a list of unique values',
@@ -85,9 +106,9 @@ if __name__ == '__main__':
                             help='Target folder where the folders will be copied to',
                             required=True)
 
-    parser.add_argument('-o','--overwrite', 
-                            help='Overwrite the target folders if already existing? (default false)',
-                            action='store_true' )
+    parser.add_argument('-a','--create_gms_input_list',
+                            help='Create the gms_input.csv list after coping',
+                            required=False, default=False, action='store_true')
 
     args = vars(parser.parse_args())
 

--- a/tools/find_test_case_folders.py
+++ b/tools/find_test_case_folders.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import re
+
+def create_huc_list(input_root_search_folder,
+                    output_path,
+                    overwrite=False):
+
+    '''
+    Summary: This scans an input directory, such as test_cases, and looks for each
+         unique huc value through those folders. This gives us a single list of all hucs
+         that can be used for alpha or sierra tests. 
+         This looks for first level folders using the following convention:
+            - *_test_cases  (ie usgs_test_cases)
+                Then subfolders using the following convention:
+                - {8 numbers}_{3 to 7 characters}. ie) 01080005_usgs
+    Input:
+        - input_root_search_folder: A fully qualified root path (relative to Docker pathing) to the folder that all hucs
+            are in.
+        - output_path: a path and file name (preferred as .lst or .txt) where the list of line delimited hucs
+            will be copied. The file and path do not need to pre-exist.
+        - overwrite: If the file exists and the overwrite flag is false, an error will be issued. Else, it will
+            be fully overwritten.
+    Output:
+        - a line delimited list of all huc numbers that have test cases available.
+    '''
+
+    if (not os.path.exists(input_root_search_folder)):
+        raise NotADirectoryError(f"Sorry. Search_folder of {input_root_search_folder} does not exist")
+
+    if (os.path.exists(output_path) and not overwrite):
+        raise Exception(f"Sorry. The file {output_path} already exists. Use 'overwrite' argument if desired.")
+
+    hucs = set()
+
+    for test_case in [test_case for test_case in os.listdir(input_root_search_folder) 
+        if re.match('.*_test_cases', test_case)]:
+            for test_id in [test_id for test_id in os.listdir(os.path.join(input_root_search_folder, test_case))
+                if re.match('\d{8}_\w{3,7}', test_id)]:
+                    hucs.add(test_id[:8])
+
+    sorted_hucs = sorted(hucs)
+    #print(sorted_hucs)
+    print(f"{str(len(sorted_hucs))} hucs found")
+    
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    # Save to disk
+    with (open(output_path, 'w')) as output_file:
+        #output_file.writelines(sorted_hucs)
+        for huc in sorted_hucs:
+            output_file.write(huc)
+            output_file.write('\n')
+
+    print(f"huc list saved at {output_path}")
+
+
+if __name__ == '__main__':
+
+# Sample Usage: python /foss_fim/tools/find_test_case_hucs.py -d /data/test_cases/ -f /some_directory/huc_list_for_tests_22020420.lst -o
+
+    parser = argparse.ArgumentParser(description='Finds all unique hucs that have test case data.')
+    parser.add_argument('-d','--input_root_search_folder', 
+                            help='Root folder to be scanned for unique hucs that have test case',
+                            required=True)
+    parser.add_argument('-f','--output_path',
+                            help='Folder path and file name to be saved (.txt or .lst suggested).',
+                            required=True)
+    parser.add_argument('-o','--overwrite', 
+                            help='Overwrite the file if already existing? (default false)',
+                            action='store_true' )
+
+    args = vars(parser.parse_args())
+
+    create_huc_list(**args)

--- a/tools/run_test_case.py
+++ b/tools/run_test_case.py
@@ -36,6 +36,8 @@ def run_alpha_test( fim_run_dir, version, test_id, magnitude,
     # make bool
     calibrated = bool( calibrated )
 
+    print(f"run_alpha_test: test_id = {test_id}")
+
     if (model == "MS") & (fr_run_dir is None):
         raise ValueError("fr_run_dir argument needs to be specified with MS model")
 


### PR DESCRIPTION
During large scale testing of GMS for `alpha testing` (synthesize_test_cases.py), some challenges were discovered. Tools and upgraded log / output tracking were required for `alpha testing` the large GMS processed folders. This was complicated by the fact that GMS output folders are likely not all in one directory or even one machine.

When alpha testing is completed, it adds a number of folders/files to a common `test_case` folder. The merging of folders and files from different FIM3 or FIM4/GMSprocessed folders is very tricky to amalgamate correctly and high risk. 

Extracting only GMS HUC (unit and branch) folders that were valid for alpha testing had a major impact on overall 
performance of `synthesize_test_cases.py`.  In order to figure out which output folders were required, one needed to create a list of HUCs that had valid test case data. The new `find_test_case_folder.py` file scans through the `test_cases` folder and creates a list of HUCs that have some test data. You can define the path and file name of the HUC list, ie) /data/inputs/huc_lists/huc_list_for_alpha_tests_22020420.lst. 

Now that we have a list of HUCs, we can run another new tool named `copy_test_case_folder.py` which uses the new HUC list to scan an output folder and copy out the HUC (unit and branches) folders into a common folder. During full BED testing of GMS, we had a total of 22 folders, each with appx 100 HUCs (units and branches). Running the `copy_test_case_folder.py` against all 22 folder (across 2 servers), allows only HUC folders that were applicable to alpha testing into a common directory. Note: It is not required to have all in one folder but make the total speed and tracking much better.

Now that we had the GMS output folders for HUCS that were `alpha testing` applicable, we needed to create a new _gms_inputs.csv_ file as this is required for running alpha testing.  Adding a command line param to the `copy_test_case_folder.py` would calculate a new _gms_input.csv_ for only HUCS in the amalgamated HUC alpha test folder. To get the new _gms_input.csv_, we needed to change the `aggregate_branch_lists.py` file to allow for more input parameters and less hardcoding. As the interface for `aggregate_branch_lists.py` changed, `gms_run_unit.sh` has to change as well.

Some additional logging was added in a couple of key places to help track progress including start dates/time, end dates/time and durations. This was added to `synthesize_test_cases.py`, `run_rest_case.py` as well as added back to `gms_run_unit.sh` and `gms_run_branch.sh`.

A few small adjustments were also made to `gms_run_unit.sh` and `gms_run_branch.sh` which could throw errors in certain overwrite / rerun conditions.

See the original [Issue 586](https://github.com/NOAA-OWP/inundation-mapping/issues/586). 

## Additions

- `tools/find_test_case_folders.py`
   - The creates a list of HUCs that have valid test data available for alpha testing. It scans through a stated directory as an argument (likely `test_cases` ) looking for all _first level_ folders following the convention of ** *_test_cases**. ie) usgs_test_cases.  Then scans through _each applicable child folder_ looking for a pattern of 8 numbers, underscore, then 3 to 7 characters. ie) 01020304_usgs.  The HUC value, ie) 01020304, is extract and added to a unique HUC value list, line delimited.
   
- `tools/copy_test_case_folders.py`
   - This tool allows for copying data from one folder to another and can use a HUC list to do it. Generally, it is used to extract only folders that are applicable to alpha testing to be consolidated to a central location for processing speed reasons. Using any .text or .lst list using values with line delimiters, it can scan through a root directory, submitted as an argument, looking for matching folder. ie) 01020304 folder in /outputs/jan_gms_run.  Note. While it will usually be a HUC list against a FIM3 or FIM4/GMS output folder, it is not mandatory. It simply looks for a folder name match at the first level under the root defined folder.  As that folder is found, it is copied including sub-files/folders, to another folder defined as a parameter. ie) /outputs/jan_gms_run_test_hucs.  Further, it has an optional argument that can generated a _gms_input.csv_ file in the target folder as the _gms_input.csv_ is required for `alpha testing`.

## Changes

- `src/gms/aggregate_branch_lists.py`
   - Was updated to allow for two new arguments which were previously hardcoded. Previously this file was used only by `gms_run_unit.sh` to create the _gms_inputs.csv_ file required for further processing steps. With adding the two new params, this tool can be re-used by tools as part of `alpha testing` via the new `copy_test_case_folders.py` to create a new _gms_inputs.csv_ file after coping folders to new locations.  

- `tools/synthesize_test_cases.py`
   - Was updated primarily for enhanced logging. It now includes outputs that show start date/time, end date/time and duration. During large scale use of the tool, progress tracking was limited.

- `tools/run_test_case.py`
   - An additional print statement at a key location helped with progress tracking and now shows what test_id (HUC and test type) is being processed.

- `gms_run_unit.sh`
   - This was upgraded for two things: 
      - Change it call to aggregate_branch_lists.py to add in the two new additional input arguments.
      - Upgrades for output to help with overall start date/time, end date/time and duration of the entire gms_run_unit.sh command. This helps track overall performance.

- `gms_run_branch.sh`
   - Upgrades for output to help with overall start date/time, end date/time and duration of the entire gms_run_unit.sh command.  This helps track overall performance.

## Testing
A couple of different test flows were done and most individual steps were tested a number of times independently to validate outputs, different input params, error conditions, etc.
One test scenario was:
    - This was tested against processing of two HUCs, one at time, through `gms_run_unit.sh` and `gms_run_branch.sh` to validate the upgraded output, but also that the changes related to creating the _gms_inputs.csv_ was done correctly. By running the two HUCs separately, two separate output folders were created.
   - Running the `find_test_case_folders.py`  tool created a master list of HUCs that had test data. This file was compared to a manually created list by another staff member to ensure it was correct. Running the tool helped prevent a manual processing of discovering valid HUCs.
   - Using the new valid test case HUC list and using the `copy_test_case_folders.py`, it was run twice against the two new test HUC folders. When running the second folder, the input param for creating the manditory `gms_inputs.csv` was included and validated by hand.
   - `synthensize_test_case.py` was run against the new combined folder with the outputs into the `test_cases` folders being evaluated at a high level, aka.. were expected folders added in correct places in the `test_cases` folder. 
   - The overall metrics output file from `synthensize_test_case.py` was not independently evaluated. This was due to the core logic of `synthensize_test_case.py` not changing. Advanced validation of the metrics file is being evaluated separately and is expected to be fine.

The entire process and tools in order to create alpha test data was rrun twice. In past months, a full BED GMS test was done which created 22 folders across two servers.  For each server, and its appx 11 folders, the entire process was run in order to create full alpha test results.  Validation at each step was done during the full alpha test run for each server. Once each server was completed, the final results were copied back to merged central server `test_cases` folder.  Merging back to a centralized `test_cases` folder was still tricky but significantly easier than validation of 22 folders from the original GMS output folders. 

Based on the initial list of 216 HUCs that appeared on the huc list for alpha testing, it was extremely difficult to validate if the correct number of total new `test_cases` folders were created. However, spot checking of a number of HUCs from both of the original two servers, suggest the outputs are fine.  No unexpected or unaccounted errors were found during final usage of the tools and processes. 


