### PR TITLE
[1pt] PR: Skip `usgs_gage_unit_setup.py` if no level paths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## v4.[to be assigned] - 2022-11-18 - [PR #746](https://github.com/NOAA-OWP/inundation-mapping/pull/746)
+
+Skips `src/usgs_gage_unit_setup.py` if no level paths exist. This may happen if a HUC has no stream orders > 2. This is a bug fix for #723 for the case that the HUC also has USGS gages.
+
+### Changes
+
+- `src/gms/run_by_unit.sh`: Adds check for `nwm_subset_streams_levelPaths.gpkg` before running `usgs_gage_unit_setup.py`
+
+<br/><br/>
+
 ## v4.0.11.1 - 2022-11-01 - [PR #732](https://github.com/NOAA-OWP/inundation-mapping/pull/732)
 
 Due to a recent IT security scan, it was determined that Jupyter-core needed to be upgraded.

--- a/src/gms/run_by_unit.sh
+++ b/src/gms/run_by_unit.sh
@@ -250,11 +250,13 @@ else
 fi
 
 ## CREATE USGS GAGES FILE
-echo -e $startDiv"Assigning USGS gages to branches for $hucNumber"$stopDiv
-date -u
-Tstart
-python3 -m memory_profiler $srcDir/usgs_gage_unit_setup.py -gages $inputDataDir/usgs_gages/usgs_gages.gpkg -nwm $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg -o $outputHucDataDir/usgs_subset_gages.gpkg -huc $hucNumber -ahps $inputDataDir/ahps_sites/nws_lid.gpkg -bzero_id $branch_zero_id -bzero $dropLowStreamOrders
-Tcount
+if [ -f $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg ]; then
+    echo -e $startDiv"Assigning USGS gages to branches for $hucNumber"$stopDiv
+    date -u
+    Tstart
+    python3 -m memory_profiler $srcDir/usgs_gage_unit_setup.py -gages $inputDataDir/usgs_gages/usgs_gages.gpkg -nwm $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg -o $outputHucDataDir/usgs_subset_gages.gpkg -huc $hucNumber -ahps $inputDataDir/ahps_sites/nws_lid.gpkg -bzero_id $branch_zero_id -bzero $dropLowStreamOrders
+    Tcount
+fi
 
 ## USGS CROSSWALK ##
 if [ -f $outputHucDataDir/usgs_subset_gages_$branch_zero_id.gpkg ]; then


### PR DESCRIPTION
Skip `usgs_gage_unit_setup.py` if no level paths exist. This may happen if a HUC has no stream orders > 2. This is a bug fix for #723 for the case that the HUC also has USGS gages.

## Additions

- `src/gms/run_by_unit.sh`: Adds check for `nwm_subset_streams_levelPaths.gpkg` before running `usgs_gage_unit_setup.py`