### PR TITLE
[1pt] PR: Mask levee-protected areas from DEM

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.(to be assigned) - 2022-12-20 - [PR #769](https://github.com/NOAA-OWP/inundation-mapping/pull/769)
+## v4.0.14.0 - 2022-12-20 - [PR #769](https://github.com/NOAA-OWP/inundation-mapping/pull/769)
 
 Masks levee-protected areas from the DEM in branch 0 and in highest two stream order branches.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.(to be assigned) - 2022-12-20 - [PR #769](https://github.com/NOAA-OWP/inundation-mapping/pull/769)
+
+Masks levee-protected areas from the DEM in branch 0 and in highest two stream order branches.
+
+### Additions
+
+- `src/gms/`
+    - `mask_dem.py`: Masks levee-protected areas from the DEM in branch 0 and in highest two stream order branches
+    - `delineate_hydros_and_produce_HAND.sh`: Adds `src/gms/mask_dem.py`
+
+
 ## v4.0.13.1 - 2022-12-09 - [PR #743](https://github.com/NOAA-OWP/inundation-mapping/pull/743)
 
 This merge adds the tools required to generate Alpha metrics by hydroid. It summarizes the Apha metrics by branch 0 catchment for use in the Hydrovis "FIM Performance" service.

--- a/src/gms/delineate_hydros_and_produce_HAND.sh
+++ b/src/gms/delineate_hydros_and_produce_HAND.sh
@@ -11,7 +11,7 @@ echo -e $startDiv"Mask levee-protected areas from DEM (*Overwrite dem_meters.tif
 date -u
 Tstart
 [ -f $outputHucDataDir/LeveeProtectedAreas_subset.gpkg ] && \
-python3 -m memory_profiler $srcDir/gms/mask_dem.py -dem $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif -nld $outputHucDataDir/LeveeProtectedAreas_subset.gpkg -out $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif
+python3 -m memory_profiler $srcDir/gms/mask_dem.py -dem $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif -nld $outputHucDataDir/LeveeProtectedAreas_subset.gpkg -out $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif  -s $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg -i $current_branch_id -b0 $branch_zero_id
 Tcount
 
 ## D8 FLOW ACCUMULATIONS ##

--- a/src/gms/delineate_hydros_and_produce_HAND.sh
+++ b/src/gms/delineate_hydros_and_produce_HAND.sh
@@ -6,6 +6,14 @@ level=$1
 ## INITIALIZE TOTAL TIME TIMER ##
 T_total_start
 
+## MASK LEVEE-PROTECTED AREAS FROM DEM ##
+echo -e $startDiv"Mask levee-protected areas from DEM (*Overwrite dem_meters.tif output) $hucNumber $branch_zero_id"$stopDiv
+date -u
+Tstart
+[ -f $outputCurrentBranchDataDir/LeveeProtectedAreas_subset.gpkg ] && \
+python3 -m memory_profiler $srcDir/gms/mask_dem.py -dem $outputCurrentBranchDataDir/dem_burned_filled_$branch_zero_id.tif -nld $outputCurrentBranchDataDir/LeveeProtectedAreas_subset.gpkg -out $outputCurrentBranchDataDir/dem_burned_filled_$branch_zero_id.tif
+Tcount
+
 ## D8 FLOW ACCUMULATIONS ##
 echo -e $startDiv"D8 Flow Accumulations $hucNumber $current_branch_id"$stopDiv
 date -u

--- a/src/gms/delineate_hydros_and_produce_HAND.sh
+++ b/src/gms/delineate_hydros_and_produce_HAND.sh
@@ -7,12 +7,13 @@ level=$1
 T_total_start
 
 ## MASK LEVEE-PROTECTED AREAS FROM DEM ##
-echo -e $startDiv"Mask levee-protected areas from DEM (*Overwrite dem_meters.tif output) $hucNumber $branch_zero_id"$stopDiv
-date -u
-Tstart
-[ -f $outputHucDataDir/LeveeProtectedAreas_subset.gpkg ] && \
-python3 -m memory_profiler $srcDir/gms/mask_dem.py -dem $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif -nld $outputHucDataDir/LeveeProtectedAreas_subset.gpkg -out $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif  -s $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg -i $current_branch_id -b0 $branch_zero_id
-Tcount
+if [ "$mask_leveed_area_toggle" = "True" ] && [ -f $outputHucDataDir/LeveeProtectedAreas_subset.gpkg ]; then
+    echo -e $startDiv"Mask levee-protected areas from DEM (*Overwrite dem_meters.tif output) $hucNumber $branch_zero_id"$stopDiv
+    date -u
+    Tstart
+    python3 -m memory_profiler $srcDir/gms/mask_dem.py -dem $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif -nld $outputHucDataDir/LeveeProtectedAreas_subset.gpkg -out $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif  -s $outputHucDataDir/nwm_subset_streams_levelPaths.gpkg -i $current_branch_id -b0 $branch_zero_id
+    Tcount
+fi
 
 ## D8 FLOW ACCUMULATIONS ##
 echo -e $startDiv"D8 Flow Accumulations $hucNumber $current_branch_id"$stopDiv

--- a/src/gms/delineate_hydros_and_produce_HAND.sh
+++ b/src/gms/delineate_hydros_and_produce_HAND.sh
@@ -10,8 +10,8 @@ T_total_start
 echo -e $startDiv"Mask levee-protected areas from DEM (*Overwrite dem_meters.tif output) $hucNumber $branch_zero_id"$stopDiv
 date -u
 Tstart
-[ -f $outputCurrentBranchDataDir/LeveeProtectedAreas_subset.gpkg ] && \
-python3 -m memory_profiler $srcDir/gms/mask_dem.py -dem $outputCurrentBranchDataDir/dem_burned_filled_$branch_zero_id.tif -nld $outputCurrentBranchDataDir/LeveeProtectedAreas_subset.gpkg -out $outputCurrentBranchDataDir/dem_burned_filled_$branch_zero_id.tif
+[ -f $outputHucDataDir/LeveeProtectedAreas_subset.gpkg ] && \
+python3 -m memory_profiler $srcDir/gms/mask_dem.py -dem $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif -nld $outputHucDataDir/LeveeProtectedAreas_subset.gpkg -out $outputCurrentBranchDataDir/dem_meters_$current_branch_id.tif
 Tcount
 
 ## D8 FLOW ACCUMULATIONS ##

--- a/src/gms/mask_dem.py
+++ b/src/gms/mask_dem.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import fiona
+import rasterio as rio
+import numpy as np
+import argparse
+from utils.shared_functions import mem_profile
+
+
+@mem_profile
+def mask_dem(dem_filename,nld_filename,flowdir_filename,out_dem_filename):
+    """
+    Masks levee-protected areas from DEM
+    """
+    with rio.open(dem_filename) as dem, rio.open(flowdir_filename) as fdir, fiona.open(nld_filename) as leveed:
+
+        dem_data = dem.read(1)
+        dem_profile = dem.profile.copy()
+
+        geoms = [feature["geometry"] for feature in leveed]
+
+        out_dem_masked, out_transform = rio.mask.mask(dem, geoms, invert=True)
+
+    with rio.open(out_dem_filename, "w", **dem_profile, BIGTIFF='YES') as dest:
+        dest.write(out_dem_masked, indexes = 1)
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Mask levee-protected areas from DEM')
+    parser.add_argument('-dem','--dem-filename', help='DEM filename', required=True,type=str)
+    parser.add_argument('-fd', '--flowdir-filename', help='Flow Direction filename', required=True, type=str)
+    parser.add_argument('-nld','--nld-filename', help='NLD filename', required=True,type=str)
+    parser.add_argument('-out','--out-dem-filename', help='out DEM filename', required=True,type=str)
+
+    args = vars(parser.parse_args())
+
+    mask_dem(**args)

--- a/src/gms/mask_dem.py
+++ b/src/gms/mask_dem.py
@@ -3,17 +3,15 @@
 import fiona
 import rasterio as rio
 from rasterio.mask import mask
-# import numpy as np
 import argparse
-# from utils.shared_functions import mem_profile
+from utils.shared_functions import mem_profile
 
-# @mem_profile
-def mask_dem(dem_filename, nld_filename, out_dem_filename):# , flowdir_filename)
+@mem_profile
+def mask_dem(dem_filename, nld_filename, out_dem_filename):
     """
     Masks levee-protected areas from DEM
     """
-    with rio.open(dem_filename) as dem, fiona.open(nld_filename) as leveed:#, \
-        # rio.open(flowdir_filename) as fdir:
+    with rio.open(dem_filename) as dem, fiona.open(nld_filename) as leveed:
         dem_data = dem.read(1)
         dem_profile = dem.profile.copy()
 
@@ -31,7 +29,6 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Mask levee-protected areas from DEM')
     parser.add_argument('-dem','--dem-filename', help='DEM filename', required=True,type=str)
-    # parser.add_argument('-fd', '--flowdir-filename', help='Flow Direction filename', required=True, type=str)
     parser.add_argument('-nld','--nld-filename', help='NLD filename', required=True,type=str)
     parser.add_argument('-out','--out-dem-filename', help='out DEM filename', required=True,type=str)
 

--- a/src/gms/mask_dem.py
+++ b/src/gms/mask_dem.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import geopandas as gpd
 import fiona
 import rasterio as rio
 from rasterio.mask import mask
@@ -7,30 +8,38 @@ import argparse
 from utils.shared_functions import mem_profile
 
 @mem_profile
-def mask_dem(dem_filename, nld_filename, out_dem_filename):
+def mask_dem(dem_filename, nld_filename, out_dem_filename, stream_layer, branch_id_attribute, branch_id, order_attribute, branch_zero_id):
     """
-    Masks levee-protected areas from DEM
+    Masks levee-protected areas from DEM in branch 0 or if stream order is at least the minimum order (max - 1)
     """
-    with rio.open(dem_filename) as dem, fiona.open(nld_filename) as leveed:
-        dem_data = dem.read(1)
-        dem_profile = dem.profile.copy()
+    streams_df = gpd.read_file(stream_layer, ignore_geometry=True)
 
-        geoms = [feature["geometry"] for feature in leveed]
+    # Rasterize if branch zero or if stream order is at least the minimum order (max - 1)
+    if (branch_id == branch_zero_id) or (streams_df.loc[streams_df[branch_id_attribute].astype(int)==branch_id, order_attribute].max() >= streams_df[order_attribute].max() - 1):
 
-        # Mask out levee-protected areas from DEM
-        out_dem_masked, out_transform = mask(dem, geoms, invert=True)
+        with rio.open(dem_filename) as dem, fiona.open(nld_filename) as leveed:
+            dem_data = dem.read(1)
+            dem_profile = dem.profile.copy()
 
+            geoms = [feature["geometry"] for feature in leveed]
 
-        with rio.open(out_dem_filename, "w", **dem_profile, BIGTIFF='YES') as dest:
-            dest.write(out_dem_masked[0,:,:], indexes=1)
+            # Mask out levee-protected areas from DEM
+            out_dem_masked, _ = mask(dem, geoms, invert=True)
+
+            with rio.open(out_dem_filename, "w", **dem_profile, BIGTIFF='YES') as dest:
+                dest.write(out_dem_masked[0,:,:], indexes=1)
 
 
 if __name__ == '__main__':
-
     parser = argparse.ArgumentParser(description='Mask levee-protected areas from DEM')
     parser.add_argument('-dem','--dem-filename', help='DEM filename', required=True,type=str)
     parser.add_argument('-nld','--nld-filename', help='NLD filename', required=True,type=str)
     parser.add_argument('-out','--out-dem-filename', help='out DEM filename', required=True,type=str)
+    parser.add_argument('-s', '--stream-layer', help='Stream layer filename', required=True)
+    parser.add_argument('-b', '--branch-id-attribute', help='Branch ID attribute name', required=False, default='levpa_id')
+    parser.add_argument('-i', '--branch-id', help='Branch ID', type=int, required='True')
+    parser.add_argument('-a', '--order-attribute', help='Stream order attribute name', required=False, default='order_')
+    parser.add_argument('-b0', '--branch-zero-id', help='Branch zero ID', type=int, required=False, default=0)
 
     args = vars(parser.parse_args())
 

--- a/src/gms/mask_dem.py
+++ b/src/gms/mask_dem.py
@@ -2,34 +2,36 @@
 
 import fiona
 import rasterio as rio
-import numpy as np
+from rasterio.mask import mask
+# import numpy as np
 import argparse
-from utils.shared_functions import mem_profile
+# from utils.shared_functions import mem_profile
 
-
-@mem_profile
-def mask_dem(dem_filename,nld_filename,flowdir_filename,out_dem_filename):
+# @mem_profile
+def mask_dem(dem_filename, nld_filename, out_dem_filename):# , flowdir_filename)
     """
     Masks levee-protected areas from DEM
     """
-    with rio.open(dem_filename) as dem, rio.open(flowdir_filename) as fdir, fiona.open(nld_filename) as leveed:
-
+    with rio.open(dem_filename) as dem, fiona.open(nld_filename) as leveed:#, \
+        # rio.open(flowdir_filename) as fdir:
         dem_data = dem.read(1)
         dem_profile = dem.profile.copy()
 
         geoms = [feature["geometry"] for feature in leveed]
 
-        out_dem_masked, out_transform = rio.mask.mask(dem, geoms, invert=True)
+        # Mask out levee-protected areas from DEM
+        out_dem_masked, out_transform = mask(dem, geoms, invert=True)
 
-    with rio.open(out_dem_filename, "w", **dem_profile, BIGTIFF='YES') as dest:
-        dest.write(out_dem_masked, indexes = 1)
+
+        with rio.open(out_dem_filename, "w", **dem_profile, BIGTIFF='YES') as dest:
+            dest.write(out_dem_masked[0,:,:], indexes=1)
 
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Mask levee-protected areas from DEM')
     parser.add_argument('-dem','--dem-filename', help='DEM filename', required=True,type=str)
-    parser.add_argument('-fd', '--flowdir-filename', help='Flow Direction filename', required=True, type=str)
+    # parser.add_argument('-fd', '--flowdir-filename', help='Flow Direction filename', required=True, type=str)
     parser.add_argument('-nld','--nld-filename', help='NLD filename', required=True,type=str)
     parser.add_argument('-out','--out-dem-filename', help='out DEM filename', required=True,type=str)
 


### PR DESCRIPTION
Masks levee-protected areas from DEM in branch 0 and two highest stream order branches to prevent slivers of inundation along the perimeter of levee-protected areas. Masking the DEM causes the same levee-protected area to be masked in the REM as well as the pixel catchments of any stream pixels in the leveed area. Closes #759 

## Additions

- `src/gms/`
    - `mask_dem.py`: Masks levee-protected areas from DEM in branch 0 and two highest stream order branches
    - `src/gms/delineate_hydros_and_produce_HAND.sh`: Adds `src/gms/mask_dem.py`

## Testing

1. Ran `src/gms/mask_dem.py` on branch 0 of HUC 12030109 to verify correct masking of DEM.
2. Ran `Inundate_gms` and `Mosaic_inundation` on HUC 12030109 to verify effect of masking DEM on REM and final inundation.

## Screenshots
1. DEM (`dem_meters_0.tif`) with levee-protected areas masked
<img width="945" alt="image" src="https://user-images.githubusercontent.com/6616694/208792494-4e3543d5-349a-422f-83ae-78a68d8deb59.png">

2. Depth raster (`depth_12030109_0.tif`): brown areas are low, positive (correct) depth values that will be inundated; green areas are high (incorrect) depth values that result from erroneous masking (fixed by #767) and will not be inundated after 
<img width="945" alt="image" src="https://user-images.githubusercontent.com/6616694/208792641-fc245546-4783-44f5-b477-810284961ada.png">

## Notes

- Depends on #767 for proper results