### PR TITLE
[1pt] Cleanup a few deny list files

### DIFF
--- a/config/deny_gms_branches_dev.lst
+++ b/config/deny_gms_branches_dev.lst
@@ -35,7 +35,7 @@ flows_points_pixels_{}.gpkg
 gw_catchments_pixels_{}.tif
 gw_catchments_reaches_{}.gpkg
 gw_catchments_reaches_{}.tif
-#gw_catchments_reaches_filtered_addedAttributes_{}.gpkg
+gw_catchments_reaches_filtered_addedAttributes_{}.gpkg
 #gw_catchments_reaches_filtered_addedAttributes_{}.tif
 #gw_catchments_reaches_filtered_addedAttributes_crosswalked_{}.gpkg
 headwaters_{}.tif

--- a/config/deny_gms_branches_prod.lst
+++ b/config/deny_gms_branches_prod.lst
@@ -35,7 +35,7 @@ flows_points_pixels_{}.gpkg
 gw_catchments_pixels_{}.tif
 gw_catchments_reaches_{}.gpkg
 gw_catchments_reaches_{}.tif
-#gw_catchments_reaches_filtered_addedAttributes_{}.gpkg
+gw_catchments_reaches_filtered_addedAttributes_{}.gpkg
 #gw_catchments_reaches_filtered_addedAttributes_{}.tif
 #gw_catchments_reaches_filtered_addedAttributes_crosswalked_{}.gpkg
 headwaters_{}.tif

--- a/config/deny_gms_unit_prod.lst
+++ b/config/deny_gms_unit_prod.lst
@@ -1,6 +1,6 @@
 # List of files for gms branches to delete
 # Use comment to allow list the file
-NHDPlusBurnLineEvent_subset.gpkg
+NHPlusBurnLineEvent_subset.gpkg
 #branch_id.lst
 #branch_polygons.gpkg
 #LandSea_subset.gpkg
@@ -20,3 +20,4 @@ nwm_headwaters.gpkg
 #wbd.gpkg
 #wbd8_clp.gpkg
 wbd_buffered.gpkg
+#wbd_buffered_streams.gpkg

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.0.12.1 - 2022-11-30 - [PR #751](https://github.com/NOAA-OWP/inundation-mapping/pull/751)
+
+Updating a few deny list files.
+
+### Changes
+
+- `config`:
+    - `deny_gms_branches_dev.lst`, `deny_gms_branches_prod.lst`, and `deny_gms_unit_prod.lst`
+
+<br/><br/>
+
 
 ## v4.0.11.5 - 2022-11-18 - [PR #746](https://github.com/NOAA-OWP/inundation-mapping/pull/746)
 


### PR DESCRIPTION
Updating a few deny list files.

## Changes

- `config`
    - `deny_gms_branches_dev.lst`: gw_catchments_reaches_filtered_addedAttributes_{}.gpkg no longer being kept after cleanup.
    - `deny_gms_branches_prod.lst`: gw_catchments_reaches_filtered_addedAttributes_{}.gpkg no longer being kept after cleanup.
    - `deny_gms_unit_prod.lst`: incorrect spelling for NHPlusBurnLineEvent_subset.gpkg. It is now being removed correctly. Also added a new line for a recently new file called wbd_buffered_streams.gpkg which will be kept as output for now.
    
## Testing

Tested a HUC and validated updates to output cleanup. No permutations of testing required.
