### PR TITLE
[1pt] Added version to pipenv in the Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,8 @@ ENV PYTHONPATH=${PYTHONPATH}:$srcDir:$projectDir/tests:$projectDir/tools
 ## install python 3 modules ##
 COPY Pipfile .
 COPY Pipfile.lock .
-RUN pip3 install pipenv && PIP_NO_CACHE_DIR=off PIP_NO_BINARY=shapely,pygeos pipenv install --system --deploy --ignore-pipfile
+RUN pip3 install pipenv==2022.4.8 && PIP_NO_CACHE_DIR=off PIP_NO_BINARY=shapely,pygeos pipenv install --system --deploy --ignore-pipfile
+
 
 ## RUN UMASK TO CHANGE DEFAULT PERMISSIONS ##
 ADD ./src/entrypoint.sh /

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -89,7 +89,7 @@ ENV PYTHONPATH=${PYTHONPATH}:$srcDir:$projectDir/tests:$projectDir/tools
 ## install python 3 modules ##
 COPY Pipfile .
 COPY Pipfile.lock .
-RUN pip3 install pipenv && PIP_NO_CACHE_DIR=off PIP_NO_BINARY=shapely,pygeos pipenv install --system --deploy --ignore-pipfile
+RUN pip3 install pipenv==2022.4.8 && PIP_NO_CACHE_DIR=off PIP_NO_BINARY=shapely,pygeos pipenv install --system --deploy --ignore-pipfile
 
 ## Copy the source code to the image
 COPY . $projectDir/


### PR DESCRIPTION
Docker build was failing saying that some packages such as shapely and entrypoints could not load.

Based on a similar issue found in dev-fim3 branch, all that was needed was to force the pipenv package to a newer version (2022.4.8)

See [Issue 633](https://github.com/NOAA-OWP/inundation-mapping/issues/633) for more details.

## Changes

`Dockerfile` and `Dockerfile.prod`: Both had the same fix of forcing a version of 2022.4.8 during docker builds.

## Testing

- A new docker image based on Dockerfile was created and tests for gms_run_unit.sh and gms_run_branch.sh were performed. A test against Dockerfile.prod was not performed but not expected to be an issue.

