### PR TITLE
[1pt] PR: Bug fix to Stage-Based CatFIM

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,14 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.0.17.1 - 2022-12-29 - [PR #778](https://github.com/NOAA-OWP/inundation-mapping/pull/778)
+
+This merge fixes a bug where all of the Stage-Based intervals were the same.
+
+### Changes
+- `/tools/generate_categorical_fim.py`: Changed `stage` variable to `interval_stage` variable in `produce_stage_based_catfim_tifs` function call.
+
+<br/><br/>
 
 ## v4.0.17.0 - 2022-12-21 - [PR #771](https://github.com/NOAA-OWP/inundation-mapping/pull/771)
 

--- a/tools/generate_categorical_fim.py
+++ b/tools/generate_categorical_fim.py
@@ -630,8 +630,6 @@ def produce_stage_based_catfim_tifs(stage, datum_adj_ft, branch_dir, lid_usgs_el
             # Create inundation maps with branch and stage data
             try:
                 print("Running inundation for " + huc + " and branch " + branch)
-                print("HAND STAGE")
-                print(hand_stage)
                 executor.submit(produce_inundation_map_with_stage_and_feature_ids, rem_path, catchments_path, hydroid_list, hand_stage, lid_directory, category, huc, lid, branch)
             except Exception:
                 messages.append([f'{lid}:inundation failed at {category}'])

--- a/tools/generate_categorical_fim.py
+++ b/tools/generate_categorical_fim.py
@@ -425,8 +425,6 @@ def iterate_through_huc_stage_based(workspace, huc, fim_dir, huc_dictionary, thr
                         category = 'moderate_' + str(interval_stage).replace('.', 'p') + 'ft'
                     if interval_stage >= major_stage:
                         category = 'major_' + str(interval_stage).replace('.', 'p') + 'ft'
-                        print("STAGE")
-                    print(stage)
                     executor.submit(produce_stage_based_catfim_tifs, interval_stage, datum_adj_ft, branch_dir, lid_usgs_elev, lid_altitude, fim_dir, segments, lid, huc, lid_directory, category, number_of_jobs)
             except TypeError:  # sometimes the thresholds are Nonetypes
                 pass

--- a/tools/generate_categorical_fim.py
+++ b/tools/generate_categorical_fim.py
@@ -425,7 +425,9 @@ def iterate_through_huc_stage_based(workspace, huc, fim_dir, huc_dictionary, thr
                         category = 'moderate_' + str(interval_stage).replace('.', 'p') + 'ft'
                     if interval_stage >= major_stage:
                         category = 'major_' + str(interval_stage).replace('.', 'p') + 'ft'
-                    executor.submit(produce_stage_based_catfim_tifs, stage, datum_adj_ft, branch_dir, lid_usgs_elev, lid_altitude, fim_dir, segments, lid, huc, lid_directory, category, number_of_jobs)
+                        print("STAGE")
+                    print(stage)
+                    executor.submit(produce_stage_based_catfim_tifs, interval_stage, datum_adj_ft, branch_dir, lid_usgs_elev, lid_altitude, fim_dir, segments, lid, huc, lid_directory, category, number_of_jobs)
             except TypeError:  # sometimes the thresholds are Nonetypes
                 pass
                     
@@ -628,6 +630,8 @@ def produce_stage_based_catfim_tifs(stage, datum_adj_ft, branch_dir, lid_usgs_el
             # Create inundation maps with branch and stage data
             try:
                 print("Running inundation for " + huc + " and branch " + branch)
+                print("HAND STAGE")
+                print(hand_stage)
                 executor.submit(produce_inundation_map_with_stage_and_feature_ids, rem_path, catchments_path, hydroid_list, hand_stage, lid_directory, category, huc, lid, branch)
             except Exception:
                 messages.append([f'{lid}:inundation failed at {category}'])
@@ -682,7 +686,6 @@ def produce_stage_based_catfim_tifs(stage, datum_adj_ft, branch_dir, lid_usgs_el
 
 
 if __name__ == '__main__':
-
     
     # Parse arguments
     parser = argparse.ArgumentParser(description = 'Run Categorical FIM')

--- a/tools/generate_categorical_fim_mapping.py
+++ b/tools/generate_categorical_fim_mapping.py
@@ -143,6 +143,7 @@ def post_process_huc_level(job_number_tif, ahps_dir_list, huc_dir, attributes_di
                     magnitude = os.path.split(tif_to_process)[1].split('_')[1]
                     try:
                         interval_stage = float((os.path.split(tif_to_process)[1].split('_')[2]).replace('p', '.').replace("ft", ""))
+                        print(interval_stage)
                         if interval_stage == 'extent':
                             interval_stage = None
                     except ValueError:

--- a/tools/generate_categorical_fim_mapping.py
+++ b/tools/generate_categorical_fim_mapping.py
@@ -143,7 +143,6 @@ def post_process_huc_level(job_number_tif, ahps_dir_list, huc_dir, attributes_di
                     magnitude = os.path.split(tif_to_process)[1].split('_')[1]
                     try:
                         interval_stage = float((os.path.split(tif_to_process)[1].split('_')[2]).replace('p', '.').replace("ft", ""))
-                        print(interval_stage)
                         if interval_stage == 'extent':
                             interval_stage = None
                     except ValueError:


### PR DESCRIPTION
This merge fixes a bug where all of the Stage-Based intervals were the same. Closes #777.

## Changes
- `/tools/generate_categorical_fim.py`: Changed `stage` variable to `interval_stage` variable in `produce_stage_based_catfim_tifs` function call.

## Testing
We tested this on UCS and it ran properly.

## Screenshots
![image](https://user-images.githubusercontent.com/69594899/209994229-d00b8d57-6b91-4821-a277-7ecd6b41eafe.png)

![image](https://user-images.githubusercontent.com/69594899/209994250-be962b68-3fb0-4f05-8ff0-385f49301d8b.png)



