### PR TITLE
[1pt] PR: Port thalweg notch fix from FIM3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## V4.[version number to be assigned] - 2022-10-19 - [PR #718](https://github.com/NOAA-OWP/inundation-mapping/pull/718)
+
+Fixes thalweg notch by clipping upstream ends of the stream segments to prevent the stream network from reaching the edge of the DEM and being treated as outlets when pit filling the burned DEM.
+
+### Changes
+
+- `src/clip_vectors_to_wbd.py`: Uses a slightly smaller buffer than wbd_buffer (wbd_buffer_distance-2*(DEM cell size)) to clip stream network inside of DEM extent.
+
+<br/><br/>
+
 ## v4.0.10.1 - 2022-10-5 - [PR #695](https://github.com/NOAA-OWP/inundation-mapping/pull/695)
 
 This hotfix address a bug with how the rating curve comparison (sierra test) handles the branch zero synthetic rating curve in the comparison plots. Address #676 

--- a/src/clip_vectors_to_wbd.py
+++ b/src/clip_vectors_to_wbd.py
@@ -1,54 +1,68 @@
 #!/usr/bin/env python3
 
+import os
 import sys
+import pandas as pd
 import geopandas as gpd
 import argparse
 from shapely.geometry import MultiPolygon,Polygon
 from utils.shared_functions import getDriver, mem_profile
-
+import rasterio as rio
 
 @mem_profile
-def subset_vector_layers(hucCode,nwm_streams_filename,nhd_streams_filename,nwm_lakes_filename,nld_lines_filename,nwm_catchments_filename,nhd_headwaters_filename,landsea_filename,wbd_filename,wbd_buffer_filename,subset_nhd_streams_filename,subset_nld_lines_filename,subset_nwm_lakes_filename,subset_nwm_catchments_filename,subset_nhd_headwaters_filename,subset_nwm_streams_filename,subset_landsea_filename,extent,great_lakes_filename,wbd_buffer_distance,lake_buffer_distance):
+def subset_vector_layers(hucCode, nwm_streams_filename, nhd_streams_filename, nwm_lakes_filename, nld_lines_filename, nwm_catchments_filename, nhd_headwaters_filename, landsea_filename, wbd_filename, wbd_buffer_filename, subset_nhd_streams_filename, subset_nld_lines_filename, subset_nwm_lakes_filename, subset_nwm_catchments_filename, subset_nhd_headwaters_filename, subset_nwm_streams_filename, subset_landsea_filename, great_lakes_filename, wbd_buffer_distance, lake_buffer_distance, dem_filename):
 
     hucUnitLength = len(str(hucCode))
+
+    with rio.open(dem_filename) as dem_raster:
+        dem_cellsize = max(dem_raster.res)
 
     # Get wbd buffer
     wbd = gpd.read_file(wbd_filename)
     wbd_buffer = wbd.copy()
-    wbd_buffer.geometry = wbd.geometry.buffer(wbd_buffer_distance,resolution=32)
-    projection = wbd_buffer.crs
+    wbd_buffer.geometry = wbd.geometry.buffer(wbd_buffer_distance, resolution=32)
 
-    great_lakes = gpd.read_file(great_lakes_filename, mask = wbd_buffer).reset_index(drop=True)
+    # Make the streams buffer smaller than the wbd_buffer so streams don't reach the edge of the DEM
+    wbd_buffer_filename_split = os.path.splitext(wbd_buffer_filename)
+    wbd_streams_buffer_filename = wbd_buffer_filename_split[0] + '_streams' + wbd_buffer_filename_split[1]
+    wbd_streams_buffer = wbd.copy()
+    wbd_streams_buffer.geometry = wbd.geometry.buffer(wbd_buffer_distance-3*dem_cellsize, resolution=32)
+
+    # projection = wbd_buffer.crs
+
+    great_lakes = gpd.read_file(great_lakes_filename, mask=wbd_buffer).reset_index(drop=True)
 
     if not great_lakes.empty:
-        print("Masking Great Lakes for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
+        print("Masking Great Lakes for HUC{} {}".format(hucUnitLength, hucCode), flush=True)
 
         # Clip excess lake area
         great_lakes = gpd.clip(great_lakes, wbd_buffer)
+        great_lakes_streams = gpd.clip(great_lakes, wbd_streams_buffer)
 
         # Buffer remaining lake area
         great_lakes.geometry = great_lakes.buffer(lake_buffer_distance)
+        great_lakes_streams.geometry = great_lakes_streams.buffer(lake_buffer_distance)
 
         # Removed buffered GL from WBD buffer
         wbd_buffer = gpd.overlay(wbd_buffer, great_lakes, how='difference')
-        wbd_buffer = wbd_buffer[['geometry']]
-        wbd_buffer.to_file(wbd_buffer_filename,driver=getDriver(wbd_buffer_filename),index=False)
+        wbd_streams_buffer = gpd.overlay(wbd_streams_buffer, great_lakes, how='difference')
 
-    else:
-        wbd_buffer = wbd_buffer[['geometry']]
-        wbd_buffer.to_file(wbd_buffer_filename,driver=getDriver(wbd_buffer_filename),index=False)
+    wbd_buffer = wbd_buffer[['geometry']]
+    wbd_streams_buffer = wbd_streams_buffer[['geometry']]
+    wbd_buffer.to_file(wbd_buffer_filename, driver=getDriver(wbd_buffer_filename), index=False)
+    wbd_streams_buffer.to_file(wbd_streams_buffer_filename, driver=getDriver(wbd_buffer_filename), index=False)
 
     del great_lakes
 
     # Clip ocean water polygon for future masking ocean areas (where applicable)
-    landsea = gpd.read_file(landsea_filename, mask = wbd_buffer)
+    landsea = gpd.read_file(landsea_filename, mask=wbd_buffer)
     if not landsea.empty:
-        landsea.to_file(subset_landsea_filename,driver=getDriver(subset_landsea_filename),index=False)
+        landsea.to_file(subset_landsea_filename, driver=getDriver(subset_landsea_filename), index=False)
     del landsea
 
     # Find intersecting lakes and writeout
     print("Subsetting NWM Lakes for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
-    nwm_lakes = gpd.read_file(nwm_lakes_filename, mask = wbd_buffer)
+    nwm_lakes = gpd.read_file(nwm_lakes_filename, mask=wbd_buffer)
     nwm_lakes = nwm_lakes.loc[nwm_lakes.Shape_Area < 18990454000.0]
 
     if not nwm_lakes.empty:
@@ -58,90 +72,66 @@ def subset_vector_layers(hucCode,nwm_streams_filename,nhd_streams_filename,nwm_l
         # Loop through the filled polygons and insert the new geometry
         for i in range(len(nwm_lakes_fill_holes)):
             nwm_lakes.loc[i,'geometry'] = nwm_lakes_fill_holes[i]
-        nwm_lakes.to_file(subset_nwm_lakes_filename,driver=getDriver(subset_nwm_lakes_filename),index=False)
+        nwm_lakes.to_file(subset_nwm_lakes_filename, driver=getDriver(subset_nwm_lakes_filename), index=False)
     del nwm_lakes
 
     # Find intersecting levee lines
-    print("Subsetting NLD levee lines for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
-    nld_lines = gpd.read_file(nld_lines_filename, mask = wbd_buffer)
+    print("Subsetting NLD levee lines for HUC{} {}".format(hucUnitLength, hucCode), flush=True)
+    nld_lines = gpd.read_file(nld_lines_filename, mask=wbd_buffer)
     if not nld_lines.empty:
-        nld_lines.to_file(subset_nld_lines_filename,driver=getDriver(subset_nld_lines_filename),index=False)
+        nld_lines.to_file(subset_nld_lines_filename, driver=getDriver(subset_nld_lines_filename), index=False)
     del nld_lines
 
     # Subset nhd headwaters
-    print("Subsetting NHD Headwater Points for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
-    nhd_headwaters = gpd.read_file(nhd_headwaters_filename, mask = wbd_buffer)
-    if extent == 'MS':
-        nhd_headwaters = nhd_headwaters.loc[nhd_headwaters.mainstem==1]
+    print("Subsetting NHD Headwater Points for HUC{} {}".format(hucUnitLength, hucCode), flush=True)
+    nhd_headwaters = gpd.read_file(nhd_headwaters_filename, mask=wbd_streams_buffer)
 
     if len(nhd_headwaters) > 0:
-        nhd_headwaters.to_file(subset_nhd_headwaters_filename,driver=getDriver(subset_nhd_headwaters_filename),index=False)
+        nhd_headwaters.to_file(subset_nhd_headwaters_filename, driver=getDriver(subset_nhd_headwaters_filename), index=False)
     else:
-        print ("No headwater point(s) within HUC " + str(hucCode) +  " boundaries.")
+        print ("No headwater point(s) within HUC " + str(hucCode) + " boundaries.")
         sys.exit(0)
     del nhd_headwaters
 
     # Subset nhd streams
-    print("Querying NHD Streams for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
-    nhd_streams = gpd.read_file(nhd_streams_filename, mask = wbd_buffer)
-
-    if extent == 'MS':
-        nhd_streams = nhd_streams.loc[nhd_streams.mainstem==1]
+    print("Querying NHD Streams for HUC{} {}".format(hucUnitLength, hucCode), flush=True)
+    nhd_streams = gpd.read_file(nhd_streams_filename, mask=wbd_streams_buffer)
 
     if len(nhd_streams) > 0:
-
-        # Find incoming stream segments (to WBD buffer) and identify which are upstream
-        threshold_segments = gpd.overlay(nhd_streams, wbd_buffer, how='symmetric_difference')
-        from_list = threshold_segments.FromNode.to_list()
-        to_list = nhd_streams.ToNode.to_list()
-        missing_segments = list(set(from_list) - set(to_list))
-
-        # special case: stream meanders in and out of WBD buffer boundary
-        if str(hucCode) == '10030203':
-            missing_segments = missing_segments + [23001300001840.0, 23001300016571.0]
-            
-        if str(hucCode) == '08030100':
-            missing_segments = missing_segments + [20000600011559.0, 20000600045761.0, 20000600002821.0]
-
-        # Remove incoming stream segment so it won't be routed as outflow during hydroconditioning
-        nhd_streams = nhd_streams.loc[~nhd_streams.FromNode.isin(missing_segments)]
+        nhd_streams = gpd.clip(nhd_streams, wbd_streams_buffer)
 
         nhd_streams.to_file(subset_nhd_streams_filename,driver=getDriver(subset_nhd_streams_filename),index=False)
     else:
-        print ("No NHD streams within HUC " + str(hucCode) +  " boundaries.")
+        print ("No NHD streams within HUC " + str(hucCode) + " boundaries.")
         sys.exit(0)
     del nhd_streams
 
     # Find intersecting nwm_catchments
-    print("Subsetting NWM Catchments for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
-    nwm_catchments = gpd.read_file(nwm_catchments_filename, mask = wbd_buffer)
-    if extent == 'MS':
-        nwm_catchments = nwm_catchments.loc[nwm_catchments.mainstem==1]
+    print("Subsetting NWM Catchments for HUC{} {}".format(hucUnitLength, hucCode), flush=True)
+    nwm_catchments = gpd.read_file(nwm_catchments_filename, mask=wbd_buffer)
 
     if len(nwm_catchments) > 0:
-        nwm_catchments.to_file(subset_nwm_catchments_filename,driver=getDriver(subset_nwm_catchments_filename),index=False)
+        nwm_catchments.to_file(subset_nwm_catchments_filename, driver=getDriver(subset_nwm_catchments_filename), index=False)
     else:
-        print ("No NHD catchments within HUC " + str(hucCode) +  " boundaries.")
+        print ("No NHD catchments within HUC " + str(hucCode) + " boundaries.")
         sys.exit(0)
     del nwm_catchments
 
     # Subset nwm streams
-    print("Subsetting NWM Streams and deriving headwaters for HUC{} {}".format(hucUnitLength,hucCode),flush=True)
-    if extent == 'GMS':
-        nwm_streams = gpd.read_file(nwm_streams_filename, mask = wbd)
-        nwm_streams = gpd.clip(nwm_streams,wbd)
-    else:
-        nwm_streams = gpd.read_file(nwm_streams_filename, mask = wbd_buffer)
+    print("Subsetting NWM Streams and deriving headwaters for HUC{} {}".format(hucUnitLength, hucCode), flush=True)
+
+    nwm_streams = gpd.read_file(nwm_streams_filename, mask = wbd)
+    nwm_streams = gpd.clip(nwm_streams, wbd)
 
      # NWM can have duplicate records, but appear to always be identical duplicates
     nwm_streams.drop_duplicates(subset="ID", keep="first", inplace=True)
 
-    if extent == 'MS':
-        nwm_streams = nwm_streams.loc[nwm_streams.mainstem==1]
     if len(nwm_streams) > 0:
-        nwm_streams.to_file(subset_nwm_streams_filename,driver=getDriver(subset_nwm_streams_filename),index=False)
+        nwm_streams = gpd.clip(nwm_streams, wbd_streams_buffer)
+
+        nwm_streams.to_file(subset_nwm_streams_filename, driver=getDriver(subset_nwm_streams_filename), index=False)
     else:
-        print ("No NWM stream segments within HUC " + str(hucCode) +  " boundaries.")
+        print ("No NWM stream segments within HUC " + str(hucCode) + " boundaries.")
         sys.exit(0)
     del nwm_streams
 
@@ -154,22 +144,22 @@ if __name__ == '__main__':
     parser.add_argument('-s','--nhd-streams',help='NHDPlus HR burnline',required=True)
     parser.add_argument('-l','--nwm-lakes', help='NWM Lakes', required=True)
     parser.add_argument('-r','--nld-lines', help='Levee vectors to use within project path', required=True)
-    parser.add_argument('-g','--wbd',help='HUC boundary',required=True)
-    parser.add_argument('-f','--wbd-buffer',help='Buffered HUC boundary',required=True)
+    parser.add_argument('-g','--wbd', help='HUC boundary', required=True)
+    parser.add_argument('-i','--dem-filename', help='DEM filename', required=True)
+    parser.add_argument('-f','--wbd-buffer', help='Buffered HUC boundary', required=True)
     parser.add_argument('-m','--nwm-catchments', help='NWM catchments', required=True)
-    parser.add_argument('-y','--nhd-headwaters',help='NHD headwaters',required=True)
-    parser.add_argument('-v','--landsea',help='LandSea - land boundary',required=True)
-    parser.add_argument('-c','--subset-nhd-streams',help='NHD streams subset',required=True)
-    parser.add_argument('-z','--subset-nld-lines',help='Subset of NLD levee vectors for HUC',required=True)
-    parser.add_argument('-a','--subset-lakes',help='NWM lake subset',required=True)
-    parser.add_argument('-n','--subset-catchments',help='NWM catchments subset',required=True)
-    parser.add_argument('-e','--subset-nhd-headwaters',help='NHD headwaters subset',required=True,default=None)
-    parser.add_argument('-b','--subset-nwm-streams',help='NWM streams subset',required=True)
-    parser.add_argument('-x','--subset-landsea',help='LandSea subset',required=True)
-    parser.add_argument('-extent','--extent',help='FIM extent',required=True)
-    parser.add_argument('-gl','--great-lakes-filename',help='Great Lakes layer',required=True)
-    parser.add_argument('-wb','--wbd-buffer-distance',help='WBD Mask buffer distance',required=True,type=int)
-    parser.add_argument('-lb','--lake-buffer-distance',help='Great Lakes Mask buffer distance',required=True,type=int)
+    parser.add_argument('-y','--nhd-headwaters', help='NHD headwaters', required=True)
+    parser.add_argument('-v','--landsea', help='LandSea - land boundary', required=True)
+    parser.add_argument('-c','--subset-nhd-streams', help='NHD streams subset', required=True)
+    parser.add_argument('-z','--subset-nld-lines', help='Subset of NLD levee vectors for HUC', required=True)
+    parser.add_argument('-a','--subset-lakes', help='NWM lake subset', required=True)
+    parser.add_argument('-n','--subset-catchments', help='NWM catchments subset', required=True)
+    parser.add_argument('-e','--subset-nhd-headwaters', help='NHD headwaters subset', required=True, default=None)
+    parser.add_argument('-b','--subset-nwm-streams', help='NWM streams subset', required=True)
+    parser.add_argument('-x','--subset-landsea', help='LandSea subset', required=True)
+    parser.add_argument('-gl','--great-lakes-filename', help='Great Lakes layer', required=True)
+    parser.add_argument('-wb','--wbd-buffer-distance', help='WBD Mask buffer distance', required=True, type=int)
+    parser.add_argument('-lb','--lake-buffer-distance', help='Great Lakes Mask buffer distance', required=True, type=int)
 
     args = vars(parser.parse_args())
 
@@ -190,9 +180,9 @@ if __name__ == '__main__':
     subset_nhd_headwaters_filename = args['subset_nhd_headwaters']
     subset_nwm_streams_filename = args['subset_nwm_streams']
     subset_landsea_filename = args['subset_landsea']
-    extent = args['extent']
     great_lakes_filename = args['great_lakes_filename']
     wbd_buffer_distance = args['wbd_buffer_distance']
     lake_buffer_distance  = args['lake_buffer_distance']
+    dem_filename = args['dem_filename']
 
-    subset_vector_layers(hucCode,nwm_streams_filename,nhd_streams_filename,nwm_lakes_filename,nld_lines_filename,nwm_catchments_filename,nhd_headwaters_filename,landsea_filename,wbd_filename,wbd_buffer_filename,subset_nhd_streams_filename,subset_nld_lines_filename,subset_nwm_lakes_filename,subset_nwm_catchments_filename,subset_nhd_headwaters_filename,subset_nwm_streams_filename,subset_landsea_filename,extent,great_lakes_filename,wbd_buffer_distance,lake_buffer_distance)
+    subset_vector_layers(hucCode,nwm_streams_filename,nhd_streams_filename,nwm_lakes_filename,nld_lines_filename,nwm_catchments_filename,nhd_headwaters_filename,landsea_filename,wbd_filename,wbd_buffer_filename,subset_nhd_streams_filename,subset_nld_lines_filename,subset_nwm_lakes_filename,subset_nwm_catchments_filename, subset_nhd_headwaters_filename, subset_nwm_streams_filename, subset_landsea_filename, great_lakes_filename,wbd_buffer_distance,lake_buffer_distance, dem_filename)

--- a/src/gms/run_by_unit.sh
+++ b/src/gms/run_by_unit.sh
@@ -71,7 +71,7 @@ Tcount
 echo -e $startDiv"Get Vector Layers and Subset $hucNumber"$stopDiv
 date -u
 Tstart
-python3 -m memory_profiler $srcDir/clip_vectors_to_wbd.py -d $hucNumber -w $input_nwm_flows -s $input_nhd_flowlines -l $input_nwm_lakes -r $input_NLD -g $outputHucDataDir/wbd.gpkg -f $outputHucDataDir/wbd_buffered.gpkg -m $input_nwm_catchments -y $input_nhd_headwaters -v $input_LANDSEA -c $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nhd_headwater_points_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -x $outputHucDataDir/LandSea_subset.gpkg -extent $extent -gl $input_GL_boundaries -lb $lakes_buffer_dist_meters -wb $wbd_buffer
+python3 -m memory_profiler $srcDir/clip_vectors_to_wbd.py -d $hucNumber -w $input_nwm_flows -s $input_nhd_flowlines -l $input_nwm_lakes -r $input_NLD -g $outputHucDataDir/wbd.gpkg -f $outputHucDataDir/wbd_buffered.gpkg -m $input_nwm_catchments -y $input_nhd_headwaters -v $input_LANDSEA -c $outputHucDataDir/NHDPlusBurnLineEvent_subset.gpkg -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nhd_headwater_points_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -x $outputHucDataDir/LandSea_subset.gpkg -gl $input_GL_boundaries -lb $lakes_buffer_dist_meters -wb $wbd_buffer -i $input_DEM
 Tcount
 
 ## Clip WBD8 ##


### PR DESCRIPTION
Ports thalweg notch fix from FIM3 (#679: dev-fim3-fix-reverse-flow), which fixes thalweg notch created by clipping upstream ends of the stream segments to prevent the stream network from reaching the edge of the DEM and being treated as outlets when pit filling the burned DEM.

## Changes
- `src/clip_vectors_to_wbd.py`: Uses a slightly smaller buffer than wbd_buffer (wbd_buffer_distance-3*[DEM cell size]) to clip stream network inside of DEM extent.