### PR TITLE
Prune branches in waterbodies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ Trims ends of branches that are in waterbodies; also removes branches if they ar
 
 ## Changes
 
-- `src/gms/stream_branches.py`: adds `trim_branches_in_waterbodies()` to prune branches in waterbodies.
+- `src/gms/stream_branches.py`: adds functionality to trim and prune branches in waterbodies.
 
 <br/><br/>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## [version to be assigned] - 2022-08-26 - [PR #671](https://github.com/NOAA-OWP/inundation-mapping/pull/671)
+## 4.0.8.0 - 2022-08-26 - [PR #671](https://github.com/NOAA-OWP/inundation-mapping/pull/671)
 
 Trims ends of branches that are in waterbodies; also removes branches if they are entirely in a waterbody.
 
@@ -10,13 +10,6 @@ Trims ends of branches that are in waterbodies; also removes branches if they ar
 - `src/gms/stream_branches.py`: adds functionality to trim and prune branches in waterbodies.
 
 <br/><br/>
-
-## v4.0.6.3 - 2022-08-04 - [PR #652](https://github.com/NOAA-OWP/inundation-mapping/pull/652)
-
-Updated `Dockerfile`, `Pipfile` and `Pipfile.lock` to add the new psycopg2 python package required for a WIP code fix for the new FIM4 calibration db.
-
-<br/><br/>
-
 
 ## v4.0.7.0 - 2022-08-17 - [PR #657](https://github.com/NOAA-OWP/inundation-mapping/pull/657)
 
@@ -54,6 +47,13 @@ Introduces synthetic rating curve calibration workflow. The calibration computes
   - `ROUGHNESS_MIN_THRESH`: min allowable adjusted roughness value (void values smaller than this)
 
 <br/><br/>
+
+## v4.0.6.3 - 2022-08-04 - [PR #652](https://github.com/NOAA-OWP/inundation-mapping/pull/652)
+
+Updated `Dockerfile`, `Pipfile` and `Pipfile.lock` to add the new psycopg2 python package required for a WIP code fix for the new FIM4 calibration db.
+
+<br/><br/>
+
 
 ## v4.0.6.2 - 2022-08-16 - [PR #639](https://github.com/NOAA-OWP/inundation-mapping/pull/639)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## [version to be assigned] - 2022-08-26 - [PR #671](https://github.com/NOAA-OWP/inundation-mapping/pull/671)
+
+Trims ends of branches that are in waterbodies; also removes branches if they are entirely in a waterbody.
+
+## Changes
+
+- `src/gms/stream_branches.py`: adds `trim_branches_in_waterbodies()` to prune branches in waterbodies.
+
+<br/><br/>
+
 ## v4.0.6.3 - 2022-08-04 - [PR #652](https://github.com/NOAA-OWP/inundation-mapping/pull/652)
 
 Updated `Dockerfile`, `Pipfile` and `Pipfile.lock` to add the new psycopg2 python package required for a WIP code fix for the new FIM4 calibration db.

--- a/src/gms/derive_level_paths.py
+++ b/src/gms/derive_level_paths.py
@@ -101,7 +101,7 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
                                                             verbose=verbose
                                                            )
     
-    # filter out streams with out catchments
+    # filter out streams without catchments
     if (catchments is not None) & (catchments_outfile is not None):
 
         catchments = gpd.read_file(catchments)
@@ -137,16 +137,20 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
                                                         outlet_linestring_index=outlet_linestring_index
                                                        )
         # headwaters write
-        headwaters.to_file(headwaters_outfile,index=False,driver='GPKG')
+        headwaters.to_file(headwaters_outfile, index=False, driver='GPKG')
 
-    
     if out_stream_network is not None:
         if verbose:
             print("Writing stream branches ...")
-        stream_network.write(out_stream_network,index=True)
+        stream_network.write(out_stream_network, index=True)
     
     if out_stream_network_dissolved is not None:
     
+        stream_network = stream_network.trim_branches_in_waterbodies(waterbodies,
+                                                    branch_id_attribute=branch_id_attribute,
+                                                    verbose=verbose
+                                                                    )
+
         # dissolve by levelpath
         stream_network = stream_network.dissolve_by_branch(branch_id_attribute=branch_id_attribute,
                                                            attribute_excluded=None, #'order_',
@@ -158,13 +162,8 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
         if waterbodies is not None:
             waterbodies = gpd.read_file(waterbodies)
 
-            stream_network = stream_network.remove_branches_in_waterbodies(waterbodies,
-                                                                out_vector_files=out_stream_network_dissolved,
-                                                                verbose=verbose
-                                                                              )
-
-        branch_inlets = stream_network.derive_inlet_points_by_feature( feature_attribute=branch_id_attribute,
-                                                                       outlet_linestring_index=outlet_linestring_index
+        branch_inlets = stream_network.derive_inlet_points_by_feature(feature_attribute=branch_id_attribute,
+                                                                      outlet_linestring_index=outlet_linestring_index
                                                                      )
    
         if branch_inlets_outfile is not None:

--- a/src/gms/derive_level_paths.py
+++ b/src/gms/derive_level_paths.py
@@ -103,7 +103,6 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
     
     # filter out streams without catchments
     if (catchments is not None) & (catchments_outfile is not None):
-
         catchments = gpd.read_file(catchments)
 
         stream_network = stream_network.remove_branches_without_catchments( 
@@ -145,9 +144,7 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
         stream_network.write(out_stream_network, index=True)
     
     if out_stream_network_dissolved is not None:
-    
-        stream_network = stream_network.trim_branches_in_waterbodies(waterbodies,
-                                                    branch_id_attribute=branch_id_attribute,
+        stream_network = stream_network.trim_branches_in_waterbodies(branch_id_attribute=branch_id_attribute,
                                                     verbose=verbose
                                                                     )
 
@@ -158,10 +155,10 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
                                                            out_vector_files=out_stream_network_dissolved,
                                                            verbose=verbose)
 
-        # filter out streams in waterbodies
-        if waterbodies is not None:
-            waterbodies = gpd.read_file(waterbodies)
-
+        stream_network = stream_network.remove_branches_in_waterbodies(waterbodies=waterbodies,
+                                                                       verbose=False
+                                                                      )
+                                       
         branch_inlets = stream_network.derive_inlet_points_by_feature(feature_attribute=branch_id_attribute,
                                                                       outlet_linestring_index=outlet_linestring_index
                                                                      )

--- a/src/gms/derive_level_paths.py
+++ b/src/gms/derive_level_paths.py
@@ -9,7 +9,7 @@ from utils.fim_enums import FIM_exit_codes
 
 def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribute,
                        out_stream_network_dissolved=None, huc_id=None,
-                       headwaters_outfile=None, catchments=None,
+                       headwaters_outfile=None, catchments=None, waterbodies=None,
                        catchments_outfile=None,
                        branch_inlets_outfile=None,
                        toNode_attribute='To_Node', fromNode_attribute='From_Node',
@@ -154,6 +154,15 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
                                                            out_vector_files=out_stream_network_dissolved,
                                                            verbose=verbose)
 
+        # filter out streams in waterbodies
+        if waterbodies is not None:
+            waterbodies = gpd.read_file(waterbodies)
+
+            stream_network = stream_network.remove_branches_in_waterbodies(waterbodies,
+                                                                out_vector_files=out_stream_network_dissolved,
+                                                                verbose=verbose
+                                                                              )
+
         branch_inlets = stream_network.derive_inlet_points_by_feature( feature_attribute=branch_id_attribute,
                                                                        outlet_linestring_index=outlet_linestring_index
                                                                      )
@@ -174,6 +183,7 @@ if __name__ == '__main__':
     parser.add_argument('-r','--reach-id-attribute', help='Reach ID attribute to use in source file', required=False, default='HydroID')
     parser.add_argument('-c','--catchments', help='NWM catchments to append level path data to', required=False, default=None)
     parser.add_argument('-t','--catchments-outfile', help='NWM catchments outfile with appended level path data', required=False, default=None)
+    parser.add_argument('-w','--waterbodies', help='NWM waterbodies to eliminate branches from', required=False, default=None)
     parser.add_argument('-n','--branch_inlets_outfile', help='Output level paths inlets', required=False, default=None)
     parser.add_argument('-o','--out-stream-network', help='Output stream network', required=False, default=None)
     parser.add_argument('-e','--headwaters-outfile', help='Output stream network headwater points', required=False, default=None)

--- a/src/gms/derive_level_paths.py
+++ b/src/gms/derive_level_paths.py
@@ -156,6 +156,7 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
                                                            verbose=verbose)
 
         stream_network = stream_network.remove_branches_in_waterbodies(waterbodies=waterbodies,
+                                                                       out_vector_files=out_stream_network_dissolved,
                                                                        verbose=False
                                                                       )
                                        

--- a/src/gms/run_by_unit.sh
+++ b/src/gms/run_by_unit.sh
@@ -83,7 +83,7 @@ Tcount
 echo -e $startDiv"Generating Level Paths for $hucNumber"$stopDiv
 date -u
 Tstart
-$srcDir/gms/derive_level_paths.py -i $outputHucDataDir/nwm_subset_streams.gpkg -b $branch_id_attribute -r "ID" -o $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg -d $outputHucDataDir/nwm_subset_streams_levelPaths_dissolved.gpkg -e $outputHucDataDir/nwm_headwaters.gpkg -c $outputHucDataDir/nwm_catchments_proj_subset.gpkg -t $outputHucDataDir/nwm_catchments_proj_subset_levelPaths.gpkg -n $outputHucDataDir/nwm_subset_streams_levelPaths_dissolved_headwaters.gpkg -v -s $dropLowStreamOrders
+$srcDir/gms/derive_level_paths.py -i $outputHucDataDir/nwm_subset_streams.gpkg -b $branch_id_attribute -r "ID" -o $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg -d $outputHucDataDir/nwm_subset_streams_levelPaths_dissolved.gpkg -e $outputHucDataDir/nwm_headwaters.gpkg -c $outputHucDataDir/nwm_catchments_proj_subset.gpkg -t $outputHucDataDir/nwm_catchments_proj_subset_levelPaths.gpkg -n $outputHucDataDir/nwm_subset_streams_levelPaths_dissolved_headwaters.gpkg -v -s $dropLowStreamOrders -w $outputHucDataDir/nwm_lakes_proj_subset.gpkg
 
 # test if we received a non-zero code back from derive_level_paths.py
 subscript_exit_code=$?

--- a/src/gms/stream_branches.py
+++ b/src/gms/stream_branches.py
@@ -160,11 +160,11 @@ class StreamNetwork(gpd.GeoDataFrame):
         return(self)
 
 
-    def to_gdf(self,*args,**kwargs):
+    def to_df(self,*args,**kwargs):
 
         """ Converts back to dataframe """
         
-        self = gpd.GeoDataFrame(self,*args,**kwargs)
+        self = pd.DataFrame(self,*args,**kwargs)
 
         return(self)
 

--- a/src/gms/stream_branches.py
+++ b/src/gms/stream_branches.py
@@ -291,7 +291,6 @@ class StreamNetwork(gpd.GeoDataFrame):
         self.loc[:,fromNode_attribute] = fromNodes
         self.loc[:,toNode_attribute] = toNodes
         
-        
         return(self)
 
 
@@ -386,7 +385,7 @@ class StreamNetwork(gpd.GeoDataFrame):
         if verbose:
             print("Removing stream segments without catchments ...")
 
-        # load cathments
+        # load catchments
         if isinstance(catchments,gpd.GeoDataFrame):
             pass
         elif isinstance(catchments,str):
@@ -413,8 +412,8 @@ class StreamNetwork(gpd.GeoDataFrame):
         if verbose:
             print("Removing stream branches without catchments ...")
 
-        # load cathments
-        if isinstance(catchments,gpd.GeoDataFrame):
+        # load catchments
+        if isinstance(catchments, gpd.GeoDataFrame):
             pass
         elif isinstance(catchments,str):
             catchments = gpd.read_file(catchments)
@@ -425,7 +424,7 @@ class StreamNetwork(gpd.GeoDataFrame):
         unique_catchments = set(catchments.loc[:,reach_id_attribute_in_catchments].unique())
 
         current_index_name = self.index.name
-        self.set_index(branch_id_attribute,drop=False,inplace=True)
+        self.set_index(branch_id_attribute, drop=False, inplace=True)
 
         for usb in unique_stream_branches:
 
@@ -439,9 +438,9 @@ class StreamNetwork(gpd.GeoDataFrame):
                 self.drop(usb,inplace=True)
 
         if current_index_name is None:
-            self.reset_index(drop=True,inplace=True)
+            self.reset_index(drop=True, inplace=True)
         else:
-            self.set_index(current_index_name,drop=True,inplace=True)
+            self.set_index(current_index_name, drop=True, inplace=True)
 
         return(self)
 
@@ -517,6 +516,7 @@ class StreamNetwork(gpd.GeoDataFrame):
 
     def remove_branches_in_waterbodies(self,
                                        waterbodies,
+                                       out_vector_files=None,
                                        verbose=False
                                        ):
         """
@@ -537,6 +537,13 @@ class StreamNetwork(gpd.GeoDataFrame):
         # Find branches in waterbodies
         sjoined = gpd.sjoin(self, waterbodies, op='within')
         self.drop(sjoined.index, inplace=True)
+
+        if out_vector_files is not None:
+            
+            if verbose:
+                print("Writing pruned branches ...")
+            
+            self.write(out_vector_files, index=False)
 
         return(self)
 
@@ -742,8 +749,8 @@ class StreamNetwork(gpd.GeoDataFrame):
         return(self)
 
 
-    def dissolve_by_branch(self,branch_id_attribute='LevelPathI',attribute_excluded='StreamOrde',
-                           values_excluded=[1,2],out_vector_files=None, verbose=False):
+    def dissolve_by_branch(self, branch_id_attribute='LevelPathI', attribute_excluded='StreamOrde',
+                           values_excluded=[1,2], out_vector_files=None, verbose=False):
         
         if verbose:
             print("Dissolving by branch ...")
@@ -795,7 +802,7 @@ class StreamNetwork(gpd.GeoDataFrame):
                 #current_stream_network = StreamNetwork(self.loc[bid_indices,:])
 
                 #current_stream_network.write(out_vector_file,index=False)
-            self.write(out_vector_files,index=False)
+            self.write(out_vector_files, index=False)
 
         return(self)
 

--- a/src/gms/stream_branches.py
+++ b/src/gms/stream_branches.py
@@ -447,7 +447,6 @@ class StreamNetwork(gpd.GeoDataFrame):
 
 
     def trim_branches_in_waterbodies(self,
-                                       waterbodies,
                                        branch_id_attribute,
                                        verbose=False
                                        ):
@@ -489,14 +488,6 @@ class StreamNetwork(gpd.GeoDataFrame):
         if verbose:
             print("Trimming stream branches in waterbodies ...")
 
-        # load waterbodies
-        if isinstance(waterbodies,gpd.GeoDataFrame):
-            pass
-        elif isinstance(waterbodies,str):
-            waterbodies = gpd.read_file(waterbodies)
-        else:
-            raise TypeError("Waterbodies needs to be GeoDataFame or path to vector file")
-
         for branch in self[branch_id_attribute].unique():
             tmp_self = self[self[branch_id_attribute]==branch]
 
@@ -520,6 +511,32 @@ class StreamNetwork(gpd.GeoDataFrame):
 
             if len(tmp_IDs) > 0:
                 self.drop(tmp_self[tmp_self.ID.isin(tmp_IDs)].index, inplace=True)
+
+        return(self)
+
+
+    def remove_branches_in_waterbodies(self,
+                                       waterbodies,
+                                       verbose=False
+                                       ):
+        """
+        Removes branches completely in waterbodies
+        """
+
+        if verbose:
+            print('Removing branches in waterbodies')
+
+        # load waterbodies
+        if isinstance(waterbodies,gpd.GeoDataFrame):
+            pass
+        elif isinstance(waterbodies,str):
+            waterbodies = gpd.read_file(waterbodies)
+        else:
+            raise TypeError("Waterbodies needs to be GeoDataFame or path to vector file")
+
+        # Find branches in waterbodies
+        sjoined = gpd.sjoin(self, waterbodies, op='within')
+        self.drop(sjoined.index, inplace=True)
 
         return(self)
 


### PR DESCRIPTION
Prunes branches in waterbodies

Recursively trims upstream and downstream ends of branches if they are associated with a lake feature, also removes branches entirely if they are completely in a waterbody. Closes #663.

## Additions

- `src/gms/stream_branches.py`: added `trim_branches_in_waterbodies()` and `remove_branches_in_waterbodies()`

## Testing

1. Ran `gms_run_unit.sh` and `gms_run_branch.sh` on HUCs 05130103, 06030002, 07140106, and 11100301

## Screenshots
Colored lines: branches, dashed red lines: pruned segments, blue polygons: lakes, black border: HUC8 boundary
HUC 05130103
<img width="687" alt="image" src="https://user-images.githubusercontent.com/6616694/186892863-9d5a736c-eb59-4e20-b1c5-f485c16d0714.png">

HUC 06030002
<img width="789" alt="image" src="https://user-images.githubusercontent.com/6616694/186894188-9fe59ac2-732f-4da4-a175-0b1a24d9b679.png">

HUC 07140106
<img width="541" alt="image" src="https://user-images.githubusercontent.com/6616694/186894755-3325eef0-2167-4f8d-b58d-f4f2a76715da.png">

HUC 11100301
<img width="786" alt="image" src="https://user-images.githubusercontent.com/6616694/186895331-6303e169-1831-4631-9df4-a045bf3bbbb7.png">
