### PR TITLE
[1pt] fixes for calib system, landSea deny list and params

### DIFF
--- a/config/deny_gms_unit_prod.lst
+++ b/config/deny_gms_unit_prod.lst
@@ -3,7 +3,7 @@
 NHDPlusBurnLineEvent_subset.gpkg
 #branch_id.lst
 #branch_polygons.gpkg
-LandSea_subset.gpkg
+#LandSea_subset.gpkg
 nhd_headwater_points_subset.gpkg
 #nld_subset_levees.gpkg
 #nwm_catchments_proj_subset.gpkg

--- a/config/params_template.env
+++ b/config/params_template.env
@@ -57,7 +57,7 @@ export src_adjust_usgs="True" # Toggle to run src adjustment routine (True=on; F
 export nwm_recur_file="data/inputs/rating_curve/nwm_recur_flows/nwm21_17C_recurrence_flows_cfs.csv" # input file location with nwm feature_id and recurrence flow values
 
 #### apply SRC adjustments using observed FIM/flow point database ####
-export src_adjust_spatial="False" # Toggle to run src adjustment routine (True=on; False=off)
+export src_adjust_spatial="True" # Toggle to run src adjustment routine (True=on; False=off)
 export fim_obs_pnt_data="data/inputs/rating_curve/water_edge_database/usgs_nws_benchmark_points_cleaned.gpkg"
 #### path to env file with sensitive paths for accessing postgres database ####
 export CALB_DB_KEYS_FILE="/data/config/calb_db_keys.env"

--- a/gms_run_branch.sh
+++ b/gms_run_branch.sh
@@ -163,6 +163,10 @@ elif [ $overwrite -eq 1 ]; then
     mkdir -p $outputRunDataDir/branch_errors
 fi
 
+## Track total time of the overall run
+T_total_start
+Tstart
+
 ## CONNECT TO CALIBRATION POSTGRESQL DATABASE (OPTIONAL) ##
 if [ "$src_adjust_spatial" = "True" ]; then
     if [ ! -f $CALB_DB_KEYS_FILE ]; then
@@ -178,13 +182,14 @@ if [ "$src_adjust_spatial" = "True" ]; then
     fi
 fi
 
+Tcount
+Tstart
+date -u
+
 ## RUN GMS BY BRANCH ##
 echo "=========================================================================="
 echo "Start of branch processing"
 echo "Started: `date -u`" 
-
-## Track total time of the overall run
-T_total_start
 Tstart
 
 if [ "$jobLimit" -eq 1 ]; then
@@ -206,15 +211,21 @@ python3 $srcDir/usgs_gage_aggregate.py -fim $outputRunDataDir -gms $gms_inputs
 
 ## RUN SYNTHETIC RATING CURVE CALIBRATION W/ USGS GAGE RATING CURVES ##
 if [ "$src_adjust_usgs" = "True" ]; then
+    Tstart
     echo -e $startDiv"Performing SRC adjustments using USGS rating curve database"$stopDiv
     # Run SRC Optimization routine using USGS rating curve data (WSE and flow @ NWM recur flow thresholds)
-    time python3 $srcDir/src_adjust_usgs_rating.py -run_dir $outputRunDataDir -usgs_rc $inputDataDir/usgs_gages/usgs_rating_curves.csv -nwm_recur $nwm_recur_file -j $jobLimit
+    python3 $srcDir/src_adjust_usgs_rating.py -run_dir $outputRunDataDir -usgs_rc $inputDataDir/usgs_gages/usgs_rating_curves.csv -nwm_recur $nwm_recur_file -j $jobLimit
+    Tcount
+    date -u
 fi
 
 ## RUN SYNTHETIC RATING CURVE CALIBRATION W/ BENCHMARK POINT DATABASE (POSTGRESQL) ##
 if [ "$src_adjust_spatial" = "True" ]; then
+    Tstart
     echo -e $startDiv"Performing SRC adjustments using benchmark point database"$stopDiv
-    time python3 $srcDir/src_adjust_spatial_obs.py -fim_dir $outputRunDataDir -j $jobLimit
+    python3 $srcDir/src_adjust_spatial_obs.py -fim_dir $outputRunDataDir -j $jobLimit
+    Tcount
+    date -u
 fi
 
 # -------------------


### PR DESCRIPTION
Comment out LandSea_subset.gpkg in deny_gms_unit_prod.lst so it does not get deleted. Some branches need it for processing.

Also.. change default for params_template.env -> src_adjust_spatial="False", back to default of "True"

During fixing this issue, Ryan and I found a couple of others related to the calib system and are now fixed in this PR.

Ryan helped fix src_adjust_usgs_rating.py and src_adjust_usgs_rating.py. It was discovered if you are processing just one huc that is not in the calibration database, it would fail (yes. some hucs will not be in the db). We also discovered and fixed an infinite loop where it attempts to call the calib database but can not connect. Now, it will make 6 attempts to connect and will abort attempts to connect (instead of indefinitely trying to connect.

## Changes

-

## Testing

To test the HUC not in the calib db, we used HUC 02060001 which does not/will not have data in the calib db.  It can also be used to test the missing LandSea file.  When you run this with this fix, in the unit folder, you will see the LandSea_subset.gpkg now exists, and in fim 4.0.9.4, this file would be missing.

To test the fix for the infinite loop, we commented out the code in gms_run_branch.sh for the code block "## CONNECT TO CALIBRATION POSTGRESQL DATABASE (OPTIONAL) ##" as a quick failed database connection emulator, then ran it.  There are multiple ways to emulate the db not being available, this being one. 

Also.. by default, the calib system should now fully run as expected.
