### PR TITLE
[1pt] PR: Hotfixes and updates to FIM4 alpha eval and eval plots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,19 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## v4.0.4.2 - 2022-05-03 - [PR #594](https://github.com/NOAA-OWP/inundation-mapping/pull/594)
+
+This hotfix includes several revisions needed to fix/update the FIM4 area inundation evaluation scripts. These changes largely migrate revisions from the FIM3 evaluation code to the FIM4 evaluation code.
+
+## Changes
+
+- `tools/eval_plots.py`: Copied FIM3 code revisions to enable RAS2FIM evals and PND plots. Replaced deprecated parameter name for matplotlib grid()
+- `tools/synthesize_test_cases.py`: Copied FIM3 code revisions to assign FR, MS, COMP resolution variable and addressed magnitude list variable for IFC eval
+- `tools/tools_shared_functions.py`: Copied FIM3 code revisions to enable probability not detected (PND) metric calculation
+- `tools/tools_shared_variables.py`: Updated magnitude dictionary variables for RAS2FIM evals and PND plots
+
+<br/><br/>
+
 ## v4.0.4.1 - 2022-05-02 - [PR #587](https://github.com/NOAA-OWP/inundation-mapping/pull/587)
 
 While testing GMS against evaluation and inundation data, we discovered some challenges for running alpha testing at full scale. Part of it was related to the very large output volume for GMS which resulted in outputs being created on multiple servers and folders. Considering the GMS volume and processing, a tool was required to extract out the ~215 HUC's that we have evaluation data for. Next, we needed isolate valid HUC output folders from original 2,188 HUC's and its 100's of thousands of branches. The first new tool allows us to point to the `test_case` data folder and create a list of all HUC's that we have validation for.

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -94,7 +94,7 @@ def boxplot(dataframe, x_field, x_order, y_field, hue_field, ordered_hue, title_
         #Define simplified labels as a list.
         new_labels = [label_dict[label] for label in org_labels]
         #Define legend location. FAR needs to be in different location than CSI/POD.
-        if y_field == 'FAR':
+        if y_field in ['FAR', 'PND']:
             legend_location = 'upper right'
         else:
             legend_location = 'lower left'
@@ -339,7 +339,7 @@ def filter_dataframe(dataframe, unique_field):
 ##############################################################################
 #Main function to analyze metric csv.
 ##############################################################################
-def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'] , spatial = False, fim_1_ms = False, site_barplots = False):
+def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR','PND'] , spatial = False, fim_1_ms = False, site_barplots = False):
 
     '''
     Creates plots and summary statistics using metrics compiled from
@@ -612,7 +612,7 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
                 nws_dataset, sites = all_datasets.get(('nws','COMP'))
             #Append usgs/nws dataframes and filter unnecessary columns and rename remaining.
             all_ahps_datasets = pd.concat([usgs_dataset, nws_dataset])
-            all_ahps_datasets = all_ahps_datasets.filter(['huc','nws_lid','version','magnitude','TP_area_km2','FP_area_km2','TN_area_km2','FN_area_km2','CSI','FAR','TPR','benchmark_source'])
+            all_ahps_datasets = all_ahps_datasets.filter(['huc','nws_lid','version','magnitude','TP_area_km2','FP_area_km2','TN_area_km2','FN_area_km2','CSI','FAR','TPR','PND','benchmark_source'])
             all_ahps_datasets.rename(columns = {'benchmark_source':'source'}, inplace = True)
 
             #Get spatial data from WRDS
@@ -657,7 +657,7 @@ def eval_plots(metrics_csv, workspace, versions = [], stats = ['CSI','FAR','TPR'
             #Join metrics to HUC spatial layer
             wbd_with_metrics = wbd_gdf.merge(huc_datasets, how = 'inner', left_on = 'HUC8', right_on = 'huc')
             #Filter out unnecessary columns
-            wbd_with_metrics = wbd_with_metrics.filter(['version','magnitude','huc','TP_area_km2','FP_area_km2','TN_area_km2','FN_area_km2','CSI','FAR','TPR','benchmark_source','geometry'])
+            wbd_with_metrics = wbd_with_metrics.filter(['version','magnitude','huc','TP_area_km2','FP_area_km2','TN_area_km2','FN_area_km2','CSI','FAR','TPR','PND','benchmark_source','geometry'])
             wbd_with_metrics.rename(columns = {'benchmark_source':'source'}, inplace = True )
             #Project to VIZ projection
             wbd_with_metrics = wbd_with_metrics.to_crs(VIZ_PROJECTION)
@@ -672,7 +672,7 @@ if __name__ == '__main__':
     parser.add_argument('-m','--metrics_csv', help = 'Metrics csv created from synthesize test cases.', required = True)
     parser.add_argument('-w', '--workspace', help = 'Output workspace', required = True)
     parser.add_argument('-v', '--versions', help = 'List of versions to be plotted/aggregated. Versions are filtered using the "startswith" approach. For example, ["fim_","fb1"] would retain all versions that began with "fim_" (e.g. fim_1..., fim_2..., fim_3...) as well as any feature branch that began with "fb". An other example ["fim_3","fb"] would result in all fim_3 versions being plotted along with the fb.', nargs = '+', default = [])
-    parser.add_argument('-s', '--stats', help = 'List of statistics (abbrev to 3 letters) to be plotted/aggregated', nargs = '+', default = ['CSI','TPR','FAR'], required = False)
+    parser.add_argument('-s', '--stats', help = 'List of statistics (abbrev to 3 letters) to be plotted/aggregated', nargs = '+', default = ['CSI','TPR','FAR','PND'], required = False)
     parser.add_argument('-sp', '--spatial', help = 'If enabled, creates spatial layers with metrics populated in attribute table.', action = 'store_true', required = False)
     parser.add_argument('-f', '--fim_1_ms', help = 'If enabled fim_1 rows will be duplicated and extent config assigned "ms" so that fim_1 can be shown on mainstems plots/stats', action = 'store_true', required = False)
     parser.add_argument('-i', '--site_plots', help = 'If enabled individual barplots for each site are created.', action = 'store_true', required = False)

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -86,7 +86,7 @@ def boxplot(dataframe, x_field, x_order, y_field, hue_field, ordered_hue, title_
             elif 'fim_2' in label:
                 label_dict[label] = 'FIM 2' + ' ' + fim_configuration.lower()
             elif 'fim_3' in label and len(label) < 20:
-                label_dict[label] = re.split('_fr|_ms', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
+                label_dict[label] = re.split('_fr|_ms|_comp', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
                 if label.endswith('_c'):
                     label_dict[label] = label_dict[label] + ' c'
             else:
@@ -253,7 +253,7 @@ def barplot(dataframe, x_field, x_order, y_field, hue_field, ordered_hue, title_
             elif 'fim_2' in label:
                 label_dict[label] = 'FIM 2' + ' ' + fim_configuration.lower()
             elif 'fim_3' in label and len(label) < 20:
-                label_dict[label] = re.split('_fr|_ms', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
+                label_dict[label] = re.split('_fr|_ms|_comp', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
                 if label.endswith('_c'):
                     label_dict[label] = label_dict[label] + ' c'
             else:

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -151,7 +151,7 @@ def scatterplot(dataframe, x_field, y_field, title_text, stats_text=False, annot
     #Set xticks and yticks and background horizontal line.
     axes.set(ylim=(0.0,1.0),yticks = np.arange(0,1.1,0.1))
     axes.set(xlim=(0.0,1.0),xticks = np.arange(0,1.1,0.1))
-    axes.grid(b=True, which='major', axis='both')
+    axes.grid(visible=True, which='major', axis='both')
 
     #Set sizes of ticks and legend.
     axes.tick_params(labelsize = 'xx-large')

--- a/tools/synthesize_test_cases.py
+++ b/tools/synthesize_test_cases.py
@@ -327,16 +327,7 @@ if __name__ == '__main__':
 
             
                             # Define the magnitude lists to use, depending on test_id.
-                            if 'ble' == current_benchmark_category:
-                                magnitude = MAGNITUDE_DICT['ble']
-                            elif ('usgs' == current_benchmark_category) | ('nws' == current_benchmark_category):
-                                magnitude = ['action', 'minor', 'moderate', 'major']
-                            elif 'ifc' == current_benchmark_category:
-                                magnitude = MAGNITUDE_DICT['ifc']
-                            elif 'ras2fim' == current_benchmark_category:
-                                magnitude = MAGNITUDE_DICT['ras2fim']
-                            else:
-                                continue
+                            magnitude = MAGNITUDE_DICT[current_benchmark_category]
 
                             alpha_test_args = { 
                                                 'fim_run_dir': fim_run_dir, 

--- a/tools/synthesize_test_cases.py
+++ b/tools/synthesize_test_cases.py
@@ -49,6 +49,7 @@ def create_master_metrics_csv(master_metrics_csv_output, dev_versions_to_include
                         'FAR',
                         'TPR',
                         'TNR',
+                        'PND',
                         'PPV',
                         'NPV',
                         'ACC',
@@ -82,18 +83,12 @@ def create_master_metrics_csv(master_metrics_csv_output, dev_versions_to_include
     else:
         iteration_list = ['official']
 
-    for benchmark_source in ['ble', 'nws', 'usgs', 'ifc']:
+    for benchmark_source in ['ble', 'nws', 'usgs', 'ifc','ras2fim']:
         benchmark_test_case_dir = os.path.join(TEST_CASES_DIR, benchmark_source + '_test_cases')
-        if benchmark_source in ['ble', 'ifc']:
+        test_cases_list = [d for d in os.listdir(benchmark_test_case_dir) if re.match('\d{8}_\w{3,7}', d)]
+        if benchmark_source in ['ble', 'ifc','ras2fim']:
             
-            if benchmark_source == 'ble':
-                magnitude_list = MAGNITUDE_DICT['ble']
-            if benchmark_source == 'ifc':
-                magnitude_list = MAGNITUDE_DICT['ifc']
-            try:
-                test_cases_list = os.listdir(benchmark_test_case_dir)
-            except FileNotFoundError:
-                continue
+            magnitude_list = MAGNITUDE_DICT[benchmark_source]
             
             for test_case in test_cases_list:
                 try:
@@ -112,12 +107,12 @@ def create_master_metrics_csv(master_metrics_csv_output, dev_versions_to_include
 
                         for magnitude in magnitude_list:
                             for version in versions_to_aggregate:
-                                if '_fr' in version:
-                                    extent_config = 'FR'
-                                elif '_ms' in version:
+                                if '_ms' in version:
                                     extent_config = 'MS'
-                                else:
+                                elif ('_fr' in version) or (version == 'fim_2_3_3'):
                                     extent_config = 'FR'
+                                else:
+                                    extent_config = 'COMP'
                                 if "_c" in version and version.split('_c')[1] == "":
                                     calibrated = "yes"
                                 else:
@@ -167,12 +162,12 @@ def create_master_metrics_csv(master_metrics_csv_output, dev_versions_to_include
 
                         for magnitude in ['action', 'minor', 'moderate', 'major']:
                             for version in versions_to_aggregate:
-                                if '_fr' in version:
-                                    extent_config = 'FR'
-                                elif '_ms' in version:
+                                if '_ms' in version:
                                     extent_config = 'MS'
-                                else:
+                                elif ('_fr' in version) or (version == 'fim_2_3_3'):
                                     extent_config = 'FR'
+                                else:
+                                    extent_config = 'COMP'
                                 if "_c" in version and version.split('_c')[1] == "":
                                     calibrated = "yes"
                                 else:
@@ -337,7 +332,9 @@ if __name__ == '__main__':
                             elif ('usgs' == current_benchmark_category) | ('nws' == current_benchmark_category):
                                 magnitude = ['action', 'minor', 'moderate', 'major']
                             elif 'ifc' == current_benchmark_category:
-                                magnitude_list = MAGNITUDE_DICT['ifc']
+                                magnitude = MAGNITUDE_DICT['ifc']
+                            elif 'ras2fim' == current_benchmark_category:
+                                magnitude = MAGNITUDE_DICT['ras2fim']
                             else:
                                 continue
 

--- a/tools/synthesize_test_cases.py
+++ b/tools/synthesize_test_cases.py
@@ -9,6 +9,7 @@ import json
 import csv
 import ast
 from tqdm import tqdm
+import re
 
 from run_test_case import run_alpha_test
 

--- a/tools/tools_shared_functions.py
+++ b/tools/tools_shared_functions.py
@@ -291,6 +291,11 @@ def compute_stats_from_contingency_table(true_negatives, false_negatives, false_
     except ZeroDivisionError:
         F1_score = "NA"
 
+    if TPR == 'NA':
+        PND = 'NA'
+    else:
+        PND = 1.0 - TPR  # Probability Not Detected (PND)
+
     stats_dictionary = {'true_negatives_count': int(true_negatives),
                         'false_negatives_count': int(false_negatives),
                         'true_positives_count': int(true_positives),
@@ -314,6 +319,7 @@ def compute_stats_from_contingency_table(true_negatives, false_negatives, false_
                         'FAR': FAR,
                         'TPR': TPR,
                         'TNR': TNR,
+                        'PND': PND,
 
                         'PPV': PPV,
                         'NPV': NPV,

--- a/tools/tools_shared_variables.py
+++ b/tools/tools_shared_variables.py
@@ -10,8 +10,9 @@ FR_BENCHMARK_CATEGORIES = ['ble', 'ifc']
 BLE_MAGNITUDE_LIST = ['100yr', '500yr']
 IFC_MAGNITUDE_LIST = ['2yr', '5yr', '10yr', '25yr', '50yr', '100yr', '200yr', '500yr']
 AHPS_MAGNITUDE_LIST = ['action', 'minor', 'moderate', 'major']
+RAS2FIM_MAGNITUDE_LIST = ['2yr', '5yr', '10yr', '25yr', '50yr', '100yr']
 
-MAGNITUDE_DICT = {'ble': BLE_MAGNITUDE_LIST, 'ifc': IFC_MAGNITUDE_LIST, 'usgs': AHPS_MAGNITUDE_LIST, 'nws': AHPS_MAGNITUDE_LIST}
+MAGNITUDE_DICT = {'ble': BLE_MAGNITUDE_LIST, 'ifc': IFC_MAGNITUDE_LIST, 'usgs': AHPS_MAGNITUDE_LIST, 'nws': AHPS_MAGNITUDE_LIST, 'ras2fim': RAS2FIM_MAGNITUDE_LIST}
 PRINTWORTHY_STATS = ['CSI', 'TPR', 'TNR', 'FAR', 'MCC', 'TP_area_km2', 'FP_area_km2', 'TN_area_km2', 'FN_area_km2', 'contingency_tot_area_km2', 'TP_perc', 'FP_perc', 'TN_perc', 'FN_perc']
 GO_UP_STATS = ['CSI', 'TPR', 'MCC', 'TN_area_km2', 'TP_area_km2', 'TN_perc', 'TP_perc', 'TNR']
 GO_DOWN_STATS = ['FAR', 'FN_area_km2', 'FP_area_km2', 'FP_perc', 'FN_perc', 'PND']

--- a/tools/tools_shared_variables.py
+++ b/tools/tools_shared_variables.py
@@ -14,7 +14,7 @@ AHPS_MAGNITUDE_LIST = ['action', 'minor', 'moderate', 'major']
 MAGNITUDE_DICT = {'ble': BLE_MAGNITUDE_LIST, 'ifc': IFC_MAGNITUDE_LIST, 'usgs': AHPS_MAGNITUDE_LIST, 'nws': AHPS_MAGNITUDE_LIST}
 PRINTWORTHY_STATS = ['CSI', 'TPR', 'TNR', 'FAR', 'MCC', 'TP_area_km2', 'FP_area_km2', 'TN_area_km2', 'FN_area_km2', 'contingency_tot_area_km2', 'TP_perc', 'FP_perc', 'TN_perc', 'FN_perc']
 GO_UP_STATS = ['CSI', 'TPR', 'MCC', 'TN_area_km2', 'TP_area_km2', 'TN_perc', 'TP_perc', 'TNR']
-GO_DOWN_STATS = ['FAR', 'FN_area_km2', 'FP_area_km2', 'FP_perc', 'FN_perc']
+GO_DOWN_STATS = ['FAR', 'FN_area_km2', 'FP_area_km2', 'FP_perc', 'FN_perc', 'PND']
 
 # Variables for eval_plots.py
 BAD_SITES = [


### PR DESCRIPTION
This hotfix includes several updates and revisions needed to fix/update the FIM4 evaluation scripts. These changes largely migrate revisions from the FIM3 evaluation code to the FIM4 evaluation code. Address #591 

## Changes

- `tools/eval_plots.py`: Copied FIM3 code revisions to enable RAS2FIM evals and PND plots. Replaced deprecated parameter name for matplotlib grid()
- `tools/synthesize_test_cases.py`: Copied FIM3 code revisions to assign FR, MS, COMP resolution variable and addressed magnitude list variable for IFC eval
- `tools/tools_shared_functions.py`: Copied FIM3 code revisions to enable probability not detected (PND) metric calculation
- `tools/tools_shared_variables.py`: Updated magnitude dictionary variables for RAS2FIM evals and PND plots

## Testing

1. Successfully completed a FIM4 `synthesize_test_cases.py` run on remote machines.
2. Metric csv files and evaluation plots available: /temp/ryan/alpha_test/fim4_0_0_0_compare_20220503/

## Screenshots
![image](https://user-images.githubusercontent.com/69868854/166573712-cf6cd82b-0999-4264-8b3d-725bc0a9dd98.png)

