### PR TITLE
[1pt] PR: Add cblend (buffer) to acquire 3dep downloads

### DIFF
--- a/data/create_vrt_file.py
+++ b/data/create_vrt_file.py
@@ -98,6 +98,8 @@ def __setup_logger(output_folder_path):
 
 if __name__ == '__main__':
 
+    # Sample Usage:  python3 /foss_fim/data/create_vrt_file.py -s /data/inputs/3dep_dems/10m_5070/ -n "fim_seamless_3dep_dem_10m_5070.vrt"
+
     parser = argparse.ArgumentParser(description='Create a vrt using all tifs in a given directory')
 
     parser.add_argument('-s','--src_directory', help='A directory of where the .tif files '\

--- a/data/usgs/acquire_and_preprocess_3dep_dems.py
+++ b/data/usgs/acquire_and_preprocess_3dep_dems.py
@@ -107,6 +107,7 @@ def acquire_and_preprocess_3dep_dems(extent_file_path,
     
     end_time = datetime.now()
     fh.print_end_header('Loading 3dep dems', start_time, end_time)
+    print(f'---- NOTE: Remember to scan the log file for any failures')
     logging.info(fh.print_date_time_duration(start_time, end_time))
 
 
@@ -127,6 +128,9 @@ def __download_usgs_dems(extent_files, output_folder_path, number_of_jobs, retry
     ----------
         - pixel size set to 10 x 10 (m)
         - block size (256) (sometimes we use 512)
+        - cblend 6 add's a small buffer when pulling down the tif (ensuring seamless
+          overlap at the borders.)    
+    
     '''
 
     print(f"==========================================================")
@@ -136,7 +140,7 @@ def __download_usgs_dems(extent_files, output_folder_path, number_of_jobs, retry
     base_cmd += ' -cutline {2} -crop_to_cutline -ot Float32 -r bilinear'
     base_cmd += ' -of "GTiff" -overwrite -co "BLOCKXSIZE=256" -co "BLOCKYSIZE=256"'
     base_cmd += ' -co "TILED=YES" -co "COMPRESS=LZW" -co "BIGTIFF=YES" -tr 10 10'
-    base_cmd += ' -t_srs EPSG:5070'
+    base_cmd += ' -t_srs EPSG:5070 -cblend 6'
    
     with ProcessPoolExecutor(max_workers=number_of_jobs) as executor:
 
@@ -205,7 +209,7 @@ def download_usgs_dem_file(extent_file,
                 base_cmd += ' -cutline {2} -crop_to_cutline -ot Float32 -r bilinear'
                 base_cmd +=  ' -of "GTiff" -overwrite -co "BLOCKXSIZE=256" -co "BLOCKYSIZE=256"'
                 base_cmd +=  ' -co "TILED=YES" -co "COMPRESS=LZW" -co "BIGTIFF=YES" -tr 10 10'
-                base_cmd +=  ' -t_srs EPSG:5070'
+                base_cmd +=  ' -t_srs EPSG:5070 -cblend 6'
         - retry (bool)
              If True, and the file exists (and is over 0k), downloading will be skipped.
         
@@ -295,7 +299,7 @@ if __name__ == '__main__':
     # Parse arguments.
     
     # sample usage (min params):
-    # - python3 /foss_fim/data/usgs/acquire_and_preprocess_3dep_dems.py -e /data/inputs/wbd/HUC4
+    # - python3 /foss_fim/data/usgs/acquire_and_preprocess_3dep_dems.py -e /data/inputs/wbd/HUC6_ESPG_5070/ -t /data/inputs/3dep_dems/10m_5070/ -r -j 20
     
     # Notes:
     #   - This is a very low use tool. So for now, this only can load 10m (1/3 arc second) and is using

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,25 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## v4.0.(pending) - 2022-10-21 - [PR #720](https://github.com/NOAA-OWP/inundation-mapping/pull/720)
+
+Earlier versions of the acquire_and_preprocess_3dep_dems.py did not have any buffer added when downloading HUC6 DEMs. This resulted in 1 pixel nodata gaps in the final REM outputs in some cases at HUC8 sharing a HUC6 border. Adding the param of cblend 6 to the gdalwarp command meant put a 6 extra pixels all around perimeter. Testing showed that 6 pixels was plenty sufficient as the gaps were never more than 1 pixel on borders of no-data.
+
+### Changes
+
+- `data`
+    - `usgs`
+        - `acquire_and_preprocess_3dep_dems.py`: Added the `cblend 6` param to the gdalwarp call for when the dem is downloaded from USGS.
+    - `create_vrt_file.py`:  Added sample usage comment.
+ - `src`
+     - `gms`
+         `run_by_unit.sh`: Added a comment about gdal as it relates to run_by_unit.
+
+Note: the new replacement inputs/3dep_dems/10m_5070/ files can / will be copied before PR approval as the true fix was replacment DEM's. There is zero risk of overwriting prior to code merge.
+
+<br/><br/>
+
 ## v4.0.10.1 - 2022-10-5 - [PR #695](https://github.com/NOAA-OWP/inundation-mapping/pull/695)
 
 This hotfix address a bug with how the rating curve comparison (sierra test) handles the branch zero synthetic rating curve in the comparison plots. Address #676 

--- a/src/gms/run_by_unit.sh
+++ b/src/gms/run_by_unit.sh
@@ -131,6 +131,7 @@ mkdir -p $outputCurrentBranchDataDir
 
 ## CLIP RASTERS
 echo -e $startDiv"Clipping rasters to branches $hucNumber $branch_zero_id"$stopDiv
+# Note: don't need to use gdalwarp -cblend as we are using a buffered wbd
 date -u
 Tstart
 [ ! -f $outputCurrentBranchDataDir/dem_meters.tif ] && \


### PR DESCRIPTION
Earlier versions of the acquire_and_preprocess_3dep_dems.py did not have any buffer added when downloading HUC6 DEMs. This resulted in 1 pixel nodata gaps in the final REM outputs in some cases at HUC8 sharing a HUC6 border. Adding the param of cblend 6 to the gdalwarp command meant put a 6 extra pixels all around perimeter. Testing showed that 6 pixels was plenty sufficient as the gaps were never more than 1 pixel on borders of no-data.

### Changes

- `data`
    - `usgs`
        - `acquire_and_preprocess_3dep_dems.py`: Added the `cblend 6` param to the gdalwarp call for when the dem is downloaded from USGS.
    - `create_vrt_file.py`:  Added sample usage comment.
 - `src`
     - `gms`
         `run_by_unit.sh`: Added a comment about gdal as it relates to run_by_unit.

Note: the new replacement inputs/3dep_dems/10m_5070/ files can / will be copied before PR approval as the true fix was replacment DEM's. There is zero risk of overwriting prior to code merge.

### Testing

- Tried a number of experiments against gdalwarp params including various cblend sizes before settling on six. Six covered our needs without inflating the file size significantly. 
- ran a huc8 that shared a huc6 border and examined the output REM to ensure there are no more no-data gaps.
- Redownloaded new 3dep replacement DEMs which will be copied to all servers shortly.