### PR TITLE
[1pt] PR: CatFIM B Option (Water Surface Elevation Method)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v3.0.33.0 - 2022-06-30 - [PR #619](https://github.com/NOAA-OWP/cahaba/pull/619)
+
+This PR adds a new option to the `/tools/generate_categorical_fim.py` script `-a` that allows for an alternate method (CatFIM B) for producing inundation maps at the official AHPS flood categories. Similar to the original CatFIM method (CatFIM A), CatFIM B produces inundation maps at the official AHPS categories, but instead of creating maps from the official AHPS discharges, maps are produced using the official stage values, which are converted to water surface elevation.
+
+## Changes
+
+- `generate_categorical_fim_flows.py` : Added options `-a` and `-f`. `-a` is interpreted as a bool and if provided by a user will run the CatFIM B method. If `-a` is passed, then the `-f` flag (fim version full path) is required so that necessary input layers can be accessed.
+- `generate_categorical_fim.py`: Added `-a` option to run the alternate CatFIM method.
+
+<br/><br/>
+
 ## v3.0.32.0 - 2022-05-26 - [PR #597](https://github.com/NOAA-OWP/cahaba/pull/588)
 
 This PR updates `synthesize_test_cases.py` with the ability to create MS, FR, and composite inundation agreement rasters and statistics all in one run. The new composited statistics are output in the same location within each test ID with the `_comp` suffix  replacing `_ms` for each dev or previous_fim run. Addresses #555.

--- a/tools/generate_categorical_fim.py
+++ b/tools/generate_categorical_fim.py
@@ -73,6 +73,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Run Categorical FIM')
     parser.add_argument('-f','--fim_version',help='Name of directory containing outputs of fim_run.sh',required=True)
     parser.add_argument('-j','--number_of_jobs',help='Number of processes to use. Default is 1.',required=False, default="1",type=int)
+    parser.add_argument('-a', '--alt-catfim', help = 'Run alternative CatFIM that bypasses synthetic rating curves?', required=False, default=False, action='store_true')
     args = vars(parser.parse_args())
 
     # Get arguments
@@ -92,7 +93,11 @@ if __name__ == '__main__':
     # Generate CatFIM flow files
     print('Creating flow files')
     start = time.time()
-    subprocess.call(['python3','/foss_fim/tools/generate_categorical_fim_flows.py', '-w' , str(output_flows_dir), '-u', nwm_us_search, '-d', nwm_ds_search])
+    if args['alt_catfim']:
+        fim_dir = args['fim_version']
+        subprocess.call(['python3','/foss_fim/tools/generate_categorical_fim_flows.py', '-w' , str(output_flows_dir), '-u', nwm_us_search, '-d', nwm_ds_search, '-a', '-f', fim_version])
+    else:
+        subprocess.call(['python3','/foss_fim/tools/generate_categorical_fim_flows.py', '-w' , str(output_flows_dir), '-u', nwm_us_search, '-d', nwm_ds_search])
     end = time.time()
     elapsed_time = (end-start)/60
     print(f'Finished creating flow files in {elapsed_time} minutes')

--- a/tools/generate_categorical_fim_flows.py
+++ b/tools/generate_categorical_fim_flows.py
@@ -228,8 +228,6 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
             hand_flow_array = subset_hydroTable[["discharge_cms"]].to_numpy()
             hand_stage_array = hand_stage_array[:, 0]
             hand_flow_array = hand_flow_array[:, 0]
-            print(hand_stage_array)
-            print(hand_flow_array)
 
             #if no segments, write message and exit out
             if not segments:
@@ -237,7 +235,7 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
                 message = f'{lid}:missing nwm segments'
                 all_messages.append(message)
                 continue
-            
+            print(lid)
             #For each flood category
             for category in flood_categories:
                 
@@ -270,10 +268,23 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
                     print("Interpolated flow")
                     print(interpolated_hand_flow)
                     print()
+                    
+                    #round flow to nearest hundredth
+                    flow = round(interpolated_hand_flow,2)
+                    print("flow")
+                    print(flow)
+                    #Create the guts of the flow file.
+                    flow_info = flow_data(segments,flow,convert_to_cms=False)
+                    print("flow_info")
+                    print(flow_info)
+                    #Define destination path and create folders
+                    output_file = workspace / huc / lid / category / (f'ahps_{lid}_huc_{huc}_flows_{category}.csv') 
+                    output_file.parent.mkdir(parents = True, exist_ok = True)
+                    #Write flow file to file
+                    flow_info.to_csv(output_file, index = False)
 
                     
                 else:  # If running in default mode
-                
                     #Get the flow
                     flow = flows[category]
                     #If there is a valid flow value, write a flow file.

--- a/tools/generate_categorical_fim_flows.py
+++ b/tools/generate_categorical_fim_flows.py
@@ -270,6 +270,8 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
                 # HAND synthetic rating curves, looking up the corresponding flows for datum-offset
                 # AHPS stage values.
                 if alt_catfim:
+                    if datum_adj_ft == None:
+                        datum_adj_ft = 0.0
                     stage = stages[category]
                     if len(hand_stage_array) > 0 and stage != None and datum_adj_ft != None:
                         # Determine datum-offset stage (from above).
@@ -290,7 +292,8 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
                         #Write flow file to file
                         flow_info.to_csv(output_file, index = False)
                     else:
-                        message = f'{lid}:{category} no stage information available'
+                        hand_stage_array_len = len(hand_stage_array)
+                        message = f'{lid}:{category}, {hydroid}, array_len:{hand_stage_array_len}, stage:{stage}, datum_adj_ft:{datum_adj_ft}'
                         all_messages.append(message)
                     
                 else:  # If running in default mode
@@ -312,8 +315,10 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
                         all_messages.append(message)
 
             #Get various attributes of the site.
-            lat = float(metadata['usgs_preferred']['latitude'])
-            lon = float(metadata['usgs_preferred']['longitude'])
+#            lat = float(metadata['usgs_preferred']['latitude'])
+#            lon = float(metadata['usgs_preferred']['longitude'])
+            lat = float(metadata['nws_preferred']['latitude'])
+            lon = float(metadata['nws_preferred']['longitude'])
             wfo = metadata['nws_data']['wfo']
             rfc = metadata['nws_data']['rfc']
             state = metadata['nws_data']['state']
@@ -343,8 +348,6 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
             else:
                 message = f'{lid}:missing all calculated flows'
                 all_messages.append(message)
-        print()
-        print()
     print('wrapping up...')
     #Recursively find all *_attributes csv files and append
     csv_files = list(workspace.rglob('*_attributes.csv'))

--- a/tools/generate_categorical_fim_flows.py
+++ b/tools/generate_categorical_fim_flows.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import pandas as pd
+import numpy as np
 import time
 from tools_shared_functions import aggregate_wbd_hucs, mainstem_nwm_segs, get_thresholds, flow_data, get_metadata, get_nwm_segs, get_datum, ngvd_to_navd_ft
 import argparse
@@ -220,6 +221,15 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
             site_ms_segs = set(segments).intersection(ms_segs)
             segments = list(site_ms_segs)    
             nwm_feature_id = metadata['identifiers']['nwm_feature_id']
+            
+            # TODO Currently using feature_id, but need to identify the HydroID instead and group by that.
+            subset_hydroTable = hydroTable.loc[hydroTable['feature_id'] == nwm_feature_id]
+            hand_stage_array = subset_hydroTable[["stage"]].to_numpy()
+            hand_flow_array = subset_hydroTable[["discharge_cms"]].to_numpy()
+            hand_stage_array = hand_stage_array[:, 0]
+            hand_flow_array = hand_flow_array[:, 0]
+            print(hand_stage_array)
+            print(hand_flow_array)
 
             #if no segments, write message and exit out
             if not segments:
@@ -246,18 +256,22 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
                     print(stage)
                     print("New stage")
                     print(datum_adj_stage)
-                    print()
                     
                     # Need feature_id for lid
-                    print("primary feature_id")
-                    print(nwm_feature_id)
-                    print("other segments")
-                    print(segments)
+#                    print("primary feature_id")
+#                    print(nwm_feature_id)
+#                    print("other segments")
+#                    print(segments)
+                    
+                    datum_adj_stage_m = datum_adj_stage*0.3048  # Convert ft to m
                     
                     # Interpolate flow value for offset stage.
+                    interpolated_hand_flow = np.interp(datum_adj_stage_m, hand_stage_array, hand_flow_array)
+                    print("Interpolated flow")
+                    print(interpolated_hand_flow)
+                    print()
+
                     
-                    
-                    pass
                 else:  # If running in default mode
                 
                     #Get the flow

--- a/tools/generate_categorical_fim_flows.py
+++ b/tools/generate_categorical_fim_flows.py
@@ -65,6 +65,7 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search):
 
     print('Retrieving metadata...')
     #Get metadata for 'CONUS'
+    print(metadata_url)
     conus_list, conus_dataframe = get_metadata(metadata_url, select_by = 'nws_lid', selector = ['all'], must_include = 'nws_data.rfc_forecast_point', upstream_trace_distance = nwm_us_search, downstream_trace_distance = nwm_ds_search )
 
     #Get metadata for Islands

--- a/tools/generate_categorical_fim_flows.py
+++ b/tools/generate_categorical_fim_flows.py
@@ -94,15 +94,15 @@ def generate_catfim_flows(workspace, nwm_us_search, nwm_ds_search, alt_catfim, f
     #Assign HUCs to all sites using a spatial join of the FIM 3 HUC layer. 
     #Get a dictionary of hucs (key) and sites (values) as well as a GeoDataFrame
     #of all sites used later in script.
-#    huc_dictionary, out_gdf = aggregate_wbd_hucs(metadata_list = all_lists, wbd_huc8_path = WBD_LAYER)
+    huc_dictionary, out_gdf = aggregate_wbd_hucs(metadata_list = all_lists, wbd_huc8_path = WBD_LAYER)
 
     import json
 #    print("Writing huc dictionary")
 #    with open(r'/data/temp/brad/alternate_catfim_temp_files/huc_dictionary.json', "w") as outfile:
 #        json.dump(huc_dictionary, outfile)
 
-    with open(r'/data/temp/brad/alternate_catfim_temp_files/huc_dictionary.json') as json_file:
-        huc_dictionary = json.load(json_file)
+#    with open(r'/data/temp/brad/alternate_catfim_temp_files/huc_dictionary.json') as json_file:
+#        huc_dictionary = json.load(json_file)
 
     #Get all possible mainstem segments
     print('Getting list of mainstem segments')


### PR DESCRIPTION
This PR adds a new option to the `/tools/generate_categorical_fim.py` script `-a` that allows for an alternate method for producing inundation maps at the official AHPS flood categories.

This PR addresses #603.

## Summary

I used FIM 3.0.32.0 for this testing. 3.0.32.0 includes calibration at USGS/NWS sites using both the available synthetic rating curves and the spatial “Alpha” benchmark data.

### CatFIM A (Original Method)
CatFIM A refers to the original CatFIM methodology, i.e. plugging the NWS threshold flows directly into the HAND synthetic rating curves, generating a new stage value different than the official threshold stage, and mapping it to the HAND grid 5 miles up and downstream of sites.

### CatFIM B (Alternate Method)
CatFIM B refers to the water surface elevation technique (see next slide). It determines the stage associated with a NWS threshold, converts the stage to WSE, applies the datum conversion if necessary (to match the HAND DEM datum). Then the HAND SRCs are converted from stage/flow pairs to WSE/flow pairs. The WSE/flow pair is used to interpolate the flow necessary to yield the NWS WSE. The HAND flow is then run through inundation.py to yield an inundation map 5 miles up and downstream of sites. I interpolate a HAND flow value because the WSE derived for a single gage is only useful for its home HAND catchment; the WSEs are not directly usable in up- or downstream catchments. By determining the flow associated with the WSE and then mapping it, it becomes possible to model “the same” conditions necessary to yield the WSE in nearby catchments.

## Changes

- `generate_categorical_fim_flows.py`: Added options `-a` and `-f`. `-a` is interpreted as a bool and if provided by a user will run the CatFIM B method. If `-a` is passed, then the `-f` flag (fim version full path) is required so that necessary input layers can be accessed.
- `generate_categorical_fim.py`: Added `-a` option to run the alternate CatFIM method.

## Testing

1. Run `generate_categorical_fim.py`. For example ```python generate_categorical_fim.py -f /data/previous_fim/fim_3_0_32_0_ms_c -a -j 6```

## Screenshots
### Workflow
![image](https://user-images.githubusercontent.com/69594899/175618829-1a9fd03a-85c9-4237-b634-0f9d50967674.png)


![image](https://user-images.githubusercontent.com/69594899/175618717-a77b08e5-f190-468d-a3a0-06ea193323f0.png)

See #603 for screenshots of results.

## Notes

- There are much fewer mapped sites in CatFIM B than CatFIM A because over 500 HUCs not having sites with acceptable amounts of datum accuracy. See Todos below for next steps. 

## Todos

- After conversation with Crane, we will need to modify `usgs_gage_crosswalk.py` to output `usgs_elev_table.csv` files for all HUCs, regardless of datum accuracy, and include datum and horizontal accuracy information in the table as additional attributes. After that, `generate_categorical_fim.py` will be able to produce maps for over 500 more HUC8s, and the accuracy information will be added to the attribute table so that users can see and query the library by datum accuracy.
