### PR TITLE
[1pt] PR: Update FIM3 alpha test to include MS/FR composite analysis

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,22 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.32.0 - 2022-05-26 - [PR #597](https://github.com/NOAA-OWP/cahaba/pull/588)
+
+This PR updates `synthesize_test_cases.py` with the ability to create MS, FR, and composite inundation agreement rasters and statistics all in one run. The new composited statistics are output in the same location within each test ID with the `_comp` suffix  replacing `_ms` for each dev or previous_fim run. Addresses #555.
+`run_test_case.py` has also been refactored to use a `test_case` python class. This workflow has shown decreased memory usage as compared to the previous version of `run_test_case.py`.
+
+## Changes
+
+- `tools/`
+    - `synthesize_test_cases.py`: Merged in `dev` branch (FIM 4) changes and re-factored to run FR, MS, and COMP `run_alpha_test` in that order (with multiprocessing).
+    - `run_test_case.py`: Merged in `dev` branch (FIM 4) changes and re-factored to run COMP tests after both FR and MS inundations/test cases are performed.
+    - `eval_plots.py`: Ensure that the new `_comp` folder produced in `synthesize_test_cases.py` is included in the plots.
+ - `src/`
+    - `inundation.py`: Included new data types to prevent memory usage warnings.
+
+<br/><br/>
+
 ## v3.0.31.0 - 2022-05-24 - [PR #597](https://github.com/NOAA-OWP/cahaba/pull/597)
 
 Modifications to enable bathymetry adjusted rating curves (BARC) to be implemented to FR flow lines to better match the MS inundation where FR & MS overlap. This PR uses an input env parameter to control which stream orders BARC is applied to for both FR & MS (currently set to orders 4-9). 

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -86,7 +86,7 @@ def boxplot(dataframe, x_field, x_order, y_field, hue_field, ordered_hue, title_
             elif 'fim_2' in label:
                 label_dict[label] = 'FIM 2' + ' ' + fim_configuration.lower()
             elif 'fim_3' in label and len(label) < 20:
-                label_dict[label] = re.split('_fr|_ms', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
+                label_dict[label] = re.split('_fr|_ms|_comp', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
                 if label.endswith('_c'):
                     label_dict[label] = label_dict[label] + ' c'
             else:
@@ -253,7 +253,7 @@ def barplot(dataframe, x_field, x_order, y_field, hue_field, ordered_hue, title_
             elif 'fim_2' in label:
                 label_dict[label] = 'FIM 2' + ' ' + fim_configuration.lower()
             elif 'fim_3' in label and len(label) < 20:
-                label_dict[label] = re.split('_fr|_ms', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
+                label_dict[label] = re.split('_fr|_ms|_comp', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
                 if label.endswith('_c'):
                     label_dict[label] = label_dict[label] + ' c'
             else:

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -600,13 +600,18 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
         ###############################################################
         #This section will join ahps metrics to a spatial point layer
         ###############################################################
-        if all_datasets.get(('nws','MS')) and all_datasets.get(('usgs','MS')):
+        if (all_datasets.get(('nws','MS')) and all_datasets.get(('usgs','MS'))) or \
+            (all_datasets.get(('nws','COMP')) and all_datasets.get(('usgs','COMP'))): # export composite metrics to shp
             #Get point data for ahps sites
             #Get metrics for usgs and nws benchmark sources
-            usgs_dataset,sites = all_datasets.get(('usgs','MS'))
-            nws_dataset, sites = all_datasets.get(('nws','MS'))
+            try:
+                usgs_dataset,sites = all_datasets.get(('usgs','MS'))
+                nws_dataset, sites = all_datasets.get(('nws','MS'))
+            except TypeError: # Composite metrics
+                usgs_dataset,sites = all_datasets.get(('usgs','COMP'))
+                nws_dataset, sites = all_datasets.get(('nws','COMP'))
             #Append usgs/nws dataframes and filter unnecessary columns and rename remaining.
-            all_ahps_datasets = usgs_dataset.append(nws_dataset)
+            all_ahps_datasets = pd.concat([usgs_dataset, nws_dataset])
             all_ahps_datasets = all_ahps_datasets.filter(['huc','nws_lid','version','magnitude','TP_area_km2','FP_area_km2','TN_area_km2','FN_area_km2','CSI','FAR','TPR','PND','benchmark_source'])
             all_ahps_datasets.rename(columns = {'benchmark_source':'source'}, inplace = True)
 
@@ -634,13 +639,19 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
         ################################################################
         #This section joins ble (FR) metrics to a spatial layer of HUCs.
         ################################################################
-        if all_datasets.get(('ble','FR')) and all_datasets.get(('ifc','FR')) and all_datasets.get(('ras2fim','FR')):
+        if (all_datasets.get(('ble','FR')) and all_datasets.get(('ifc','FR')) and all_datasets.get(('ras2fim','FR'))) or \
+            (all_datasets.get(('ble','COMP')) and all_datasets.get(('ifc','COMP')) and all_datasets.get(('ras2fim','COMP'))):
             #Select BLE, FR dataset.
-            ble_dataset, sites = all_datasets.get(('ble','FR'))
-            ifc_dataset, sites = all_datasets.get(('ifc','FR'))
-            ras2fim_dataset, sites = all_datasets.get(('ras2fim','FR'))
-            huc_datasets = ble_dataset.append(ifc_dataset)
-            huc_datasets = huc_datasets.append(ras2fim_dataset)
+            try:
+                ble_dataset, sites = all_datasets.get(('ble','FR'))
+                ifc_dataset, sites = all_datasets.get(('ifc','FR'))
+                ras2fim_dataset, sites = all_datasets.get(('ras2fim','FR'))
+            except TypeError:
+                ble_dataset, sites = all_datasets.get(('ble','COMP'))
+                ifc_dataset, sites = all_datasets.get(('ifc','COMP'))
+                ras2fim_dataset, sites = all_datasets.get(('ras2fim','COMP'))
+
+            huc_datasets = pd.concat([ble_dataset, ifc_dataset, ras2fim_dataset])
             #Read in HUC spatial layer
             wbd_gdf = gpd.read_file(Path(WBD_LAYER), layer = 'WBDHU8')
             #Join metrics to HUC spatial layer

--- a/tools/inundation.py
+++ b/tools/inundation.py
@@ -468,7 +468,8 @@ def __subset_hydroTable_to_forecast(hydroTable,forecast,subset_hucs=None):
                                  hydroTable,
                                  dtype={'HUC':str,'feature_id':str,
                                          'HydroID':str,'stage':float,
-                                         'discharge_cms':float,'LakeID' : int}
+                                         'discharge_cms':float,'LakeID' : int, 
+                                         'last_updated':object,'submitter':object,'adjust_ManningN':object,'obs_source':object}
                                 )
         huc_error = hydroTable.HUC.unique()
         hydroTable.set_index(['HUC','feature_id','HydroID'],inplace=True)

--- a/tools/run_test_case.py
+++ b/tools/run_test_case.py
@@ -10,6 +10,13 @@ from tools_shared_functions import compute_contingency_stats_from_rasters
 class benchmark(object):
     
     def __init__(self, category):
+        """Class that handles benchmark data.
+
+            Parameters
+            ----------
+            category : str
+                Category of the benchmark site. Should be one of ['ble', 'ifc', 'nws', 'usgs', 'ras2fim']
+        """
         self.AHPS_BENCHMARK_CATEGORIES = AHPS_BENCHMARK_CATEGORIES
         self.MAGNITUDE_DICT = MAGNITUDE_DICT
         
@@ -18,9 +25,11 @@ class benchmark(object):
         self.is_ahps = True if self.category in self.AHPS_BENCHMARK_CATEGORIES else False
     
     def magnitudes(self):
+        '''Returns the magnitudes associated with the benchmark category.'''
         return self.MAGNITUDE_DICT[self.category]
     
     def huc_data(self):
+        '''Returns a dict of HUC8, magnitudes, and sites.'''
         huc_mags = {}
         for huc in os.listdir(self.validation_data):
             if not re.match('\d{8}', huc): continue
@@ -28,7 +37,12 @@ class benchmark(object):
         return huc_mags
     
     def data(self, huc):
+        '''Returns a dict of magnitudes and sites for a given huc. Sites will be AHPS lids for 
+           AHPS sites and empty strings for non-AHPS sites.
+        '''
         huc_dir = os.path.join(self.validation_data, huc)
+        if not os.path.isdir(huc_dir):
+            return {}
         if self.is_ahps:
             lids = os.listdir(huc_dir)
 
@@ -49,7 +63,22 @@ class benchmark(object):
 class test_case(benchmark):
 
     def __init__(self, test_id, version, archive=True):
+        """Class that handles test cases, specifically running the alpha test.
 
+            Parameters
+            ----------
+            test_id : str
+                ID of the test case in huc8_category format, e.g. `12090201_ble`.
+            version : str
+                Version of FIM to which this test_case belongs. This should correspond to the fim directory
+                name in either `/data/previous_fim/` or `/data/outputs/`.
+            archive : bool
+                If true, this test case outputs will be placed into the `official_versions` folder
+                and the FIM model will be read from the `/data/previous_fim` folder.
+                If false, it will be saved to the `testing_versions/` folder and the FIM model 
+                will be read from the `/data/outputs/` folder.
+        
+        """
         self.test_id = test_id
         self.huc, self.benchmark_cat = test_id.split('_')
         super().__init__(self.benchmark_cat)
@@ -79,15 +108,15 @@ class test_case(benchmark):
                         },
                     }
 
-    def alpha_test(self, fim_directory, calibrated=False, compare_to_previous=False, mask_type='filter', inclusion_area='',
+    def alpha_test(self, fim_directory, calibrated=False, model='', compare_to_previous=False, mask_type='huc', inclusion_area='',
                 inclusion_area_buffer=0, overwrite=True, verbose=False):
+        '''Compares a FIM directory with benchmark data from a variety of sources.'''
 
         if not overwrite:
             return
 
         fim_huc_dir = fim_directory
         self.stats_modes_list = ['total_area']
-        model = 'MS' if re.search('_ms', self.version) else 'FR'
 
         # Create paths to fim_run outputs for use in inundate()
         self.rem = os.path.join(fim_huc_dir, 'rem_zeroed_masked.tif')
@@ -103,7 +132,7 @@ class test_case(benchmark):
             self.catchment_poly = os.path.join(fim_huc_dir, 'gw_catchments_reaches_filtered_addedAttributes_crosswalked.gpkg')
         self.hydro_table = os.path.join(fim_huc_dir, 'hydroTable.csv')
 
-        # Map necessary inputs for inundation().
+        # Map necessary inputs for inundate().
         self.hucs, self.hucs_layerName = os.path.join(INPUTS_DIR, 'wbd', 'WBD_National.gpkg'), 'WBDHU8'
 
         if inclusion_area != '':
@@ -121,19 +150,33 @@ class test_case(benchmark):
             shutil.rmtree(self.dir)
         os.mkdir(self.dir)
 
-        validation_dict = self.data(self.huc)
-        for magnitude in validation_dict:
-            for instance in validation_dict[magnitude]:            # instance will be the lid for AHPS sites and '' for other sites
+        # Get the magnitudes and lids for the current huc and loop through them
+        validation_data = self.data(self.huc)
+        for magnitude in validation_data:
+            for instance in validation_data[magnitude]:      # instance will be the lid for AHPS sites and '' for other sites
+                # For each site, inundate the REM and compute aggreement raster with stats
                 self._inundate_and_compute(magnitude, instance)
 
             # Clean up 'total_area' outputs from AHPS sites
             if self.is_ahps:
                 self.clean_ahps_outputs(os.path.join(self.dir, magnitude))
 
-        # write out evaluation meta-data
+        # Write out evaluation meta-data
         self.write_metadata(calibrated, model)
         
     def _inundate_and_compute(self, magnitude, lid, compute_only=False):
+        '''Method for inundating and computing contingency rasters as part of the alpha_test.
+           Used by both the alpha_test() and composite() methods.
+
+            Parameters
+            ----------
+            magnitude : str
+                Magnitude of the current benchmark site.
+            lid : str
+                lid of the current benchmark site. For non-AHPS sites, this should be an empty string ('').
+            compute_only : bool
+                If true, skips inundation and only computes contingency stats.
+        '''
 
         # Output files
         test_case_out_dir     = os.path.join(self.dir, magnitude)
@@ -190,33 +233,34 @@ class test_case(benchmark):
 
 
     @classmethod
-    def run_alpha_test(cls, fim_run_dir, version, test_id, magnitude, calibrated, compare_to_previous=False, archive_results=False, 
+    def run_alpha_test(cls, fim_run_dir, version, test_id, magnitude, calibrated, model, compare_to_previous=False, archive_results=False, 
                        mask_type='huc', inclusion_area='', inclusion_area_buffer=0, light_run=False, overwrite=True):
+        '''Class method for instantiating the test_case class and running alpha_test directly'''
+
         alpha_class = cls(test_id, version, archive_results)
-        alpha_class.alpha_test(fim_run_dir, calibrated, compare_to_previous=False, mask_type='filter', inclusion_area='',
-                inclusion_area_buffer=0, overwrite=True, verbose=False)
+        alpha_class.alpha_test(fim_run_dir, calibrated, model, compare_to_previous, mask_type, inclusion_area,
+                inclusion_area_buffer, overwrite)
 
     @classmethod
-    def composite(cls, test_id, version_1='', version_2='', archive_results=True, calibrated=False, overwrite=True):
+    def composite(cls, test_id, version_ms='', version_fr='', archive_results=True, calibrated=False, overwrite=True):
+        '''Class method for compositing MS and FR inundation and creating an agreement raster with stats'''
 
         if not overwrite:
             return
 
-        composite_version_name = re.sub(r'(.*)(_ms|_fr)', r'\1_comp', version_1, count=1)
-
+        composite_version_name = re.sub(r'(.*)(_ms|_fr)', r'\1_comp', version_ms, count=1)
         composite_test_case = cls(test_id, composite_version_name, archive_results)
-        input_test_case_1 = cls(test_id, version_1, archive_results)
-        input_test_case_2 = cls(test_id, version_2, archive_results)
+        input_test_case_1 = cls(test_id, version_ms, archive_results)
+        input_test_case_2 = cls(test_id, version_fr, archive_results)
         composite_test_case.stats_modes_list = ['total_area']
 
-        
         # Delete the directory if it exists
         if os.path.exists(composite_test_case.dir):
             shutil.rmtree(composite_test_case.dir)
 
-        validation_dict = composite_test_case.data(composite_test_case.huc)
-        for magnitude in validation_dict:
-            for instance in validation_dict[magnitude]:                       # instance will be the lid for AHPS sites and '' for other sites
+        validation_data = composite_test_case.data(composite_test_case.huc)
+        for magnitude in validation_data:
+            for instance in validation_data[magnitude]:      # instance will be the lid for AHPS sites and '' for other sites (ble/ifc/ras2fim)
                 inundation_prefix = instance + '_' if instance else ''
 
                 input_inundation_1 = os.path.join(input_test_case_1.dir, magnitude, f'{inundation_prefix}inundation_extent_{input_test_case_1.huc}.tif')
@@ -239,27 +283,18 @@ class test_case(benchmark):
                                             )
                     composite_test_case._inundate_and_compute(magnitude, instance, compute_only=True)
 
-                elif os.path.isfile(input_inundation_1) or os.path.isfile(input_inundation_2): 
-                    # If only one model (MS or FR) has inundation, simply copy over all files as the composite
-                    single_test_case = input_test_case_1 if os.path.isfile(input_inundation_1) else input_test_case_2
-                    shutil.copytree(single_test_case.dir, re.sub(r'(.*)(_ms|_fr)', r'\1_comp', single_test_case.dir, count=1))
-                    composite_test_case.write_metadata(calibrated, 'COMP')
-                    return
-
-            # Clean up 'total_area' outputs from AHPS sites
-            if composite_test_case.is_ahps:
-                composite_test_case.clean_ahps_outputs(os.path.join(composite_test_case.dir, magnitude))
-
+        composite_test_case.write_metadata(calibrated, 'COMP')
 
     def write_metadata(self, calibrated, model):
-        # write out evaluation meta-data
+        '''Writes metadata files for a test_case directory.'''
         with open(os.path.join(self.dir,'eval_metadata.json'),'w') as meta:
             eval_meta = { 'calibrated' : calibrated , 'model' : model }
             meta.write( 
                         json.dumps(eval_meta,indent=2) 
                     )
-    def clean_ahps_outputs(self, directory):
-        output_file_list = [os.path.join(directory, of) for of in os.listdir(directory)]
+    def clean_ahps_outputs(self, magnitude_directory):
+        '''Cleans up `total_area` files from an input AHPS magnitude directory.'''
+        output_file_list = [os.path.join(magnitude_directory, of) for of in os.listdir(magnitude_directory)]
         for output_file in output_file_list:
             if "total_area" in output_file:
                 os.remove(output_file)

--- a/tools/run_test_case.py
+++ b/tools/run_test_case.py
@@ -4,12 +4,40 @@ import os
 import sys
 import shutil
 import argparse
+import traceback
+from pathlib import Path
+import json
+import ast
+import pandas as pd
 
 from tools_shared_functions import compute_contingency_stats_from_rasters
-from tools_shared_variables import (TEST_CASES_DIR, INPUTS_DIR, ENDC, TRED_BOLD, WHITE_BOLD, CYAN_BOLD, AHPS_BENCHMARK_CATEGORIES)
+from tools_shared_variables import (TEST_CASES_DIR, INPUTS_DIR, ENDC, TRED_BOLD, WHITE_BOLD, CYAN_BOLD, AHPS_BENCHMARK_CATEGORIES, IFC_MAGNITUDE_LIST, BLE_MAGNITUDE_LIST )
 from inundation import inundate
+from gms_tools.inundate_gms import Inundate_gms
+from gms_tools.mosaic_inundation import Mosaic_inundation
+from gms_tools.overlapping_inundation import OverlapWindowMerge
+from glob import glob
+from tools_shared_variables import elev_raster_ndv
 
-def run_alpha_test(fim_run_dir, version, test_id, magnitude, compare_to_previous=False, archive_results=False, mask_type='huc', inclusion_area='', inclusion_area_buffer=0, light_run=False, overwrite=True):
+def run_alpha_test( fim_run_dir, version, test_id, magnitude, 
+                calibrated, model,
+                compare_to_previous=False, archive_results=False, 
+                mask_type='filter', inclusion_area='', 
+                inclusion_area_buffer=0, light_run=False, 
+                overwrite=True, fr_run_dir=None, 
+                gms_workers=1,verbose=False,
+                gms_verbose=False
+              ):
+    
+    # check eval_meta input
+    if model not in {None,'FR','MS','GMS'}:
+        raise ValueError("Model argument needs to be \'FR\', \'MS\', or \'GMS.\'")
+
+    # make bool
+    calibrated = bool( calibrated )
+
+    if (model == "MS") & (fr_run_dir is None):
+        raise ValueError("fr_run_dir argument needs to be specified with MS model")
 
     benchmark_category = test_id.split('_')[1] # Parse benchmark_category from test_id.
     current_huc = test_id.split('_')[0]  # Break off HUC ID and assign to variable.
@@ -24,17 +52,22 @@ def run_alpha_test(fim_run_dir, version, test_id, magnitude, compare_to_previous
     if os.path.exists(version_test_case_dir_parent):
         if overwrite == True:
             shutil.rmtree(version_test_case_dir_parent)
+            if model == 'MS':
+                shutil.rmtree('_comp'.join(version_test_case_dir_parent.rsplit('_ms', 1)), ignore_errors=True)
         else:
-            print("Metrics for ({version}: {test_id}) already exist. Use overwrite flag (-o) to overwrite metrics.".format(version=version, test_id=test_id))
+            print(f"Metrics for ({version}: {test_id}) already exist. Use overwrite flag (-o) to overwrite metrics.")
             return
 
-    os.mkdir(version_test_case_dir_parent)
+    os.makedirs(version_test_case_dir_parent,exist_ok=True)
 
-    print("Running the alpha test for test_id: " + test_id + ", " + version + "...")
+    __vprint("Running the alpha test for test_id: " + test_id + ", " + version + "...",verbose)
     stats_modes_list = ['total_area']
 
     fim_run_parent = os.path.join(os.environ['outputDataDir'], fim_run_dir)
     assert os.path.exists(fim_run_parent), "Cannot locate " + fim_run_parent
+
+    # get hydrofabric directory
+    hydrofabric_dir = Path(fim_run_parent).parent.absolute()
 
     # Create paths to fim_run outputs for use in inundate().
     rem = os.path.join(fim_run_parent, 'rem_zeroed_masked.tif')
@@ -113,6 +146,10 @@ def run_alpha_test(fim_run_dir, version, test_id, magnitude, compare_to_previous
             forecast_list = [forecast_path]
             inundation_raster_list = [os.path.join(version_test_case_dir, 'inundation_extent.tif')]
 
+        if not benchmark_raster_path_list:
+            os.rmdir(version_test_case_dir)
+            continue
+
         for index in range(0, len(benchmark_raster_path_list)):
             benchmark_raster_path = benchmark_raster_path_list[index]
             forecast = forecast_list[index]
@@ -132,57 +169,184 @@ def run_alpha_test(fim_run_dir, version, test_id, magnitude, compare_to_previous
                     continue
             else:  # If not in AHPS_BENCHMARK_CATEGORIES.
                 if not os.path.exists(benchmark_raster_path) or not os.path.exists(forecast):  # Skip loop instance if the benchmark raster doesn't exist.
+                    inundate_exit_status = -1
                     continue
             # Run inundate.
-#            print("-----> Running inundate() to produce modeled inundation extent for the " + magnitude + " magnitude...")
+            __vprint("-----> Running inundate() to produce inundation extent for the " + magnitude + " magnitude...",verbose)
+            # The inundate adds the huc to the name so I account for that here.
+            predicted_raster_path = os.path.join(
+                                        os.path.split(inundation_raster)[0], 
+                                        os.path.split(inundation_raster)[1].replace('.tif', '_'+current_huc+'.tif')
+                                                )  
             try:
-                inundate_test = inundate(
-                         rem,catchments,catchment_poly,hydro_table,forecast,mask_type,hucs=hucs,hucs_layerName=hucs_layerName,
-                         subset_hucs=current_huc,num_workers=1,aggregate=False,inundation_raster=inundation_raster,inundation_polygon=None,
-                         depths=None,out_raster_profile=None,out_vector_profile=None,quiet=True
+                if model == 'GMS':
+                    
+                    map_file = Inundate_gms(
+                                                hydrofabric_dir=hydrofabric_dir, 
+                                                forecast=forecast, 
+                                                num_workers=gms_workers,
+                                                hucs=current_huc,
+                                                inundation_raster=inundation_raster,
+                                                inundation_polygon=None, depths_raster=None,
+                                                verbose=gms_verbose,
+                                                log_file=None,
+                                                output_fileNames=None
+                                            )
+                    
+                    mask_path_gms = os.path.join(fim_run_parent, 'wbd.gpkg')
+
+                    Mosaic_inundation(
+                                        map_file,mosaic_attribute='inundation_rasters',
+                                        mosaic_output=inundation_raster,
+                                        mask=mask_path_gms,unit_attribute_name='huc8',
+                                        nodata=elev_raster_ndv,workers=1,
+                                        remove_inputs=True,
+                                        subset=None,verbose=verbose
+                                        )
+                
+                else:
+                    inundate_exit_status = inundate(
+                                rem,catchments,catchment_poly,hydro_table,forecast,
+                                mask_type,hucs=hucs,hucs_layerName=hucs_layerName,
+                                subset_hucs=current_huc,num_workers=1,aggregate=False,
+                                inundation_raster=inundation_raster,inundation_polygon=None,
+                                depths=None,out_raster_profile=None,out_vector_profile=None,
+                                quiet=True
                         )
-                if inundate_test == 0:
-#                    print("-----> Inundation mapping complete.")
-                    predicted_raster_path = os.path.join(os.path.split(inundation_raster)[0], os.path.split(inundation_raster)[1].replace('.tif', '_' + current_huc + '.tif'))  # The inundate adds the huc to the name so I account for that here.
+                    if inundate_exit_status != 0:
+                        #os.rmdir(version_test_case_dir)
+                        continue
+
+                if model =='MS':
+                    
+                    # Mainstems inundation
+                    #fr_run_parent = os.path.join(os.environ['outputDataDir'], fr_run_dir,current_huc)
+                    #assert os.path.exists(fr_run_parent), "Cannot locate " + fr_run_parent
+                    
+                    inundation_raster_ms = os.path.join(
+                                        os.path.split(inundation_raster)[0], 
+                                        os.path.split(inundation_raster)[1].replace('.tif', f'_{current_huc}.tif'.format(current_huc))
+                                            )  
+                    inundation_raster_fr = os.path.join(
+                                        os.path.split(version_test_case_dir_parent)[0],
+                                        fr_run_dir,
+                                        magnitude,
+                                        os.path.split(inundation_raster)[1].replace('.tif', f'_{current_huc}.tif')
+                                            )
+                    if not os.path.isfile(inundation_raster_fr):
+                        inundation_raster_fr = inundation_raster_ms
+                    
+                    #os.rename(predicted_raster_path,inundation_raster_ms)
+
+                    ms_inundation_map_file = { 
+                                                'huc8' : [current_huc] * 2,
+                                                'branchID' : [None] * 2,
+                                                'inundation_rasters' : [inundation_raster_fr,inundation_raster_ms],
+                                                'depths_rasters' : [None] * 2,
+                                                'inundation_polygons' : [None] * 2
+                                                }
+                    ms_inundation_map_file = pd.DataFrame(ms_inundation_map_file)
+
+                    ## Composite inundation
+                    composite_test_case_dir = os.path.join(
+                                        os.path.dirname(version_test_case_dir_parent),
+                                        version.replace('_ms','_comp'),
+                                        magnitude
+                                        )
+                    composite_inundation_raster = os.path.join(
+                                        composite_test_case_dir,
+                                        os.path.split(inundation_raster)[1],#.replace('.tif', f'_{current_huc}.tif')
+                                            )
+                    os.makedirs(os.path.dirname(composite_inundation_raster), exist_ok=True)
+                    
+                    Mosaic_inundation(
+                                        ms_inundation_map_file,mosaic_attribute='inundation_rasters',
+                                        mosaic_output=composite_inundation_raster,
+                                        mask=catchment_poly,unit_attribute_name='huc8',
+                                        nodata=elev_raster_ndv,workers=1,
+                                        remove_inputs=False,
+                                        subset=None,verbose=verbose
+                                        )
 
                     # Define outputs for agreement_raster, stats_json, and stats_csv.
                     if benchmark_category in AHPS_BENCHMARK_CATEGORIES:
-                        agreement_raster, stats_json, stats_csv = os.path.join(version_test_case_dir, lid + 'total_area_agreement.tif'), os.path.join(version_test_case_dir, 'stats.json'), os.path.join(version_test_case_dir, 'stats.csv')
+                        agreement_raster, stats_json, stats_csv = os.path.join(composite_test_case_dir, lid + 'total_area_agreement.tif'), os.path.join(composite_test_case_dir, 'stats.json'), os.path.join(composite_test_case_dir, 'stats.csv')
                     else:
-                        agreement_raster, stats_json, stats_csv = os.path.join(version_test_case_dir, 'total_area_agreement.tif'), os.path.join(version_test_case_dir, 'stats.json'), os.path.join(version_test_case_dir, 'stats.csv')
+                        agreement_raster, stats_json, stats_csv = os.path.join(composite_test_case_dir, 'total_area_agreement.tif'), os.path.join(composite_test_case_dir, 'stats.json'), os.path.join(composite_test_case_dir, 'stats.csv')
+                    compute_contingency_stats_from_rasters(composite_inundation_raster.replace('.tif', f'_{current_huc}.tif'),
+                                                        benchmark_raster_path,
+                                                        agreement_raster,
+                                                        stats_csv=stats_csv,
+                                                        stats_json=stats_json,
+                                                        mask_values=[],
+                                                        stats_modes_list=stats_modes_list,
+                                                        test_id=test_id,
+                                                        mask_dict=mask_dict,
+                                                        )
+                __vprint("-----> Inundation mapping complete.",verbose)
 
-                    compute_contingency_stats_from_rasters(predicted_raster_path,
-                                                           benchmark_raster_path,
-                                                           agreement_raster,
-                                                           stats_csv=stats_csv,
-                                                           stats_json=stats_json,
-                                                           mask_values=[],
-                                                           stats_modes_list=stats_modes_list,
-                                                           test_id=test_id,
-                                                           mask_dict=mask_dict,
-                                                           )
+                # Define outputs for agreement_raster, stats_json, and stats_csv.
+                if benchmark_category in AHPS_BENCHMARK_CATEGORIES:
+                    agreement_raster, stats_json, stats_csv = os.path.join(version_test_case_dir, lid + 'total_area_agreement.tif'), os.path.join(version_test_case_dir, 'stats.json'), os.path.join(version_test_case_dir, 'stats.csv')
+                else:
+                    agreement_raster, stats_json, stats_csv = os.path.join(version_test_case_dir, 'total_area_agreement.tif'), os.path.join(version_test_case_dir, 'stats.json'), os.path.join(version_test_case_dir, 'stats.csv')
+                
+                compute_contingency_stats_from_rasters(predicted_raster_path,
+                                                        benchmark_raster_path,
+                                                        agreement_raster,
+                                                        stats_csv=stats_csv,
+                                                        stats_json=stats_json,
+                                                        mask_values=[],
+                                                        stats_modes_list=stats_modes_list,
+                                                        test_id=test_id,
+                                                        mask_dict=mask_dict,
+                                                        )
 
-                    if benchmark_category in AHPS_BENCHMARK_CATEGORIES:
-                        del mask_dict[ahps_lid]
+                if benchmark_category in AHPS_BENCHMARK_CATEGORIES:
+                    del mask_dict[ahps_lid]
 
-                    print(" ")
-                    print("Evaluation metrics for " + test_id + ", " + version + ", " + magnitude + " are available at " + CYAN_BOLD + version_test_case_dir + ENDC)
-                    print(" ")
-                elif inundate_test == 1:
-                    pass
-                    print (f"No matching feature IDs between forecast and hydrotable for magnitude: {magnitude}")
-                    #return
+                __vprint(" ",verbose)
+                # print("Evaluation complete. All metrics for " + test_id + ", " + version + ", " + magnitude + " are available at " + CYAN_BOLD + version_test_case_dir + ENDC) # GMS
+                __vprint("Evaluation metrics for " + test_id + ", " + version + ", " + magnitude + " are available at " + CYAN_BOLD + version_test_case_dir + ENDC,verbose) # cahaba/dev
+                __vprint(" ",verbose)
+
             except Exception as e:
-                print(e)
+                print(test_id, model)
+                print(traceback.print_exc())
+                #print(e)
 
         if benchmark_category in AHPS_BENCHMARK_CATEGORIES:
             # -- Delete temp files -- #
             # List all files in the output directory.
-            output_file_list = os.listdir(version_test_case_dir)
+            output_file_list = [os.path.join(version_test_case_dir, of) for of in os.listdir(version_test_case_dir)]
+            if model == 'MS' and fr_run_dir:
+                output_file_list += [os.path.join(composite_test_case_dir, of) for of in os.listdir(composite_test_case_dir)]
             for output_file in output_file_list:
                 if "total_area" in output_file:
-                    full_output_file_path = os.path.join(version_test_case_dir, output_file)
-                    os.remove(full_output_file_path)
+                    #full_output_file_path = os.path.join(version_test_case_dir, output_file)
+                    os.remove(output_file)
+
+    # write out evaluation meta-data
+    with open(os.path.join(version_test_case_dir_parent,'eval_metadata.json'),'w') as meta:
+        eval_meta = { 'calibrated' : calibrated , 'model' : model }
+        meta.write( 
+                    json.dumps(eval_meta,indent=2) 
+                   )
+    # write evaluation metadata for the composite directory too
+    if model == 'MS' and fr_run_dir:
+        if inundate_exit_status == 0:
+            with open(os.path.join(os.path.dirname(composite_test_case_dir),'eval_metadata.json'),'w') as meta:
+                eval_meta = { 'calibrated' : calibrated , 'model' : 'COMP' }
+                meta.write( 
+                            json.dumps(eval_meta,indent=2) 
+                        )
+        else: # Copy FR alpha to composite folder when the MS inundation fails
+            shutil.copytree(fr_run_dir.join(version_test_case_dir_parent.rsplit(version, 1)), '_comp'.join(version_test_case_dir_parent.rsplit('_ms', 1)))
+
+
+def __vprint(message,verbose):
+    if verbose:
+        print(message)
 
 
 if __name__ == '__main__':
@@ -192,7 +356,9 @@ if __name__ == '__main__':
     parser.add_argument('-r','--fim-run-dir',help='Name of directory containing outputs of fim_run.sh',required=True)
     parser.add_argument('-b', '--version',help='The name of the working version in which features are being tested',required=True,default="")
     parser.add_argument('-t', '--test-id',help='The test_id to use. Format as: HUC_BENCHMARKTYPE, e.g. 12345678_ble.',required=True,default="")
-    parser.add_argument('-m', '--mask-type', help='Specify \'huc\' (FIM < 3) or \'filter\' (FIM >= 3) masking method', required=False,default="huc")
+    parser.add_argument('-m', '--mask-type', help='Specify \'huc\' (FIM < 3) or \'filter\' (FIM >= 3) masking method. MS and GMS are currently on supporting huc', required=False,default="filter")
+    parser.add_argument('-n','--calibrated',help='Denotes use of calibrated n values',required=False, default=False,action='store_true')
+    parser.add_argument('-e','--model',help='Denotes model used. FR, MS, or GMS allowed',required=True)
     parser.add_argument('-y', '--magnitude',help='The magnitude to run.',required=False, default="")
     parser.add_argument('-c', '--compare-to-previous', help='Compare to previous versions of HAND.', required=False,action='store_true')
     parser.add_argument('-a', '--archive-results', help='Automatically copy results to the "previous_version" archive for test_id. For admin use only.', required=False,action='store_true')
@@ -200,6 +366,10 @@ if __name__ == '__main__':
     parser.add_argument('-ib','--inclusion-area-buffer', help='Buffer to use when masking contingency metrics with inclusion area.', required=False, default="0")
     parser.add_argument('-l', '--light-run', help='Using the light_run option will result in only stat files being written, and NOT grid files.', required=False, action='store_true')
     parser.add_argument('-o','--overwrite',help='Overwrite all metrics or only fill in missing metrics.',required=False, default=False, action='store_true')
+    parser.add_argument('-w','--gms-workers', help='Number of workers to use for GMS Branch Inundation', required=False, default=1)
+    parser.add_argument('-d','--fr-run-dir',help='Name of test case directory containing inundation for FR configuration',required=False,default=None)
+    parser.add_argument('-v', '--verbose', help='Verbose operation', required=False, action='store_true', default=False)
+    parser.add_argument('-vg', '--gms-verbose', help='Prints progress bar for GMS', required=False, action='store_true', default=False)
 
     # Extract to dictionary and assign to variables.
     args = vars(parser.parse_args())
@@ -207,7 +377,7 @@ if __name__ == '__main__':
     valid_test_id_list = os.listdir(TEST_CASES_DIR)
 
     exit_flag = False  # Default to False.
-    print()
+    __vprint("",args['verbose'])
 
     # Ensure test_id is valid.
 #    if args['test_id'] not in valid_test_id_list:
@@ -236,11 +406,15 @@ if __name__ == '__main__':
     except ValueError:
         print(TRED_BOLD + "Error: " + WHITE_BOLD + "The provided inclusion_area_buffer (-ib) " + CYAN_BOLD + args['inclusion_area_buffer'] + WHITE_BOLD + " is not a round number." + ENDC)
 
+    benchmark_category = args['test_id'].split('_')[1]
+
     if args['magnitude'] == '':
-        if 'ble' in args['test_id'].split('_'):
-            args['magnitude'] = ['100yr', '500yr']
-        elif 'nws' or 'usgs' in args['test_id'].split('_'):
+        if 'ble' == benchmark_category:
+            args['magnitude'] = BLE_MAGNITUDE_LIST
+        elif ('nws' == benchmark_category) | ('usgs' == benchmark_category):
             args['magnitude'] = ['action', 'minor', 'moderate', 'major']
+        elif 'ifc' == benchmark_category:
+            args['magnitude'] = IFC_MAGNITUDE_LIST
         else:
             print(TRED_BOLD + "Error: " + WHITE_BOLD + "The provided magnitude (-y) " + CYAN_BOLD + args['magnitude'] + WHITE_BOLD + " is invalid. ble options include: 100yr, 500yr. ahps options include action, minor, moderate, major." + ENDC)
             exit_flag = True

--- a/tools/synthesize_test_cases.py
+++ b/tools/synthesize_test_cases.py
@@ -3,10 +3,16 @@
 import os
 import argparse
 from multiprocessing import Pool
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed, wait
 import json
 import csv
+import ast
+from tqdm import tqdm
+from copy import deepcopy
+import re
 
 from run_test_case import run_alpha_test
+
 from tools_shared_variables import TEST_CASES_DIR, PREVIOUS_FIM_DIR, OUTPUTS_DIR, AHPS_BENCHMARK_CATEGORIES, MAGNITUDE_DICT
 
 
@@ -81,189 +87,175 @@ def create_master_metrics_csv(master_metrics_csv_output, dev_versions_to_include
 
     for benchmark_source in ['ble', 'nws', 'usgs', 'ifc', 'ras2fim']:
         benchmark_test_case_dir = os.path.join(TEST_CASES_DIR, benchmark_source + '_test_cases')
+        test_cases_list = [d for d in os.listdir(benchmark_test_case_dir) if re.match('\d{8}_\w{3,7}', d)]
+
         if benchmark_source in ['ble', 'ifc', 'ras2fim']:
             
             magnitude_list = MAGNITUDE_DICT[benchmark_source]
-            test_cases_list = os.listdir(benchmark_test_case_dir)
 
             for test_case in test_cases_list:
-                try:
-                    int(test_case.split('_')[0])
 
-                    huc = test_case.split('_')[0]
+                huc = test_case.split('_')[0]
 
-                    for iteration in iteration_list:
+                for iteration in iteration_list:
 
-                        if iteration == "official":
-                            versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'official_versions')
-                            versions_to_aggregate = os.listdir(PREVIOUS_FIM_DIR)
-                        if iteration == "comparison":
-                            versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'testing_versions')
-                            versions_to_aggregate = dev_versions_to_include_list
+                    if iteration == "official":
+                        versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'official_versions')
+                        versions_to_aggregate = os.listdir(PREVIOUS_FIM_DIR)
+                        # add in composite of versions
+                        composite_versions = [v.replace('_ms', '_comp') for v in versions_to_aggregate if '_ms' in v]
+                        versions_to_aggregate += composite_versions
+                    if iteration == "comparison":
+                        versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'testing_versions')
+                        versions_to_aggregate = dev_versions_to_include_list
 
-                        for magnitude in magnitude_list:
-                            for version in versions_to_aggregate:
-                                if '_fr' in version:
-                                    extent_config = 'FR'
-                                elif '_ms' in version:
-                                    extent_config = 'MS'
-                                else:
-                                    extent_config = 'FR'
-                                if "_c" in version and version.split('_c')[1] == "":
-                                    calibrated = "yes"
-                                else:
-                                    calibrated = "no"
-                                version_dir = os.path.join(versions_to_crawl, version)
-                                magnitude_dir = os.path.join(version_dir, magnitude)
+                    for magnitude in magnitude_list:
+                        for version in versions_to_aggregate:
+                            if '_ms' in version:
+                                extent_config = 'MS'
+                            elif ('_fr' in version) or (version == 'fim_2_3_3'):
+                                extent_config = 'FR'
+                            else:
+                                extent_config = 'COMP'
+                            if "_c" in version and version.split('_c')[1] == "":
+                                calibrated = "yes"
+                            else:
+                                calibrated = "no"
+                            version_dir = os.path.join(versions_to_crawl, version)
+                            magnitude_dir = os.path.join(version_dir, magnitude)
 
-                                if os.path.exists(magnitude_dir):
-                                    magnitude_dir_list = os.listdir(magnitude_dir)
-                                    for f in magnitude_dir_list:
-                                        if '.json' in f:
-                                            flow = 'NA'
-                                            nws_lid = "NA"
-                                            sub_list_to_append = [version, nws_lid, magnitude, huc]
-                                            full_json_path = os.path.join(magnitude_dir, f)
-                                            if os.path.exists(full_json_path):
-                                                stats_dict = json.load(open(full_json_path))
-                                                for metric in metrics_to_write:
-                                                    sub_list_to_append.append(stats_dict[metric])
-                                                sub_list_to_append.append(full_json_path)
-                                                sub_list_to_append.append(flow)
-                                                sub_list_to_append.append(benchmark_source)
-                                                sub_list_to_append.append(extent_config)
-                                                sub_list_to_append.append(calibrated)
+                            if os.path.exists(magnitude_dir):
+                                magnitude_dir_list = os.listdir(magnitude_dir)
+                                for f in magnitude_dir_list:
+                                    if '.json' in f:
+                                        flow = 'NA'
+                                        nws_lid = "NA"
+                                        sub_list_to_append = [version, nws_lid, magnitude, huc]
+                                        full_json_path = os.path.join(magnitude_dir, f)
+                                        if os.path.exists(full_json_path):
+                                            stats_dict = json.load(open(full_json_path))
+                                            for metric in metrics_to_write:
+                                                sub_list_to_append.append(stats_dict[metric])
+                                            sub_list_to_append.append(full_json_path)
+                                            sub_list_to_append.append(flow)
+                                            sub_list_to_append.append(benchmark_source)
+                                            sub_list_to_append.append(extent_config)
+                                            sub_list_to_append.append(calibrated)
 
-                                                list_to_write.append(sub_list_to_append)
-                except ValueError:
-                    pass
-
+                                            list_to_write.append(sub_list_to_append)
+        
         if benchmark_source in AHPS_BENCHMARK_CATEGORIES:
-            test_cases_list = os.listdir(benchmark_test_case_dir)
 
             for test_case in test_cases_list:
-                try:
-                    int(test_case.split('_')[0])
 
-                    huc = test_case.split('_')[0]
+                huc = test_case.split('_')[0]
 
-                    for iteration in iteration_list:
+                for iteration in iteration_list:
 
-                        if iteration == "official":
-                            versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'official_versions')
-                            versions_to_aggregate = os.listdir(PREVIOUS_FIM_DIR)
-                        if iteration == "comparison":
-                            versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'testing_versions')
-                            versions_to_aggregate = dev_versions_to_include_list
+                    if iteration == "official":
+                        versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'official_versions')
+                        versions_to_aggregate = os.listdir(PREVIOUS_FIM_DIR)
+                        # add in composite of versions
+                        composite_versions = [v.replace('_ms', '_comp') for v in versions_to_aggregate if '_ms' in v]
+                        versions_to_aggregate += composite_versions
+                    if iteration == "comparison":
+                        versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'testing_versions')
+                        versions_to_aggregate = dev_versions_to_include_list
 
-                        for magnitude in ['action', 'minor', 'moderate', 'major']:
-                            for version in versions_to_aggregate:
-                                if '_fr' in version:
-                                    extent_config = 'FR'
-                                elif '_ms' in version:
-                                    extent_config = 'MS'
-                                else:
-                                    extent_config = 'FR'
-                                if "_c" in version and version.split('_c')[1] == "":
-                                    calibrated = "yes"
-                                else:
-                                    calibrated = "no"
+                    for magnitude in ['action', 'minor', 'moderate', 'major']:
+                        for version in versions_to_aggregate:
+                            if '_ms' in version:
+                                extent_config = 'MS'
+                            elif ('_fr' in version) or (version == 'fim_2_3_3'):
+                                extent_config = 'FR'
+                            else:
+                                extent_config = 'COMP'
+                            if "_c" in version and version.split('_c')[1] == "":
+                                calibrated = "yes"
+                            else:
+                                calibrated = "no"
 
-                                version_dir = os.path.join(versions_to_crawl, version)
-                                magnitude_dir = os.path.join(version_dir, magnitude)
-                                if os.path.exists(magnitude_dir):
-                                    magnitude_dir_list = os.listdir(magnitude_dir)
-                                    for f in magnitude_dir_list:
-                                        if '.json' in f and 'total_area' not in f:
-                                            nws_lid = f[:5]
-                                            sub_list_to_append = [version, nws_lid, magnitude, huc]
-                                            full_json_path = os.path.join(magnitude_dir, f)
-                                            flow = ''
-                                            if os.path.exists(full_json_path):
+                            version_dir = os.path.join(versions_to_crawl, version)
+                            magnitude_dir = os.path.join(version_dir, magnitude)
+                            if os.path.exists(magnitude_dir):
+                                magnitude_dir_list = [f for f in os.listdir(magnitude_dir) if f.endswith('.json') and 'total_area' not in f]
+                                for f in magnitude_dir_list:
+                                    nws_lid = f[:5]
+                                    sub_list_to_append = [version, nws_lid, magnitude, huc]
+                                    full_json_path = os.path.join(magnitude_dir, f)
+                                    flow = ''
+                                    if os.path.exists(full_json_path):
 
-                                                # Get flow used to map.
-                                                flow_file = os.path.join(benchmark_test_case_dir, 'validation_data_' + benchmark_source, huc, nws_lid, magnitude, 'ahps_' + nws_lid + '_huc_' + huc + '_flows_' + magnitude + '.csv')
-                                                if os.path.exists(flow_file):
-                                                    with open(flow_file, newline='') as csv_file:
-                                                        reader = csv.reader(csv_file)
-                                                        next(reader)
-                                                        for row in reader:
-                                                            flow = row[1]
+                                        # Get flow used to map.
+                                        flow_file = os.path.join(benchmark_test_case_dir, 'validation_data_' + benchmark_source, huc, nws_lid, magnitude, 'ahps_' + nws_lid + '_huc_' + huc + '_flows_' + magnitude + '.csv')
+                                        if os.path.exists(flow_file):
+                                            with open(flow_file, newline='') as csv_file:
+                                                reader = csv.reader(csv_file)
+                                                next(reader)
+                                                for row in reader:
+                                                    flow = row[1]
 
-                                                stats_dict = json.load(open(full_json_path))
-                                                for metric in metrics_to_write:
-                                                    sub_list_to_append.append(stats_dict[metric])
-                                                sub_list_to_append.append(full_json_path)
-                                                sub_list_to_append.append(flow)
-                                                sub_list_to_append.append(benchmark_source)
-                                                sub_list_to_append.append(extent_config)
-                                                sub_list_to_append.append(calibrated)
+                                        stats_dict = json.load(open(full_json_path))
+                                        for metric in metrics_to_write:
+                                            sub_list_to_append.append(stats_dict[metric])
+                                        sub_list_to_append.append(full_json_path)
+                                        sub_list_to_append.append(flow)
+                                        sub_list_to_append.append(benchmark_source)
+                                        sub_list_to_append.append(extent_config)
+                                        sub_list_to_append.append(calibrated)
 
-                                                list_to_write.append(sub_list_to_append)
-                except ValueError:
-                    pass
-
+                                        list_to_write.append(sub_list_to_append)
+    
     with open(master_metrics_csv_output, 'w', newline='') as csvfile:
         csv_writer = csv.writer(csvfile)
         csv_writer.writerows(list_to_write)
-
-
-def process_alpha_test(args):
-    """
-    This function is designed to be used in multiprocessing. It handles the calling of the run_alpha_test function.
-    
-    Args:
-        args (list): Formatted [fim_run_dir (str), version (str), test_id (str), magnitude (str), archive_results (bool), overwrite (bool)]
-    
-    """
-    
-    fim_run_dir = args[0]
-    version = args[1]
-    test_id = args[2]
-    magnitude = args[3]
-    archive_results = args[4]
-    overwrite = args[5]
-
-    mask_type = 'huc'
-
-    if archive_results == False:
-        compare_to_previous = True
-    else:
-        compare_to_previous = False
-
-    try:
-        run_alpha_test(fim_run_dir, version, test_id, magnitude, compare_to_previous=compare_to_previous, archive_results=archive_results, mask_type=mask_type, overwrite=overwrite)
-    except Exception as e:
-        print(e)
 
 
 if __name__ == '__main__':
 
     # Parse arguments.
     parser = argparse.ArgumentParser(description='Caches metrics from previous versions of HAND.')
-    parser.add_argument('-c','--config',help='Save outputs to development_versions or previous_versions? Options: "DEV" or "PREV"',required=True)
+    parser.add_argument('-c','--config',help='Save outputs to development_versions or previous_versions? Options: "DEV" or "PREV"',required=False,default='DEV')
+    parser.add_argument('-l','--calibrated',help='Denotes use of calibrated n values. This should be taken from meta-data from hydrofabric dir',required=False, default=False,action='store_true')
+    parser.add_argument('-e','--model',help='Denotes model used. FR, MS, or GMS allowed. This should be taken from meta-data in hydrofabric dir.',required=True)
     parser.add_argument('-v','--fim-version',help='Name of fim version to cache.',required=False, default="all")
-    parser.add_argument('-j','--job-number',help='Number of processes to use. Default is 1.',required=False, default="1")
+    parser.add_argument('-jh','--job-number-huc',help='Number of processes to use for HUC scale operations. HUC and Batch job numbers should multiply to no more than one less than the CPU count of the machine.',required=False, default=1,type=int)
+    parser.add_argument('-jb','--job-number-branch',help='Number of processes to use for Branch scale operations. HUC and Batch job numbers should multiply to no more than one less than the CPU count of the machine.',required=False, default=1,type=int)
     parser.add_argument('-s','--special-string',help='Add a special name to the end of the branch.',required=False, default="")
     parser.add_argument('-b','--benchmark-category',help='A benchmark category to specify. Defaults to process all categories.',required=False, default="all")
     parser.add_argument('-o','--overwrite',help='Overwrite all metrics or only fill in missing metrics.',required=False, action="store_true")
     parser.add_argument('-dc', '--dev-version-to-compare', nargs='+', help='Specify the name(s) of a dev (testing) version to include in master metrics CSV. Pass a space-delimited list.',required=False)
-    parser.add_argument('-m','--master-metrics-csv',help='Define path for master metrics CSV file.',required=True)
+    parser.add_argument('-m','--master-metrics-csv',help='Define path for master metrics CSV file.',required=False,default=None)
+    parser.add_argument('-d','--fr-run-dir',help='Name of test case directory containing FIM for FR model',required=False,default=None)
+    parser.add_argument('-vr','--verbose',help='Verbose',required=False,default=None,action='store_true')
+    parser.add_argument('-vg','--gms-verbose',help='GMS Verbose Progress Bar',required=False,default=None,action='store_true')
 
     # Assign variables from arguments.
     args = vars(parser.parse_args())
     config = args['config']
     fim_version = args['fim_version']
-    job_number = int(args['job_number'])
+    job_number_huc = args['job_number_huc']
+    job_number_branch = args['job_number_branch']
     special_string = args['special_string']
     benchmark_category = args['benchmark_category']
     overwrite = args['overwrite']
     dev_versions_to_compare = args['dev_version_to_compare']
     master_metrics_csv = args['master_metrics_csv']
+    fr_run_dir = args['fr_run_dir']
+    calibrated = args['calibrated']
+    model = args['model']
+    verbose = args['verbose']
+    gms_verbose = args['gms_verbose']
 
-    if overwrite:
-        if input("Are you sure you want to overwrite metrics? y/n: ") == "n":
-            quit
+    # check job numbers
+    total_cpus_requested = job_number_huc * job_number_branch
+    total_cpus_available = os.cpu_count() - 1
+    if total_cpus_requested > total_cpus_available:
+        raise ValueError('The HUC job number, {}, multiplied by the branch job number, {}, '\
+                          'exceeds your machine\'s available CPU count minus one. '\
+                          'Please lower the job_number_huc or job_number_branch'\
+                          'values accordingly.'.format(job_number_huc,job_number_branch)
+                        )
 
     # Default to processing all possible versions in PREVIOUS_FIM_DIR. Otherwise, process only the user-supplied version.
     if fim_version != "all":
@@ -287,24 +279,31 @@ if __name__ == '__main__':
     benchmark_category_list = []
     if benchmark_category == "all":
         for d in test_cases_dir_list:
-            if 'test_cases' in d:
+            if ('test_cases') in d:
                 benchmark_category_list.append(d.replace('_test_cases', ''))
     else:
         benchmark_category_list = [benchmark_category]
 
     # Loop through benchmark categories.
-    procs_list = []
+    procs_list = [] ; procs_dict = {}
     for bench_cat in benchmark_category_list:
         
         # Map path to appropriate test_cases folder and list test_ids into bench_cat_id_list.
         bench_cat_test_case_dir = os.path.join(TEST_CASES_DIR, bench_cat + '_test_cases')
         bench_cat_id_list = os.listdir(bench_cat_test_case_dir)
+        
+        # temp
+        #bench_cat_id_list = ['07060003_ifc']
 
+        #if job_number_huc == 1:
+            # something wrong about this lengtu
+            #pb = tqdm(total=len(bench_cat_id_list))
         # Loop through test_ids in bench_cat_id_list.
         for test_id in bench_cat_id_list:
             if 'validation' and 'other' not in test_id:
                 current_huc = test_id.split('_')[0]
-                if test_id.split('_')[1] in bench_cat:
+                current_benchmark_category = test_id.split('_')[1]
+                if current_benchmark_category in bench_cat:
                     # Loop through versions.
                     for version in previous_fim_list:
                         if config == 'DEV':
@@ -318,35 +317,135 @@ if __name__ == '__main__':
                                 fim_run_dir = os.path.join(OUTPUTS_DIR, version, current_huc[:6])
                             elif config == 'PREV':
                                 fim_run_dir = os.path.join(PREVIOUS_FIM_DIR, version, current_huc[:6])
-                                    
+                        
                         if os.path.exists(fim_run_dir):
+
                             # If a user supplies a special_string (-s), then add it to the end of the created dirs.
                             if special_string != "":
                                 version = version + '_' + special_string
-                                
+
+            
                             # Define the magnitude lists to use, depending on test_id.
-                            benchmark_type = test_id.split('_')[1]
-                            magnitude = MAGNITUDE_DICT[benchmark_type]
-                            
-                            # Either add to list to multiprocess or process serially, depending on user specification.
-                            if job_number > 1:
-                                procs_list.append([fim_run_dir, version, test_id, magnitude, archive_results, overwrite])
+                            if 'ble' == current_benchmark_category:
+                                magnitude = MAGNITUDE_DICT['ble']
+                            elif ('usgs' == current_benchmark_category) | ('nws' == current_benchmark_category):
+                                magnitude = ['action', 'minor', 'moderate', 'major']
+                            elif 'ifc' == current_benchmark_category:
+                                magnitude = MAGNITUDE_DICT['ifc']
+                            elif 'ras2fim' == current_benchmark_category:
+                                magnitude = MAGNITUDE_DICT['ras2fim']
                             else:
-                                process_alpha_test([fim_run_dir, version, test_id, magnitude, archive_results, overwrite])
+                                continue
+
+                            alpha_test_args = { 
+                                                'fim_run_dir': fim_run_dir, 
+                                                'version': version, 
+                                                'test_id': test_id, 
+                                                'magnitude': magnitude, 
+                                                'calibrated': calibrated,
+                                                'model': model,
+                                                'compare_to_previous': not archive_results, 
+                                                'archive_results': archive_results, 
+                                                'mask_type': 'huc',
+                                                'overwrite': overwrite, 
+                                                'fr_run_dir': fr_run_dir, 
+                                                'gms_workers': job_number_branch,
+                                                'verbose': False,
+                                                'gms_verbose': False
+                                              }
+                            procs_dict[test_id] = alpha_test_args
+
+    if job_number_huc == 1:
+        
+        number_of_hucs = len(procs_dict)
+        verbose_by_huc = not number_of_hucs == 1
+
+        for current_huc, alpha_test_args in tqdm(procs_dict.items(),total=number_of_hucs,disable=(not verbose_by_huc)):
+            alpha_test_args.update({'gms_verbose': not verbose_by_huc})
+
+            try:
+                ## FR MUST be run before MS / composite runs
+                if fr_run_dir:
+                    fr_alpha_test_args = deepcopy(alpha_test_args)
+                    fr_alpha_test_args['fim_run_dir'] = fr_alpha_test_args['fim_run_dir'].replace(fr_alpha_test_args['version'],fr_alpha_test_args['fr_run_dir'])
+                    fr_alpha_test_args['version'] = fr_alpha_test_args['fr_run_dir']
+                    fr_alpha_test_args['fr_run_dir'] = None
+                    fr_alpha_test_args['compare_to_previous'] = False
+                    fr_alpha_test_args['model'] = 'FR'
+                    run_alpha_test(**fr_alpha_test_args)
+
+                run_alpha_test(**alpha_test_args)
+            except Exception as exc:
+                print('{}, {}, {}'.format(test_id,exc.__class__.__name__,exc))
 
     # Multiprocess alpha test runs.
-    if job_number > 1:
-        with Pool(processes=job_number) as pool:
-            pool.map(process_alpha_test, procs_list)
+    if job_number_huc > 1:
+        
+        #executor = ProcessPoolExecutor(max_workers=job_number_huc)
+        with ProcessPoolExecutor(max_workers=job_number_huc) as executor:
+            ## FR MUST be run before MS / composite runs
+            if model == 'MS' and fr_run_dir:
+                fr_proc_dict = deepcopy(procs_dict)
+                for proc in fr_proc_dict:
+                    fr_proc_dict[proc]['fim_run_dir'] = fr_proc_dict[proc]['fim_run_dir'].replace(fr_proc_dict[proc]['version'],fr_proc_dict[proc]['fr_run_dir'])
+                    fr_proc_dict[proc]['version'] = fr_proc_dict[proc]['fr_run_dir']
+                    fr_proc_dict[proc]['fr_run_dir'] = None
+                    fr_proc_dict[proc]['compare_to_previous'] = False
+                    fr_proc_dict[proc]['model'] = 'FR'
             
+                #fr_proc_dict = {key+'_fr' : value for key, value in fr_proc_dict.items() }
+                fr_executor_generator = { 
+                                    executor.submit(run_alpha_test,**inp) : ids for ids,inp in fr_proc_dict.items()
+                                    }
+                ms_executor_generator = {}
+                for future in tqdm(as_completed(fr_executor_generator),
+                            total=len(fr_executor_generator),
+                            disable=(not verbose),
+                            desc="Running FR test cases with {} workers".format(job_number_huc)):
+                    test_id = fr_executor_generator[future]
+                    try:
+                        future.result()
+                    except Exception as exc:
+                        print('{}, {}, {}'.format(test_id,exc.__class__.__name__,exc))
+                wait(fr_executor_generator.keys())
+
+            ## Submit MS alpha tests to the pool
+            executor_generator = { 
+                                executor.submit(run_alpha_test,**inp) : ids for ids,inp in procs_dict.items()
+                                }
+
+            if model == 'GMS':
+                desc = f"Running test cases with {job_number_huc} HUC workers and {job_number_branch} Branch workers"
+            else:
+                desc = f"Running MS test cases with {job_number_huc} workers".format(job_number_huc)
+
+            for future in tqdm(as_completed(executor_generator),
+                            total=len(executor_generator),
+                            disable=(not verbose),
+                            desc=desc,
+                            ):
+            
+                hucCode = executor_generator[future]
+
+                try:
+                    future.result()
+                except Exception as exc:
+                    print('{}, {}, {}'.format(hucCode,exc.__class__.__name__,exc))
+    
     if config == 'DEV':
         if dev_versions_to_compare != None:
-            dev_versions_to_include_list = dev_versions_to_compare + [version]
+            dev_versions_to_include_list = dev_versions_to_compare + previous_fim_list
         else:
-            dev_versions_to_include_list = [version]
+            dev_versions_to_include_list = previous_fim_list
+        # Include FR and Composite metrics if running composite alpha
+        if model == 'MS' and fr_run_dir:
+            dev_versions_to_include_list += [fr_run_dir, fr_run_dir.replace('_fr', '_comp')]
     if config == 'PREV':
         dev_versions_to_include_list = []
 
-    # Do aggregate_metrics.
-    print("Creating master metrics CSV...")
-    create_master_metrics_csv(master_metrics_csv_output=master_metrics_csv, dev_versions_to_include_list=dev_versions_to_include_list)
+    if master_metrics_csv is not None:
+        # Do aggregate_metrics.
+        print("Creating master metrics CSV...")
+
+        # this function is not compatible with GMS
+        create_master_metrics_csv(master_metrics_csv_output=master_metrics_csv, dev_versions_to_include_list=dev_versions_to_include_list)

--- a/tools/synthesize_test_cases.py
+++ b/tools/synthesize_test_cases.py
@@ -215,8 +215,7 @@ if __name__ == '__main__':
     parser.add_argument('-l','--calibrated',help='Denotes use of calibrated n values. This should be taken from meta-data from hydrofabric dir',required=False, default=False,action='store_true')
     parser.add_argument('-e','--model',help='Denotes model used. FR, MS, or GMS allowed. This should be taken from meta-data in hydrofabric dir.',required=True)
     parser.add_argument('-v','--fim-version',help='Name of fim version to cache.',required=False, default="all")
-    parser.add_argument('-jh','--job-number-huc',help='Number of processes to use for HUC scale operations. HUC and Batch job numbers should multiply to no more than one less than the CPU count of the machine.',required=False, default=1,type=int)
-    parser.add_argument('-jb','--job-number-branch',help='Number of processes to use for Branch scale operations. HUC and Batch job numbers should multiply to no more than one less than the CPU count of the machine.',required=False, default=1,type=int)
+    parser.add_argument('-j','--job-number-huc',help='Number of processes to use for HUC scale operations. HUC and Batch job numbers should multiply to no more than one less than the CPU count of the machine.',required=False, default=1,type=int)
     parser.add_argument('-s','--special-string',help='Add a special name to the end of the branch.',required=False, default="")
     parser.add_argument('-b','--benchmark-category',help='A benchmark category to specify. Defaults to process all categories.',required=False, default="all")
     parser.add_argument('-o','--overwrite',help='Overwrite all metrics or only fill in missing metrics.',required=False, action="store_true")
@@ -224,7 +223,6 @@ if __name__ == '__main__':
     parser.add_argument('-m','--master-metrics-csv',help='Define path for master metrics CSV file.',required=False,default=None)
     parser.add_argument('-d','--fr-run-dir',help='Name of test case directory containing FIM for FR model',required=False,default=None)
     parser.add_argument('-vr','--verbose',help='Verbose',required=False,default=None,action='store_true')
-    parser.add_argument('-vg','--gms-verbose',help='GMS Verbose Progress Bar',required=False,default=None,action='store_true')
 
     # Assign variables from arguments.
     args = vars(parser.parse_args())
@@ -241,7 +239,6 @@ if __name__ == '__main__':
     calibrated = args['calibrated']
     model = args['model']
     verbose = args['verbose']
-    gms_verbose = args['gms_verbose']
 
     # check job numbers
     total_cpus_requested = job_number_huc * job_number_branch
@@ -292,7 +289,7 @@ if __name__ == '__main__':
         
         # Loop through test_ids in bench_cat_id_list.
         for test_id in bench_cat_id_list:
-                       
+            
             current_huc, current_benchmark_category = test_id.split('_')
             if current_benchmark_category in bench_cat:
                 # Loop through versions.


### PR DESCRIPTION
This PR updates `synthesize_test_cases.py` with the ability to create MS, FR, and composite inundation agreement rasters and statistics all in one run. The new composited statistics are output in the same location within each test ID with the `_comp` suffix  replacing `_ms` for each dev or previous_fim run. Addresses #555.
`run_test_case.py` has also been refactored to use a `test_case` python class. This workflow has shown decreased memory usage as compared to the previous version of `run_test_case.py`.

## Changes

- `tools/`
    - `synthesize_test_cases.py`: Merged in `dev` branch (FIM 4) changes and re-factored to run FR, MS, and COMP `run_alpha_test` in that order (with multiprocessing).
    - `run_test_case.py`: Merged in `dev` branch (FIM 4) changes and re-factored to run COMP tests after both FR and MS inundations/test cases are performed.
    - `eval_plots.py`: Ensure that the new `_comp` folder produced in `synthesize_test_cases.py` is included in the plots.
 - `src/`
    - `inundation.py`: Included new data types to prevent memory usage warnings.


## Testing

1. Ran the full set of alpha test HUCs using the command ` python /foss_fim/tools/synthesize_test_cases.py -c PREV -e MS -v fim_3_0_28_1_ms -d fim_3_0_28_1_fr -v -j 8 -m /data/temp/carson/alpha_class_test.csv -o`
2. `python /foss_fim/tools/eval_plots.py -m /data/temp/ryan/alpha_test/fim3_alpha_composite/fim3_alpha_composite.csv -w /data/temp/carson/fim3_alpha_sp -v fim_3_0_28_1_comp -sp`


## Screenshots

New output of `synthesize_test_cases.py` in `/data/test_cases/nws_test_cases/official_versions/02040104_nws/` includes the new `_comp` folder.
![image](https://user-images.githubusercontent.com/90792257/164754064-ed9fbf5b-d239-49b4-851f-819f1c83753a.png)

New output of `eval_plots.py` includes a `comp` folder that contains the plots for composite alpha tests. See next screen for example plot.
![image](https://user-images.githubusercontent.com/90792257/164754433-ef1c5b4e-d18d-4c3a-8281-6fc7de7bcd1a.png)

Alpha test plot showing composite metrics summary (output of `eval_plots.py`).
![image](https://user-images.githubusercontent.com/90792257/164754595-003e11ce-3261-4b44-ba86-70c87d898730.png)


## Notes

-

## Todos

- Update CHANGELOG.md
- Run this branch of the alpha test on the newest release version of FIM that's currently being generated.
- Merge changes to `dev-fim3` into this branch before it gets merged.


