### PR TITLE
[1pt] PR: Runs branch 0 on HUCs without other branches after stream order filtering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,24 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.[to be assigned] - 2022-10-24 - [PR #723](https://github.com/NOAA-OWP/inundation-mapping/pull/723)
+
+Runs branch 0 on HUCs with no other branches remaining after filtering stream orders if `drop_low_stream_orders` is used.
+
+### Additions
+
+- `src/gms`
+    - `stream_branches.py`: adds `exclude_attribute_values()` to filter out stream orders 1&2 outside of `load_file()`
+
+### Changes
+
+- `src/gms`
+    - `buffer_stream_branches.py`: adds check for `streams_file`
+    - `derive_level_paths.py`: checks length of `stream_network` before filtering out stream orders 1&2, then filters using `stream_network.exclude_attribute_values()`
+    - `generate_branch_list.py`: adds check for `stream_network_dissolved`
+
+<br/><br/>
+    
 ## v4.0.10.1 - 2022-10-5 - [PR #695](https://github.com/NOAA-OWP/inundation-mapping/pull/695)
 
 This hotfix address a bug with how the rating curve comparison (sierra test) handles the branch zero synthetic rating curve in the comparison plots. Address #676 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.[to be assigned] - 2022-10-24 - [PR #723](https://github.com/NOAA-OWP/inundation-mapping/pull/723)
+## v4.0.10.2 - 2022-10-24 - [PR #723](https://github.com/NOAA-OWP/inundation-mapping/pull/723)
 
 Runs branch 0 on HUCs with no other branches remaining after filtering stream orders if `drop_low_stream_orders` is used.
 

--- a/src/gms/buffer_stream_branches.py
+++ b/src/gms/buffer_stream_branches.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-
+import os
 from stream_branches import StreamNetwork
 from stream_branches import StreamBranchPolygons
 import argparse
@@ -19,16 +19,17 @@ if __name__ == '__main__':
     # extract to dictionary
     args = vars(parser.parse_args())
 
-    streams_file , branch_id_attribute, buffer_distance, stream_polygons_file, verbose = args["streams"], args["branch_id"] , args["buffer_distance"], args["branches"] , args["verbose"]
+    streams_file, branch_id_attribute, buffer_distance, stream_polygons_file, verbose = args["streams"], args["branch_id"] , args["buffer_distance"], args["branches"] , args["verbose"]
     
-    # load file
-    stream_network = StreamNetwork.from_file( filename=streams_file,branch_id_attribute=branch_id_attribute,
-                                              values_excluded=None,attribute_excluded=None, verbose = verbose)
-    
-    # make stream polygons 
-    stream_polys = StreamBranchPolygons.buffer_stream_branches( stream_network,
-                                                                buffer_distance=buffer_distance,
-                                                                verbose=verbose                  )
-    
-    stream_polys.write(stream_polygons_file,verbose=verbose)
+    if os.path.exists(streams_file):
+        # load file
+        stream_network = StreamNetwork.from_file( filename=streams_file,branch_id_attribute=branch_id_attribute,
+                                                values_excluded=None,attribute_excluded=None, verbose = verbose)
+        
+        # make stream polygons 
+        stream_polys = StreamBranchPolygons.buffer_stream_branches( stream_network,
+                                                                    buffer_distance=buffer_distance,
+                                                                    verbose=verbose                  )
+        
+        stream_polys.write(stream_polygons_file,verbose=verbose)
 

--- a/src/gms/derive_level_paths.py
+++ b/src/gms/derive_level_paths.py
@@ -44,12 +44,6 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
 
         # if there are no reaches at this point (due to filtering)
         if (len(stream_network) == 0):
-            # This is technically not an error but we need to have it logged so the user know what
-            # happened to it and we need the huc to not be included in future processing. 
-            # We need it to be not included in the gms_input.csv at the end of the unit processing.
-            # Throw an exception with valid text. This will show up in the non-zero exit codes and explain why an error.
-            # Later, we can look at creating custom sys exit codes 
-            # raise UserWarning("Sorry, no branches exist but branch zero processing will continue. This could be an empty file due to stream order filtering.")
             print("No branches exist but branch zero processing will continue. This could be due to stream order filtering.")
             return
                                                  

--- a/src/gms/derive_level_paths.py
+++ b/src/gms/derive_level_paths.py
@@ -24,27 +24,35 @@ def Derive_level_paths(in_stream_network, out_stream_network, branch_id_attribut
     if verbose:
         print("Loading stream network ...")
         
-    if (drop_low_stream_orders):
-        stream_network = StreamNetwork.from_file(filename=in_stream_network,
-                                                 branch_id_attribute="order_",
-                                                 values_excluded=[1,2]
-                                                 )
-                                                 
-                                                 
-    else:
-        stream_network = StreamNetwork.from_file(filename=in_stream_network)
+    stream_network = StreamNetwork.from_file(filename=in_stream_network)
 
-    # if there are no reaches at this point (due to filtering if applicable)
-    if (len(stream_network) == 0) and (drop_low_stream_orders):
+    # if there are no reaches at this point
+    if (len(stream_network) == 0):
         # This is technically not an error but we need to have it logged so the user know what
         # happened to it and we need the huc to not be included in future processing. 
         # We need it to be not included in the gms_input.csv at the end of the unit processing.
         # Throw an exception with valid text. This will show up in the non-zero exit codes and explain why an error.
         # Later, we can look at creating custom sys exit codes 
-        # raise UserWarning("Sorry, no branches exist and processing can not continue. This could be an empty file or stream order filtering.")
-        print("Sorry, no branches exist and processing can not continue. This could be an empty file or stream order filtering.")
+        # raise UserWarning("Sorry, no branches exist and processing can not continue. This could be an empty file.")
+        print("Sorry, no branches exist and processing can not continue. This could be an empty file.")
         sys.exit(FIM_exit_codes.GMS_UNIT_NO_BRANCHES.value)  # will send a 60 back
+                                                 
+    elif (drop_low_stream_orders):
+        stream_network = stream_network.exclude_attribute_values(branch_id_attribute="order_",
+                                               values_excluded=[1,2]
+                                              )
 
+        # if there are no reaches at this point (due to filtering)
+        if (len(stream_network) == 0):
+            # This is technically not an error but we need to have it logged so the user know what
+            # happened to it and we need the huc to not be included in future processing. 
+            # We need it to be not included in the gms_input.csv at the end of the unit processing.
+            # Throw an exception with valid text. This will show up in the non-zero exit codes and explain why an error.
+            # Later, we can look at creating custom sys exit codes 
+            # raise UserWarning("Sorry, no branches exist but branch zero processing will continue. This could be an empty file due to stream order filtering.")
+            print("No branches exist but branch zero processing will continue. This could be due to stream order filtering.")
+            return
+                                                 
     inlets_attribute = 'inlet_id'
     outlets_attribute = 'outlet_id'
     outlet_linestring_index = -1

--- a/src/gms/generate_branch_list.py
+++ b/src/gms/generate_branch_list.py
@@ -1,25 +1,26 @@
 #!/usr/bin/env python3
 
+import os
 import pandas as pd
 from stream_branches import StreamNetwork
 import argparse
 
 def Generate_branch_list(stream_network_dissolved, branch_id_attribute, output_branch_list, branch_zero):
 
-    # load stream network
+    if os.path.exists(stream_network_dissolved):
+        # load stream network
+        stream_network_dissolved = StreamNetwork.from_file( stream_network_dissolved,
+                                                            branch_id_attribute=branch_id_attribute )
 
-    stream_network_dissolved = StreamNetwork.from_file( stream_network_dissolved,
-                                                        branch_id_attribute=branch_id_attribute )
+        # reduce to branch id attribute and convert to pandas df
+        stream_network_dissolved = stream_network_dissolved.loc[:,branch_id_attribute]
 
-    # reduce to branch id attribute and convert to pandas df
-    stream_network_dissolved = stream_network_dissolved.loc[:,branch_id_attribute]
-
-    # write
-    stream_network_dissolved.to_csv(output_branch_list,sep= " ",index=False,header=False)
+        # write
+        stream_network_dissolved.to_csv(output_branch_list,sep= " ",index=False,header=False)
 
     # Add branch zero ID to branch list
     if branch_zero:
-        with open(output_branch_list,'a') as branch_lst:
+        with open(output_branch_list, 'a') as branch_lst:
             branch_lst.write(f'{branch_zero}')
 
 if __name__ == '__main__':

--- a/src/gms/stream_branches.py
+++ b/src/gms/stream_branches.py
@@ -375,6 +375,18 @@ class StreamNetwork(gpd.GeoDataFrame):
 
         return(headwater_points_gdf)
 
+
+    def exclude_attribute_values(self, branch_id_attribute=None, values_excluded=None, verbose=False):
+                      
+        if (branch_id_attribute is not None) and (values_excluded is not None):
+            self = StreamNetwork(self[~self[branch_id_attribute].isin(values_excluded)], branch_id_attribute=branch_id_attribute)
+       
+        if verbose:         
+             print("Number of df rows = " + str(self.shape[0]))
+        
+        return(self)
+
+
     def remove_stream_segments_without_catchments( self,
                                                    catchments,
                                                    reach_id_attribute='NHDPlusID',


### PR DESCRIPTION
Runs branch 0 on HUCs with no other branches remaining after filtering stream orders if `drop_low_stream_orders` is used. Closes #715.

## Additions

- `src/gms`
    - `stream_branches.py`: adds `exclude_attribute_values()` to filter out stream orders 1&2 outside of `load_file()`

## Changes

- `src/gms`
    - `buffer_stream_branches.py`: adds check for `streams_file`
    - `derive_level_paths.py`: checks length of `stream_network` before filtering out stream orders 1&2, then filters using `stream_network.exclude_attribute_values()`
    - `generate_branch_list.py`: adds check for `stream_network_dissolved`

## Testing

1. Ran `gms_run_unit.sh` and `gms_run_branch.sh` on HUCs 10060007 (no 3+ stream orders) and 12030102