### PR TITLE
[1pt] PR: Apply BARC for select FR streams

### DIFF
--- a/config/params_template.env
+++ b/config/params_template.env
@@ -32,7 +32,7 @@ export thalweg_stg_search_max_limit=3 # Threshold: Stage value limit below which
 export bathy_xs_area_chg_flag=1 # Flag: Cross section area limit to cap the amount of bathy XS area added to the SRC. Limits the bathy_calc_xs_area/ BANKFULL_XSEC_AREA to the specified threshold
 export bankful_xs_area_ratio_flag=10 # Flag: Identify bogus BARC adjusted values where the regression bankfull XS Area/SRC bankfull area is > threshold (topwidth crosswalk issues or bad bankfull regression data points??)
 export thalweg_hyd_radius_flag=10 # Flag: Idenitify possible erroneous BARC-adjusted hydraulic radius values. BARC discharge values greater than the specified threshold and within the thal_stg_limit are set to 0
-export ignore_streamorders=10 # Ignore BARC calculations for streamorders >= this value (10 is Mississippi R)
+export ignore_streamorders=[1,2,10] # Ignore BARC calculations for streamorders >= this value (10 is Mississippi R)
 
 #### estimating bankfull stage in SRCs ####
 export src_bankfull_toggle="True" # Toggle to run identify_bankfull routine (True=on; False=off)

--- a/config/params_template.env
+++ b/config/params_template.env
@@ -32,7 +32,7 @@ export thalweg_stg_search_max_limit=3 # Threshold: Stage value limit below which
 export bathy_xs_area_chg_flag=1 # Flag: Cross section area limit to cap the amount of bathy XS area added to the SRC. Limits the bathy_calc_xs_area/ BANKFULL_XSEC_AREA to the specified threshold
 export bankful_xs_area_ratio_flag=10 # Flag: Identify bogus BARC adjusted values where the regression bankfull XS Area/SRC bankfull area is > threshold (topwidth crosswalk issues or bad bankfull regression data points??)
 export thalweg_hyd_radius_flag=10 # Flag: Idenitify possible erroneous BARC-adjusted hydraulic radius values. BARC discharge values greater than the specified threshold and within the thal_stg_limit are set to 0
-export ignore_streamorders=[1,2,10] # Ignore BARC calculations for streamorders >= this value (10 is Mississippi R)
+export ignore_streamorders=[1,2,3,10] # Ignore BARC calculations for streamorders >= this value (10 is Mississippi R)
 
 #### estimating bankfull stage in SRCs ####
 export src_bankfull_toggle="True" # Toggle to run identify_bankfull routine (True=on; False=off)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,22 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.31.0 - 2022-05-24 - [PR #597](https://github.com/NOAA-OWP/cahaba/pull/597)
+
+Modifications to enable bathymetry adjusted rating curves (BARC) to be implemented to FR flow lines to better match the MS inundation where FR & MS overlap. This PR uses an input env parameter to control which stream orders BARC is applied to for both FR & MS (currently set to orders 4-9). 
+
+## Additions
+
+- `tools/copy_huc_dirs.py`: New utility script to copy a list of HUC fim output files from src directory to dst directory by feeding the script a list of HUC ids. This streamlines the development process when testing code modifications and performing the subsequent FIM evaluations.
+
+## Changes
+
+- `config/params_template.env`: Changed `ignore_streamorders` parameter to use a list of stream orders that will be ignored within BARC routine
+- `src/bathy_src_adjust_topwidth.py`: Revised to read a list of stream orders and then mask the BARC calculations for select stream orders
+- `src/utils/shared_variables.py`: Included a copy of the BARC input parameters to allow user to run BARC as a stand alone script (outside `fim_run.sh`) 
+
+<br/><br/>
+
 ## v3.0.30.0 - 2022-04-19 - [PR #577](https://github.com/NOAA-OWP/cahaba/pull/577)
 
 Modifications to enforce consistent hydroTable.csv column dimensions for all HUCs (huc8 and huc6).

--- a/fim_run.sh
+++ b/fim_run.sh
@@ -154,7 +154,7 @@ fi
 
 # identify missing HUCs
 # time python3 /foss_fim/tools/fim_completion_check.py -i $hucList -o $outputRunDataDir
-if [ "$extent" = "MS" ] && [ "$bathy_src_toggle" = "True" ]; then
+if [ "$bathy_src_toggle" = "True" ]; then
     # Run BARC routine
     echo -e $startDiv"Performing Bathy Adjusted Rating Curve routine"$stopDiv
     time python3 /foss_fim/src/bathy_src_adjust_topwidth.py -fim_dir $outputRunDataDir -bfull_geom $bankfull_input_table -j $jobLimit -plots $src_plot_option

--- a/src/bathy_src_adjust_topwidth.py
+++ b/src/bathy_src_adjust_topwidth.py
@@ -12,7 +12,6 @@ from os.path import isfile, join, dirname, isdir
 import datetime as dt
 import sys
 from os import environ
-import utils.shared_variables
 import json
 sns.set_theme(style="whitegrid")
 # from utils.shared_functions import mem_profile
@@ -40,13 +39,14 @@ thal_hyd_radius_flag = 10
 ignore_streamorder = [1,2,10]
 '''
 
+# import utils.shared_variables # <-- use the shared variables stored here if running this as a stand alone script (outside fim_run.sh)
 sa_ratio_flag = float(environ['surf_area_thalweg_ratio_flag']) #10x --> Flag: Surface area ratio value to identify possible thalweg notch "jump" (SA x+1 / SA x)
 thal_stg_limit = float(environ['thalweg_stg_search_max_limit']) #3m --> Threshold: Stage value limit below which to look for the surface area ratio flag (only flag thalweg notch below this threshold)
 bankful_xs_ratio_flag = float(environ['bankful_xs_area_ratio_flag']) #10x --> Flag: Identify bogus BARC adjusted values where the regression bankfull XS Area/SRC bankfull area is > threshold (topwidth crosswalk issues or bad bankfull regression data points??)
 bathy_xsarea_flag = float(environ['bathy_xs_area_chg_flag']) #1x --> Flag: Cross section area limit to cap the amount of bathy XS area added to the SRC. Limits the bathy_calc_xs_area/ BANKFULL_XSEC_AREA to the specified threshold
 thal_hyd_radius_flag = float(environ['thalweg_hyd_radius_flag']) #10x --> Flag: Idenitify possible erroneous BARC-adjusted hydraulic radius values. BARC discharge values greater than the specified threshold and within the thal_stg_limit are set to 0
 ignore_streamorder = json.loads(environ['ignore_streamorders']) #10 --> Do not perform BARC for streamorders >= provided value
-print(ignore_streamorder)
+print('BARC will not be applied to these stream orders: ' + str(ignore_streamorder))
 
 def bathy_rc_lookup(args):
     input_src_fileName                  = args[0]

--- a/src/bathy_src_adjust_topwidth.py
+++ b/src/bathy_src_adjust_topwidth.py
@@ -12,6 +12,8 @@ from os.path import isfile, join, dirname, isdir
 import datetime as dt
 import sys
 from os import environ
+import utils.shared_variables
+import json
 sns.set_theme(style="whitegrid")
 # from utils.shared_functions import mem_profile
 
@@ -29,19 +31,22 @@ sns.set_theme(style="whitegrid")
     src_plot_option : str
         Optional (True or False): use this flag to crate src plots for all hydroids
 """
+'''
+sa_ratio_flag = 10
+thal_stg_limit = 3
+bankful_xs_ratio_flag = 10
+bathy_xsarea_flag = 1
+thal_hyd_radius_flag = 10
+ignore_streamorder = [1,2,10]
+'''
 
-# sa_ratio_flag = 10
-# thal_stg_limit = 3
-# bankful_xs_ratio_flag = 10
-# bathy_xsarea_flag = 1
-# thal_hyd_radius_flag = 10
-# ignore_streamorder = 10
 sa_ratio_flag = float(environ['surf_area_thalweg_ratio_flag']) #10x --> Flag: Surface area ratio value to identify possible thalweg notch "jump" (SA x+1 / SA x)
 thal_stg_limit = float(environ['thalweg_stg_search_max_limit']) #3m --> Threshold: Stage value limit below which to look for the surface area ratio flag (only flag thalweg notch below this threshold)
 bankful_xs_ratio_flag = float(environ['bankful_xs_area_ratio_flag']) #10x --> Flag: Identify bogus BARC adjusted values where the regression bankfull XS Area/SRC bankfull area is > threshold (topwidth crosswalk issues or bad bankfull regression data points??)
 bathy_xsarea_flag = float(environ['bathy_xs_area_chg_flag']) #1x --> Flag: Cross section area limit to cap the amount of bathy XS area added to the SRC. Limits the bathy_calc_xs_area/ BANKFULL_XSEC_AREA to the specified threshold
 thal_hyd_radius_flag = float(environ['thalweg_hyd_radius_flag']) #10x --> Flag: Idenitify possible erroneous BARC-adjusted hydraulic radius values. BARC discharge values greater than the specified threshold and within the thal_stg_limit are set to 0
-ignore_streamorder = int(environ['ignore_streamorders']) #10 --> Do not perform BARC for streamorders >= provided value
+ignore_streamorder = json.loads(environ['ignore_streamorders']) #10 --> Do not perform BARC for streamorders >= provided value
+print(ignore_streamorder)
 
 def bathy_rc_lookup(args):
     input_src_fileName                  = args[0]
@@ -168,8 +173,9 @@ def bathy_rc_lookup(args):
         ## Merge bathy_calc_xs_area to the modified_src_base
         modified_src_base = modified_src_base.merge(xs_area_hydroid_lookup.loc[:,['HydroID','bathy_calc_xs_area','barc_on']],how='left',on='HydroID')
 
-        ## Mask/null the bathy calculated area for streamorders that the user wants to ignore (set bathy_cals_xs_area = 0 for streamorder = 10)
-        modified_src_base['bathy_calc_xs_area'].mask(modified_src_base['order_'] >= ignore_streamorder,0.0,inplace=True)
+        ## Mask/null the bathy calculated area for streamorders that the user wants to ignore (set bathy_cals_xs_area = 0 for streamorder = X)
+        modified_src_base['bathy_calc_xs_area'].mask(modified_src_base['order_'].isin(ignore_streamorder),0.0,inplace=True)
+        modified_src_base['barc_on'] = np.where(modified_src_base['bathy_calc_xs_area'] <= 0, False, True) # field to identify where vmann is on/off
 
         ## Calculate new bathy adjusted channel geometry variables
         modified_src_base = modified_src_base.rename(columns={'Discharge (m3s-1)':'orig_Discharge (m3s-1)','XS Area (m2)':'orig_XS Area (m2)','Volume (m3)':'orig_Volume (m3)','WetArea (m2)':'orig_WetArea (m2)','HydraulicRadius (m)':'orig_HydraulicRadius (m)'})

--- a/src/utils/shared_variables.py
+++ b/src/utils/shared_variables.py
@@ -66,3 +66,11 @@ os.environ['agg_nhd_headwaters_adj_fileName'] = os.path.join(os.environ.get('nhd
 os.environ['agg_nhd_streams_adj_fileName'] = os.path.join(os.environ.get('nhdplus_aggregate_dir'),'agg_nhd_streams_adj.gpkg')
 os.environ['nwm_catchments_orig_filename'] = os.path.join(os.environ.get('nwm_dir'),'nwm_catchments_original.gpkg')
 os.environ['nwm_catchments_all_filename'] = os.path.join(os.environ.get('nwm_dir'),'nwm_catchments.gpkg')
+
+#### bathy SRC estimation parameters ####
+os.environ['surf_area_thalweg_ratio_flag'] = '10' # Flag: Surface area ratio value to identify possible thalweg notch "jump" (SA x+1 / SA x)
+os.environ['thalweg_stg_search_max_limit'] = '3' # Threshold: Stage value limit below which to look for the surface area ratio flag (only flag thalweg notch below this threshold)
+os.environ['bathy_xs_area_chg_flag'] = '1' # Flag: Cross section area limit to cap the amount of bathy XS area added to the SRC. Limits the bathy_calc_xs_area/ BANKFULL_XSEC_AREA to the specified threshold
+os.environ['bankful_xs_area_ratio_flag'] = '10' # Flag: Identify bogus BARC adjusted values where the regression bankfull XS Area/SRC bankfull area is > threshold (topwidth crosswalk issues or bad bankfull regression data points??)
+os.environ['thalweg_hyd_radius_flag'] = '10' # Flag: Idenitify possible erroneous BARC-adjusted hydraulic radius values. BARC discharge values greater than the specified threshold and within the thal_stg_limit are set to 0
+os.environ['ignore_streamorders'] = '[1,2,3,4,5,10]' # Ignore BARC calculations for streamorders >= this value (10 is Mississippi R)

--- a/src/utils/shared_variables.py
+++ b/src/utils/shared_variables.py
@@ -73,4 +73,4 @@ os.environ['thalweg_stg_search_max_limit'] = '3' # Threshold: Stage value limit 
 os.environ['bathy_xs_area_chg_flag'] = '1' # Flag: Cross section area limit to cap the amount of bathy XS area added to the SRC. Limits the bathy_calc_xs_area/ BANKFULL_XSEC_AREA to the specified threshold
 os.environ['bankful_xs_area_ratio_flag'] = '10' # Flag: Identify bogus BARC adjusted values where the regression bankfull XS Area/SRC bankfull area is > threshold (topwidth crosswalk issues or bad bankfull regression data points??)
 os.environ['thalweg_hyd_radius_flag'] = '10' # Flag: Idenitify possible erroneous BARC-adjusted hydraulic radius values. BARC discharge values greater than the specified threshold and within the thal_stg_limit are set to 0
-os.environ['ignore_streamorders'] = '[1,2,3,4,5,10]' # Ignore BARC calculations for streamorders >= this value (10 is Mississippi R)
+os.environ['ignore_streamorders'] = '[1,2,3,10]' # Ignore BARC calculations for streamorders >= this value (10 is Mississippi R)

--- a/tools/copy_huc_dirs.py
+++ b/tools/copy_huc_dirs.py
@@ -7,41 +7,29 @@ Created on Fri May  6 14:39:44 2022
 import shutil
 import os
 import argparse
+import multiprocessing
+from multiprocessing import Pool
 
 ########################################################################
 #Function to copy huc subdirectories to new location
 ########################################################################
-def copy_huc_dirs(huc_copy_lst, src, dst):
-    # reading the file
-    huc_txt = open(huc_copy_lst, "r")
-    hucs = huc_txt.read()
-    huc_list = hucs.split("\n")
-    huc_list = list(filter(None, huc_list))
-    print(str(len(huc_list)) + ' hucs in provided text file')
-    huc_txt.close()
+def copy_huc_dirs(huc, src, dst):
     
-    src_huc_dirs = [dI for dI in os.listdir(src) if os.path.isdir(os.path.join(src,dI))]
-    
-    for huc in huc_list:
-        if huc in src_huc_dirs:
-            # Check if file already exists
-            if os.path.isdir(dst+os.sep+huc):
-                print(huc, 'exists in the destination path - removing!')
-                shutil.rmtree(dst+os.sep+huc)
-            print('Copying huc directory: ' + str(huc))
-            shutil.copytree(src+os.sep+huc, dst+os.sep+huc)
-        else:
-            print('!!Source directory not found: ' + str(huc))
-    
-    print('Completed copy process')
+    # Check if file already exists
+    if os.path.isdir(dst+os.sep+huc):
+        print(huc, 'exists in the destination path - removing!')
+        shutil.rmtree(dst+os.sep+huc)
+    print('Copying huc directory: ' + str(huc))
+    shutil.copytree(src+os.sep+huc, dst+os.sep+huc)
 
 if __name__ == '__main__':
 
     # Parse arguments.
     parser = argparse.ArgumentParser(description='Copy tool for moving huc directories from src to dst')
     parser.add_argument('-src','--src',help='Name of src directory with huc subdirectories (e.g. data/ouputs/dev_abc/src/)',required=True)
-    parser.add_argument('-dst', '--dst',help='Name of dst directory to create huc subdirectories (e.g. data/ouputs/dev_abc/dst/)',required=True,default="")
+    parser.add_argument('-dst', '--dst',help='Name of dst directory (dir must exist) to create huc subdirectories (e.g. data/ouputs/dev_abc/dst/)',required=True,default="")
     parser.add_argument('-huc', '--huc-lst',help='Location of a line delimited text file with huc ids to copy (12345678)',required=True,default="")
+    parser.add_argument('-j', '--job-number',help='The number of jobs',required=False,default=1)
     
     # Extract to dictionary and assign to variables.
     args = vars(parser.parse_args())
@@ -49,7 +37,40 @@ if __name__ == '__main__':
     src = args['src']
     dst = args['dst']
     huc_copy_lst = args['huc_lst']
+    job_number = int(args['job_number'])
+
+    # reading the huc list file
+    huc_txt = open(huc_copy_lst, "r")
+    hucs = huc_txt.read()
+    huc_list = hucs.split("\n")
+    huc_list = list(filter(None, huc_list))
+    print(str(len(huc_list)) + ' hucs in provided text file')
+    huc_txt.close()
+
+    # append "logs" directory to list of hucs (need the logs for some stand alone processing steps)
+    huc_list.append("logs") 
     
-    copy_huc_dirs(huc_copy_lst, src, dst)
+    src_huc_dirs = [dI for dI in os.listdir(src) if os.path.isdir(os.path.join(src,dI))]
+    
+    procs_list = []; huc_count=0
+    for huc in huc_list:
+        if huc in src_huc_dirs:
+            procs_list.append([huc,src,dst])
+            huc_count += 1
+        else:
+            print('!!Source directory not found: ' + str(huc))
+    
+    if huc_count > 0:
+        if not os.path.exists(dst):
+            print("destination directory does not exists - creating it: " + str(dst))
+            os.mkdir(dst)
+
+        # Multiprocess.
+        print('Copying ' + str(huc_count) + ' huc dirs using '+ str(job_number) + ' jobs...')
+        with Pool(processes=job_number) as pool:
+            pool.starmap(copy_huc_dirs, procs_list)
+        print('Completed copy process!')
+    else:
+        print("Could not find any HUC directories to copy - exiting!")
 
     

--- a/tools/copy_huc_dirs.py
+++ b/tools/copy_huc_dirs.py
@@ -1,0 +1,55 @@
+"""
+Created on Fri May  6 14:39:44 2022
+
+@author: ryan.spies
+"""
+
+import shutil
+import os
+import argparse
+
+########################################################################
+#Function to copy huc subdirectories to new location
+########################################################################
+def copy_huc_dirs(huc_copy_lst, src, dst):
+    # reading the file
+    huc_txt = open(huc_copy_lst, "r")
+    hucs = huc_txt.read()
+    huc_list = hucs.split("\n")
+    huc_list = list(filter(None, huc_list))
+    print(str(len(huc_list)) + ' hucs in provided text file')
+    huc_txt.close()
+    
+    src_huc_dirs = [dI for dI in os.listdir(src) if os.path.isdir(os.path.join(src,dI))]
+    
+    for huc in huc_list:
+        if huc in src_huc_dirs:
+            # Check if file already exists
+            if os.path.isdir(dst+os.sep+huc):
+                print(huc, 'exists in the destination path - removing!')
+                shutil.rmtree(dst+os.sep+huc)
+            print('Copying huc directory: ' + str(huc))
+            shutil.copytree(src+os.sep+huc, dst+os.sep+huc)
+        else:
+            print('!!Source directory not found: ' + str(huc))
+    
+    print('Completed copy process')
+
+if __name__ == '__main__':
+
+    # Parse arguments.
+    parser = argparse.ArgumentParser(description='Copy tool for moving huc directories from src to dst')
+    parser.add_argument('-src','--src',help='Name of src directory with huc subdirectories (e.g. data/ouputs/dev_abc/src/)',required=True)
+    parser.add_argument('-dst', '--dst',help='Name of dst directory to create huc subdirectories (e.g. data/ouputs/dev_abc/dst/)',required=True,default="")
+    parser.add_argument('-huc', '--huc-lst',help='Location of a line delimited text file with huc ids to copy (12345678)',required=True,default="")
+    
+    # Extract to dictionary and assign to variables.
+    args = vars(parser.parse_args())
+    
+    src = args['src']
+    dst = args['dst']
+    huc_copy_lst = args['huc_lst']
+    
+    copy_huc_dirs(huc_copy_lst, src, dst)
+
+    

--- a/tools/copy_huc_dirs.py
+++ b/tools/copy_huc_dirs.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     # Parse arguments.
     parser = argparse.ArgumentParser(description='Copy tool for moving huc directories from src to dst')
     parser.add_argument('-src','--src',help='Name of src directory with huc subdirectories (e.g. data/ouputs/dev_abc/src/)',required=True)
-    parser.add_argument('-dst', '--dst',help='Name of dst directory (dir must exist) to create huc subdirectories (e.g. data/ouputs/dev_abc/dst/)',required=True,default="")
+    parser.add_argument('-dst', '--dst',help='Name of dst directory (will create if DNE) to create huc subdirectories (e.g. data/ouputs/dev_abc/dst/)',required=True,default="")
     parser.add_argument('-huc', '--huc-lst',help='Location of a line delimited text file with huc ids to copy (12345678)',required=True,default="")
     parser.add_argument('-j', '--job-number',help='The number of jobs',required=False,default=1)
     


### PR DESCRIPTION
This PR enables BARC to be implemented to FR flow lines to better match the MS inundation where FR & MS overlap. This PR uses an input env parameter to control which stream orders BARC is applied to for both FR & MS (currently set to SO 4-9). Address #585 

## Additions

- `tools/copy_huc_dirs.py`: New utility script to copy a list of HUC fim output files from src directory to dst directory by feeding the script a list of HUC ids. This streamlines the development process when testing code modifications and performing the subsequent FIM evaluations.

## Changes

- `config/params_template.env`: Changed `ignore_streamorders` parameter to use a list of stream orders that will be ignored within BARC routine
- `src/bathy_src_adjust_topwidth.py`: Revised to read a list of stream orders and then mask the BARC calculations for select stream orders
- `src/utils/shared_variables.py`: Included a copy of the BARC input parameters to allow user to run BARC as a stand alone script (outside `fim_run.sh`) 

## Testing

1. Performed a multitude of BARC stream order filtering iterations to identify the ideal FIM performance. Currently, the default solution will impliment BARC for both MS & FR resolutions for stream orders 4-9.
RAS2FIM alpha evaluation:
![image](https://user-images.githubusercontent.com/69868854/168609913-cb3b1542-e5e4-4ae8-b61d-4457a95d169d.png)
BLE alpha evaluation:
![image](https://user-images.githubusercontent.com/69868854/168614275-6385bc27-0491-4d87-8e55-9097d04bbc70.png)

2. Performed qualitative evaluation of evaluation inundation outputs to confirm that FR inundation more closely agrees with the MS inundation in overlap areas (see examples below).

## Screenshots
Problem: With the current FIM3 version FR FIM extents typically produces larger inundated area compared to the MS inundation for the same flow line. BARC is effectively reducing the inundation extent for MS flow lines. With this configuration the FR + MS composite effectively negates the BARC influence for MS flows lines. This is highlighted by the distinct FR vs. MS inundation outputs in the image below (using same flow for both FR and MS).
![image](https://user-images.githubusercontent.com/69868854/168612675-9d192f3d-bb1b-4a6d-af10-d488d4b961c7.png)

Solution: Implementing BARC for both FR and MS results in similar synthetic rating curves and resulting inundation extents where FR and MS flow lines overlap. This ensures consistency between the two resolutions. The bankfull regression performance is notably less reliable for smaller streams (stream orders <4); therefore, the new approach limits BARC implementation to stream orders 4, 5, 6, 7, 8, and 9.
![image](https://user-images.githubusercontent.com/69868854/168612950-db7f9e29-b02f-4c5f-ae3f-b974d1cd1099.png)
![image](https://user-images.githubusercontent.com/69868854/168657652-0b910b8f-0bf9-4bc2-94eb-e75357b6e330.png)

Mainstem stream order histogram:
![image](https://user-images.githubusercontent.com/69868854/168610362-b738fc85-b4e8-470a-97e4-376b1f69c578.png)

Full resolution stream order histogram:
![image](https://user-images.githubusercontent.com/69868854/168610485-af79e34a-241a-466b-ad1f-30ef817802b4.png)

Noted several locations where gaps in the MS inundation (bad crosswalk?) are filled with the FR inundation. Suggest looking into the root cause of the MS gaps.
![image](https://user-images.githubusercontent.com/69868854/168614919-b724d93d-8bf1-4f23-9b09-363fd6eb65ec.png)

## Todos

- [ ] Currently running a FR BED simulation with the new code
- [ ] Updated changelog
