### PR TITLE
[1pt] API Tool references fix

### DIFF
--- a/api/frontend/docker-compose-dev.yml
+++ b/api/frontend/docker-compose-dev.yml
@@ -1,3 +1,6 @@
+
+## DEPRECATED - May 27, 2022
+
 version: '3.5'
 services:
   fim_frontend_gui:

--- a/api/frontend/gui/requirements.txt
+++ b/api/frontend/gui/requirements.txt
@@ -1,5 +1,4 @@
-flask==1.1.2
+flask==2.1.2
 flask-socketio==5.0.0
-itsdangerous==2.0.1
 gevent==20.9.0
 gunicorn==20.0.4

--- a/api/frontend/nginx-dev.conf
+++ b/api/frontend/nginx-dev.conf
@@ -1,3 +1,6 @@
+
+## DEPRECATED - May 27, 2022
+
 user nginx;
 worker_processes 1;
 pid /var/run/nginx.pid;

--- a/api/node/connector/requirements.txt
+++ b/api/node/connector/requirements.txt
@@ -1,4 +1,4 @@
-flask==1.1.2
+flask==2.1.2
+werkzeug==2.0.0
 flask-socketio==5.0.0
-itsdangerous==2.0.1
 eventlet==0.31.0

--- a/api/node/docker-compose-dev.yml
+++ b/api/node/docker-compose-dev.yml
@@ -1,3 +1,6 @@
+
+## DEPRECATED - May 27, 2022
+
 version: '3.5'
 services:
   fim_node_connector:


### PR DESCRIPTION
The API tool had to be stopped today due to an API tool restart yesterday for configuration issues. The API tool was having trouble restarting, so was updated with a different way to handle the flask version issue from a few weeks ago. See previous [PR 566.](https://github.com/NOAA-OWP/inundation-mapping/pull/566.)

A few other docker files were adjusted to show they are deprecated. In the NWC offices, only the "prod" versions are applicable and the "dev" versions can create some confusion. The "dev" versions do not fully work anyways.

This PR is based on issue [606](https://github.com/NOAA-OWP/inundation-mapping/issues/606). 

## Changes

- `api`
   - `node`
      - `docker-compose-dev.yml`: Note added to the top of page saying now deprecated.
      - `connector`
         - `requirements.txt`: Changed some reference names and versions, mostly based on upgrading Flask version.
  - `frontend`
     - `docker-compose-dev.yml`: Note added to the top of page saying now deprecated.
     - `nginx-dev.conf`: Note added to the top of page saying now deprecated.
     - `gui`
        - `requirements.txt`: Changed some reference names and versions, mostly based on upgrading Flask version.

## Testing
Simply getting the API tool operational again as a web UI was a key to proving the changes were successful. A test submission of small huc list was used to validate that both the `node` tools on one server were correctly interacting with the `frontend` tools on another server (standard architecture for this tool).
