### PR TITLE
[2pt] PR: Patches for FIM4 alpha test

### DIFF
--- a/src/gms/remove_error_branches.py
+++ b/src/gms/remove_error_branches.py
@@ -16,7 +16,7 @@ def remove_error_branches(logfile, gms_inputs):
             print('\nLog file is empty. Skipping this HUC.\n')
             return
 
-        gms_inputs_df = pd.read_csv(gms_inputs, header=None)
+        gms_inputs_df = pd.read_csv(gms_inputs, header=None, dtype={0:str,1:str})
 
         # Make copy of gms_inputs.csv
         gms_inputs_copy = os.path.splitext(gms_inputs)[0] + '_original.csv'
@@ -44,7 +44,6 @@ def remove_error_branches(logfile, gms_inputs):
 
                 huc = split[0]
                 branch = split[3]
-                huc_level = len(huc)
 
                 if huc not in first_occurrence:
                     # Ignore previous removals for this HUC
@@ -59,14 +58,13 @@ def remove_error_branches(logfile, gms_inputs):
                     shutil.rmtree(branch_dir)
 
                 # Remove bad branch from DataFrame
-                if int(branch) in gms_inputs_df.loc[:,1].values:
-                    gms_inputs_df = gms_inputs_df.drop(index=gms_inputs_df[gms_inputs_df.loc[:,1]==int(branch)].index[0])
+                if branch in gms_inputs_df.loc[:,1].values:
+                    gms_inputs_df = gms_inputs_df.drop(index=gms_inputs_df[gms_inputs_df.loc[:,1]==branch].index[0])
 
-                tmp_df = pd.DataFrame([huc.zfill(huc_level), branch]).T
                 if error_branches is None:
-                    error_branches = tmp_df
+                    error_branches = gms_inputs_df
                 else:
-                    error_branches = pd.concat([error_branches, tmp_df])
+                    error_branches = pd.concat([error_branches, gms_inputs_df])
 
         # Save list of removed branches
         pd.DataFrame(error_branches).to_csv(gms_inputs_removed, header=False, index=False)

--- a/src/gms/remove_error_branches.py
+++ b/src/gms/remove_error_branches.py
@@ -61,10 +61,11 @@ def remove_error_branches(logfile, gms_inputs):
                 if branch in gms_inputs_df.loc[:,1].values:
                     gms_inputs_df = gms_inputs_df.drop(index=gms_inputs_df[gms_inputs_df.loc[:,1]==branch].index[0])
 
+                tmp_df = pd.DataFrame([huc, branch]).T
                 if error_branches is None:
-                    error_branches = gms_inputs_df
+                    error_branches = tmp_df
                 else:
-                    error_branches = pd.concat([error_branches, gms_inputs_df])
+                    error_branches = pd.concat([error_branches, tmp_df])
 
         # Save list of removed branches
         pd.DataFrame(error_branches).to_csv(gms_inputs_removed, header=False, index=False)

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -89,6 +89,8 @@ def boxplot(dataframe, x_field, x_order, y_field, hue_field, ordered_hue, title_
                 label_dict[label] = re.split('_fr|_ms|_comp', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
                 if label.endswith('_c'):
                     label_dict[label] = label_dict[label] + ' c'
+            elif 'fim_4' in label and len(label) < 20:
+                label_dict[label] = label.replace('_','.').replace('fim.','FIM ')
             else:
                 label_dict[label] = label
         #Define simplified labels as a list.
@@ -256,6 +258,8 @@ def barplot(dataframe, x_field, x_order, y_field, hue_field, ordered_hue, title_
                 label_dict[label] = re.split('_fr|_ms|_comp', label)[0].replace('_','.').replace('fim.','FIM ') + ' ' + fim_configuration.lower()
                 if label.endswith('_c'):
                     label_dict[label] = label_dict[label] + ' c'
+            elif 'fim_4' in label and len(label) < 20:
+                label_dict[label] = label.replace('_','.').replace('fim.','FIM ')
             else:
                 label_dict[label] = label
         #Define simplified labels as a list.

--- a/tools/run_test_case.py
+++ b/tools/run_test_case.py
@@ -305,7 +305,7 @@ class test_case(benchmark):
                                     unit_attribute_name = 'huc8',
                                     nodata = elev_raster_ndv,
                                     workers = 1,
-                                    remove_inputs = False,
+                                    remove_inputs = True,
                                     subset = None,
                                     verbose = verbose )
             # FIM v3 and before

--- a/tools/synthesize_test_cases.py
+++ b/tools/synthesize_test_cases.py
@@ -99,6 +99,9 @@ def create_master_metrics_csv(master_metrics_csv_output, dev_versions_to_include
                         if iteration == "official":
                             versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'official_versions')
                             versions_to_aggregate = os.listdir(PREVIOUS_FIM_DIR)
+                            # add in composite of versions
+                            composite_versions = [v.replace('_ms', '_comp') for v in versions_to_aggregate if '_ms' in v]
+                            versions_to_aggregate += composite_versions
                         if iteration == "comparison":
                             versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'testing_versions')
                             versions_to_aggregate = dev_versions_to_include_list
@@ -154,6 +157,9 @@ def create_master_metrics_csv(master_metrics_csv_output, dev_versions_to_include
                         if iteration == "official":
                             versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'official_versions')
                             versions_to_aggregate = os.listdir(PREVIOUS_FIM_DIR)
+                            # add in composite of versions
+                            composite_versions = [v.replace('_ms', '_comp') for v in versions_to_aggregate if '_ms' in v]
+                            versions_to_aggregate += composite_versions
                         if iteration == "comparison":
                             versions_to_crawl = os.path.join(benchmark_test_case_dir, test_case, 'testing_versions')
                             versions_to_aggregate = dev_versions_to_include_list
@@ -427,7 +433,7 @@ if __name__ == '__main__':
         else:
             dev_versions_to_include_list = previous_fim_list
     if config == 'PREV':
-        dev_versions_to_include_list = []
+        dev_versions_to_include_list = dev_versions_to_compare
 
     if master_metrics_csv is not None:
         # Do aggregate_metrics.


### PR DESCRIPTION
Patches small bugs in the alpha test functionality.

## Changes

- `src/gms/remove_error_branches.py`: Specified dtype when reading the gms_inputs.csv so HUCs keep their leading zeros.
-  `tools/`
    - `eval_plots.py`: Added prettier FIM labels in the plot legend.
    - `run_test_case.py`: Set remove_inputs to True in mosaic_inundation.
    - `synthesize_test_cases.py`: Made sure that composite FIM 3 test cases are compiled with FIM 4 test cases.


