### PR TITLE
Update to fix error related to old version of flask

### DIFF
--- a/api/frontend/gui/requirements.txt
+++ b/api/frontend/gui/requirements.txt
@@ -1,4 +1,4 @@
-flask==1.1.2
+flask==2.1.2
 flask-socketio==5.0.0
 gevent==20.9.0
 gunicorn==20.0.4

--- a/api/node/connector/connector.py
+++ b/api/node/connector/connector.py
@@ -224,4 +224,5 @@ def ws_new_job(job_params):
    
 
 if __name__ == '__main__':
+
     socketio.run(app, host="0.0.0.0", port="6000")

--- a/api/node/connector/requirements.txt
+++ b/api/node/connector/requirements.txt
@@ -1,3 +1,4 @@
-flask==1.1.2
+flask==2.1.2
+werkzeug==2.0.0
 flask-socketio==5.0.0
 eventlet==0.31.0


### PR DESCRIPTION
The API tool was failing with an error on the UI saying that the service was unavailable. 

Upon research, a reboot to the USC2 machine, which runs part of the API tool, failed to start a key service. An update was made to a child python package related to a key package we use called Flask. When Flash reloaded, it auto reloaded it's children packages and one of them was no longer compatible.   

We made an update to use the new Flash python package and restarted the services.

## Changes

- `api/frontend/gui`:
    - `requirements.txt` : Updated the version related to `flask`.

- `api/frontend/node`:
     - `requirements.txt` : Updated the version related to `flask`. An additional line for `werkzeug` was also now required. 

## Testing

A full test using a small HUC list with 4 HUCs against the `dev-fim3` branch and it was successful.

