### PR TITLE
[1pt] PR: Update derive level paths to use stream order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,12 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 4.0.9.0 - 2022-09-09 - [PR #672](https://github.com/NOAA-OWP/inundation-mapping/pull/672)
+
+When deriving level paths, this improvement allows stream order to override arbolate sum when selecting the proper upstream segment to continue the current branch.
+
+<br/><br/>
+
 ## 4.0.8.0 - 2022-08-26 - [PR #671](https://github.com/NOAA-OWP/inundation-mapping/pull/671)
 
 Trims ends of branches that are in waterbodies; also removes branches if they are entirely in a waterbody.

--- a/src/gms/derive_level_paths.py
+++ b/src/gms/derive_level_paths.py
@@ -96,7 +96,7 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
                                                             upstreams=upstreams,
                                                             branch_id_attribute=branch_id_attribute,
                                                             reach_id_attribute=reach_id_attribute,
-                                                            comparison_attributes='arbolate_sum',
+                                                            comparison_attributes=['arbolate_sum', 'order_'],
                                                             comparison_function=max,
                                                             verbose=verbose
                                                            )

--- a/unit_tests/gms/derive_level_paths_unittests.py
+++ b/unit_tests/gms/derive_level_paths_unittests.py
@@ -16,7 +16,7 @@ from unit_tests_utils import FIM_unit_test_helpers as ut_helpers
 sys.path.append('/foss_fim/src/gms/')
 import derive_level_paths as src
 import stream_branches
-from utils.fim_enums import FIM_system_exit_codes as fec
+from utils.fim_enums import FIM_exit_codes as fec
 
 
 # NOTE: This goes directly to the function.


### PR DESCRIPTION
When deriving level paths using only arbolate sum, branches end up veering off the main river near the upstream HUC8 boundary because the main river has a lower arbolate sum due to being cut off at the WBD. This improvement uses stream order to override that behavior so that the branch stays on the main river. Addresses #660.

## Changes

- `src/gms/`
    - `derive_level_paths.py`: Added `order_` to the list of comparison_attributes in the `derive_stream_branches` method.
    - `stream_branches.py`: Updated the `derive_stream_branches` method to first consider stream order when choosing which upstream segment to continue the current level path. If both upstream segment have the same order, then arbolate sum is used.
-  `unit_tests/gms/derive_level_paths_unittests.py`: Updated the import to the new class.

## Testing

1. This PR has been tested on the benchmark hucs using the following command:
```
gms_pipeline.sh -u /data/inputs/huc_lists/all_eval_hucs_20220506.lst -n carson_order_test -j 80
```

## Screenshots
BEFORE: The main branch (blue) veers off to the northern tributary because it has a higher arbolate sum.
![image](https://user-images.githubusercontent.com/90792257/186924167-8cd66e1b-a0f7-49b5-a795-b36c5aae777c.png)

AFTER: The main branch (blue) continues on the larger river because its higher stream order now overrides the lower arbolate sum.
![image](https://user-images.githubusercontent.com/90792257/186924035-2add75fe-6157-4c02-90d0-0019534fe22c.png)

The issues we were seeing with `shlt2` are fixed by this PR. (see screenshot in #660)
![image](https://user-images.githubusercontent.com/90792257/187722531-06d01c30-8cb6-4b02-8d7f-4f464aa5793a.png)



