### PR TITLE
[1pt] Prune branches that fail with Exit status: 61 in split_flows.py

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## [Version to be assigned] - 2022-08-12 - [PR #655](https://github.com/NOAA-OWP/inundation-mapping/pull/655)
+## v4.0.6.1 - 2022-08-12 - [PR #655](https://github.com/NOAA-OWP/inundation-mapping/pull/655)
 
 Prunes branches that fail with NO_FLOWLINES_EXIST (Exit code: 61) in `gms_run_branch.sh` after running `split_flows.py`
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,20 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## [Version to be assigned] - 2022-08-12 - [PR #655](https://github.com/NOAA-OWP/inundation-mapping/pull/655)
+
+Prunes branches that fail with NO_FLOWLINES_EXIST (Exit code: 61) in `gms_run_branch.sh` after running `split_flows.py`
+
+## Additions
+- Adds `remove_error_branches.py` (called from `gms_run_branch.sh`)
+- Adds `gms_inputs_removed.csv` to log branches that have been removed across all HUCs
+
+## Removals
+- Deletes branch folders that fail
+- Deletes branch from `gms_inputs.csv`
+
+<br/><br/>
+
 ## v4.0.6.0 - 2022-08-10 - [PR #614](https://github.com/NOAA-OWP/inundation-mapping/pull/614)
 
 Addressing #560, this fix in run_by_branch trims the DEM derived streamline if it extends past the end of the branch streamline. It does this by finding the terminal point of the branch stream, snapping to the nearest point on the DEM derived stream, and cutting off the remaining downstream portion of the DEM derived stream.

--- a/gms_run_branch.sh
+++ b/gms_run_branch.sh
@@ -194,6 +194,13 @@ echo
 echo "Start non-zero exit code checking"
 find $outputRunDataDir/logs/branch -name "*_branch_*.log" -type f | xargs grep -E "Exit status: ([1-9][0-9]{0,2})" >"$outputRunDataDir/branch_errors/non_zero_exit_codes.log" &
 
+# -------------------
+## REMOVE FAILED BRANCHES ##
+# Needed in case aggregation fails, we will need the logs
+echo
+echo "Removing branches that failed with Exit status: 61"
+python3 $srcDir/gms/remove_error_branches.py -f "$outputRunDataDir/branch_errors/non_zero_exit_codes.log" -g $outputRunDataDir/gms_inputs.csv
+
 echo "=========================================================================="
 echo "GMS_run_branch complete"
 Tcount

--- a/src/gms/remove_error_branches.py
+++ b/src/gms/remove_error_branches.py
@@ -8,9 +8,8 @@ import argparse
 import pandas as pd
 import shutil
 
-def remove_error_branches(logfile, gms_inputs, huc_level=8):
+def remove_error_branches(logfile, gms_inputs):
     if os.path.isfile(logfile):
-
         errors_df = pd.read_csv(logfile, sep=':', header=None)
         gms_inputs_df = pd.read_csv(gms_inputs, header=None)
 
@@ -41,10 +40,12 @@ def remove_error_branches(logfile, gms_inputs, huc_level=8):
 
                 huc = split[0]
                 branch = split[3]
+                huc_level = len(huc)
 
                 if huc not in first_occurrence:
                     # Ignore previous removals for this HUC
-                    error_branches = error_branches[error_branches[0] != huc]
+                    if error_branches is not None:
+                        error_branches = error_branches[error_branches[0] != huc]
 
                     first_occurrence.append(huc)
 
@@ -81,9 +82,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Remove branches with Exit status: 61')
     parser.add_argument('-f','--logfile', help='Location of non_zero_exit_codes.log', required=True)
     parser.add_argument('-g','--gms-inputs', help='Location of gms_inputs.csv', required=True)
-    parser.add_argument('-l','--huc-level', help='Level of HUC (e.g., 8 for HUC8)', type=int, required=False, default=8)
 
     # extract to dictionary
     args = vars(parser.parse_args())
 
-    remove_error_branches(args['logfile'], args['gms_inputs'], args['huc_level'])
+    remove_error_branches(args['logfile'], args['gms_inputs'])

--- a/src/gms/remove_error_branches.py
+++ b/src/gms/remove_error_branches.py
@@ -8,46 +8,82 @@ import argparse
 import pandas as pd
 import shutil
 
-def remove_error_branches(logfile, gms_inputs):
+def remove_error_branches(logfile, gms_inputs, huc_level=8):
     if os.path.isfile(logfile):
 
         errors_df = pd.read_csv(logfile, sep=':', header=None)
         gms_inputs_df = pd.read_csv(gms_inputs, header=None)
 
+        # Make copy of gms_inputs.csv
+        gms_inputs_copy = os.path.splitext(gms_inputs)[0] + '_original.csv'
+        if not os.path.isfile(gms_inputs_copy):
+            gms_inputs_df.to_csv(gms_inputs_copy, header=False, index=False)
+            
+        gms_inputs_removed = os.path.splitext(gms_inputs)[0] + '_removed.csv'
+        if not os.path.isfile(gms_inputs_removed):
+            error_branches = None
+        else:
+            error_branches = pd.read_csv(gms_inputs_removed, header=None, dtype=str)
+
+
+        first_occurrence = []
         for i, row in errors_df.iterrows():
             error_code = row[2]
 
             if error_code == 61:
                 dirname, basename = os.path.split(row[0])
 
-                splitext = str.split(os.path.splitext(basename)[0], '_')
+                filename = os.path.splitext(basename)[0]
 
-                huc = splitext[0]
-                branch = splitext[3]
+                print(f"Removing {filename}")
+
+                split = str.split(filename, '_')
+
+                huc = split[0]
+                branch = split[3]
+
+                if huc not in first_occurrence:
+                    # Ignore previous removals for this HUC
+                    error_branches = error_branches[error_branches[0] != huc]
+
+                    first_occurrence.append(huc)
 
                 output_dir = os.path.split(os.path.split(dirname)[0])[0]
                 branch_dir = os.path.join(output_dir, huc, 'branches', branch)
                 if os.path.exists(branch_dir):
                     shutil.rmtree(branch_dir)
 
+                # Remove bad branch from DataFrame
                 if int(branch) in gms_inputs_df.loc[:,1].values:
                     gms_inputs_df = gms_inputs_df.drop(index=gms_inputs_df[gms_inputs_df.loc[:,1]==int(branch)].index[0])
 
+                tmp_df = pd.DataFrame([huc.zfill(huc_level), branch]).T
+                if error_branches is None:
+                    error_branches = tmp_df
+                else:
+                    error_branches = pd.concat([error_branches, tmp_df])
+
+        # Save list of removed branches
+        pd.DataFrame(error_branches).to_csv(gms_inputs_removed, header=False, index=False)
+
         # Overwrite gms_inputs.csv with error branches removed
         gms_inputs_df.to_csv(gms_inputs, header=False, index=False)
+
+        print('Done removing error branches')
+
+    else:
+        print('No log file found')
 
 
 if __name__ == '__main__':
 
     # parse arguments
     parser = argparse.ArgumentParser(description='Remove branches with Exit status: 61')
-    parser.add_argument('-f','--logfile', help='non_zero_exit_codes.log', required=True)
-    parser.add_argument('-g','--gms-inputs', help='gms_inputs.csv', required=True)
+    parser.add_argument('-f','--logfile', help='Location of non_zero_exit_codes.log', required=True)
+    parser.add_argument('-g','--gms-inputs', help='Location of gms_inputs.csv', required=True)
+    parser.add_argument('-l','--huc-level', help='Level of HUC (e.g., 8 for HUC8)', type=int, required=False, default=8)
 
     # extract to dictionary
     args = vars(parser.parse_args())
 
-    remove_error_branches(args['logfile'], args['gms_inputs'])
-
-    # remove_error_branches('/data/outputs/dev-prune-error-branches/branch_errors/non_zero_exit_codes.log',
-    #                       '/data/outputs/dev-prune-error-branches/gms_inputs.csv')
+    remove_error_branches(args['logfile'], args['gms_inputs'], args['huc_level'])

--- a/src/gms/remove_error_branches.py
+++ b/src/gms/remove_error_branches.py
@@ -10,7 +10,12 @@ import shutil
 
 def remove_error_branches(logfile, gms_inputs):
     if os.path.isfile(logfile):
-        errors_df = pd.read_csv(logfile, sep=':', header=None)
+        try:
+            errors_df = pd.read_csv(logfile, sep=':', header=None)
+        except pd.errors.EmptyDataError:
+            print('\nLog file is empty. Skipping this HUC.\n')
+            return
+
         gms_inputs_df = pd.read_csv(gms_inputs, header=None)
 
         # Make copy of gms_inputs.csv
@@ -23,7 +28,6 @@ def remove_error_branches(logfile, gms_inputs):
             error_branches = None
         else:
             error_branches = pd.read_csv(gms_inputs_removed, header=None, dtype=str)
-
 
         first_occurrence = []
         for i, row in errors_df.iterrows():
@@ -70,10 +74,10 @@ def remove_error_branches(logfile, gms_inputs):
         # Overwrite gms_inputs.csv with error branches removed
         gms_inputs_df.to_csv(gms_inputs, header=False, index=False)
 
-        print('Done removing error branches')
+        print('\nDone removing error branches\n')
 
     else:
-        print('No log file found')
+        print('\nNo log file found\n')
 
 
 if __name__ == '__main__':

--- a/src/gms/remove_error_branches.py
+++ b/src/gms/remove_error_branches.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Removes branches with Exit status: 61 following split_flows.py.
+# Removes both the branch folder and the reference in gms_inputs.csv
+
+import os
+import argparse
+import pandas as pd
+import shutil
+
+def remove_error_branches(logfile, gms_inputs):
+    if os.path.isfile(logfile):
+
+        errors_df = pd.read_csv(logfile, sep=':', header=None)
+        gms_inputs_df = pd.read_csv(gms_inputs, header=None)
+
+        for i, row in errors_df.iterrows():
+            error_code = row[2]
+
+            if error_code == 61:
+                dirname, basename = os.path.split(row[0])
+
+                splitext = str.split(os.path.splitext(basename)[0], '_')
+
+                huc = splitext[0]
+                branch = splitext[3]
+
+                output_dir = os.path.split(os.path.split(dirname)[0])[0]
+                branch_dir = os.path.join(output_dir, huc, 'branches', branch)
+                if os.path.exists(branch_dir):
+                    shutil.rmtree(branch_dir)
+
+                if int(branch) in gms_inputs_df.loc[:,1].values:
+                    gms_inputs_df = gms_inputs_df.drop(index=gms_inputs_df[gms_inputs_df.loc[:,1]==int(branch)].index[0])
+
+        # Overwrite gms_inputs.csv with error branches removed
+        gms_inputs_df.to_csv(gms_inputs, header=False, index=False)
+
+
+if __name__ == '__main__':
+
+    # parse arguments
+    parser = argparse.ArgumentParser(description='Remove branches with Exit status: 61')
+    parser.add_argument('-f','--logfile', help='non_zero_exit_codes.log', required=True)
+    parser.add_argument('-g','--gms-inputs', help='gms_inputs.csv', required=True)
+
+    # extract to dictionary
+    args = vars(parser.parse_args())
+
+    remove_error_branches(args['logfile'], args['gms_inputs'])
+
+    # remove_error_branches('/data/outputs/dev-prune-error-branches/branch_errors/non_zero_exit_codes.log',
+    #                       '/data/outputs/dev-prune-error-branches/gms_inputs.csv')

--- a/tools/gms_tools/inundate_gms.py
+++ b/tools/gms_tools/inundate_gms.py
@@ -2,11 +2,8 @@
 
 import os
 import argparse
-import logging
-import sys
-import traceback
+# import logging
 
-import numpy as np
 import pandas as pd
 
 from tqdm import tqdm


### PR DESCRIPTION
Removes branches that fail with Exit status: 61 in split_flows.py. Closes #653.

During `gms_run_branch.sh`, a new file, `remove_error_branches.py`, reads the `non_zero_exit_codes.log` to determine which branches exited with code 61: FIM_exit_codes.NO_FLOWLINES_EXIST. It then deletes the branch folder, removes the branch from `gms_inputs.csv`, and adds the branch to `gms_inputs_removed.csv`. 

## Additions

- Adds `remove_error_branches.py` (called from `gms_run_branch.sh`)
- Adds `gms_inputs_original.csv` to save original `gms_inputs.csv` before pruning
- Adds `gms_inputs_removed.csv` to log branches that have been removed across all HUCs

## Removals

- Deletes branch folders that fail
- Deletes branch from `gms_inputs.csv`

## Testing

1. Run on two HUC8s, one with two branches that fail: 12100303 and 08080103 (two error branches). Produced expected outputs. Also tested outputs on inundate_gms (on HUC 12020005 since that HUC had validation data).

```
gms_run_unit.sh -s -u 12100303 -n dev-prune-error-branches -c /foss_fim/config/params_template.env -j 6 -d /foss_fim/config/deny_gms_unit_default.lst -o

gms_run_branch.sh -s -n dev-prune-error-branches -u 12100303 -c /foss_fim/config/params_template.env -j 6 -d /foss_fim/config/deny_gms_branches_default.lst -o

gms_run_unit.sh -s -u 08080103 -n dev-prune-error-branches -c /foss_fim/config/params_template.env -j 6 -d /foss_fim/config/deny_gms_unit_default.lst -o

gms_run_branch.sh -s -n dev-prune-error-branches -u 08080103 -c /foss_fim/config/params_template.env -j 6 -d /foss_fim/config/deny_gms_branches_default.lst -o

/foss_fim/tools/gms_tools/inundate_gms.py -y /data/outputs/dev-prune-error-branches -u 12020005 -f /data/test_cases/ble_test_cases/validation_data_ble/12020005/100yr/ble_huc_12020005_flows_100yr.csv -w 7 -i /data/temp/12020005_inundation_test.tif -o /data/temp/12020005_inundation_test.csv -v
```


## Notes

- When HUCs are run separately (e.g., from `gms_run_branch.sh`), `gms_inputs.csv` and `non_zero_exit_codes.log` are overwritten so they are only relevant to the last HUC that was run.
