### PR TITLE
[1pt] PR: Bug fix: `inundation.py` ignoring nodata

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.(to be assigned) - 2022-12-20 - [PR #767](https://github.com/NOAA-OWP/inundation-mapping/pull/767)
+
+Fixes inundation of nodata areas of REM.
+
+### Changes
+
+- `tools/inundation.py`: Assigns depth a value of `0` if REM is less than `0`
+
+<br/><br/>
+
 ## v4.0.13.1 - 2022-12-09 - [PR #743](https://github.com/NOAA-OWP/inundation-mapping/pull/743)
 
 This merge adds the tools required to generate Alpha metrics by hydroid. It summarizes the Apha metrics by branch 0 catchment for use in the Hydrovis "FIM Performance" service.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.(to be assigned) - 2022-12-20 - [PR #767](https://github.com/NOAA-OWP/inundation-mapping/pull/767)
+## v4.0.13.2 - 2022-12-20 - [PR #767](https://github.com/NOAA-OWP/inundation-mapping/pull/767)
 
 Fixes inundation of nodata areas of REM.
 

--- a/tools/inundation.py
+++ b/tools/inundation.py
@@ -459,7 +459,7 @@ def __make_windows_generator(rem,
         hucCode = None
        #window = Window(col_off=0,row_off=0,width=rem.width,height=rem.height)
 
-        yield (rem.read(1, masked=True),catchments.read(1),rem.crs.wkt,
+        yield (rem.read(1),catchments.read(1),rem.crs.wkt,
                rem.transform,rem.profile,catchments.profile,hucCode,
                catchmentStagesDict,depths,inundation_raster,
                inundation_polygon,out_raster_profile,out_vector_profile,quiet)

--- a/tools/inundation.py
+++ b/tools/inundation.py
@@ -365,9 +365,11 @@ def __go_fast_mapping(rem,catchments,catchmentStagesDict,inundation,depths):
 
     for i,(r,cm) in enumerate(zip(rem,catchments)):
         if cm in catchmentStagesDict:
-
-            depth = catchmentStagesDict[cm] - r
-            depths[i] = max(depth,0) # set negative depths to 0
+            if r >= 0:
+                depth = catchmentStagesDict[cm] - r
+                depths[i] = max(depth,0) # set negative depths to 0
+            else:
+                depths[i] = 0
 
             if depths[i] > 0: # set positive depths to positive
                 inundation[i] *= -1
@@ -457,7 +459,7 @@ def __make_windows_generator(rem,
         hucCode = None
        #window = Window(col_off=0,row_off=0,width=rem.width,height=rem.height)
 
-        yield (rem.read(1),catchments.read(1),rem.crs.wkt,
+        yield (rem.read(1, masked=True),catchments.read(1),rem.crs.wkt,
                rem.transform,rem.profile,catchments.profile,hucCode,
                catchmentStagesDict,depths,inundation_raster,
                inundation_polygon,out_raster_profile,out_vector_profile,quiet)


### PR DESCRIPTION
Bug fix for `inundation.py` ignoring nodata value and inundating masked areas in REM raster. Fixes #761

## Changes

- `tools/inundation.py`: Sets depth to `0` if REM value is less than `0`

## Testing

1. Ran `inundation.py` on HUC 12030109 branch 0. Verified values in QGIS (screenshot below).
2. Ran `gms_pipeline.sh` and `synthesize_test_cases.py` on HUC 12030109 without errors.

## Screenshots

Levee-protected areas (gray, 50% transparent) are no being inundated, for example in the depth raster:
<img width="957" alt="image" src="https://user-images.githubusercontent.com/6616694/208725036-630c7df7-cd76-4329-85b6-014d8739748a.png">