### PR TITLE
[1pt] PR: Update hydrovis S3 push whitelist

### DIFF
--- a/config/aws_s3_put_fim4_hydrovis_whitelist.lst
+++ b/config/aws_s3_put_fim4_hydrovis_whitelist.lst
@@ -2,3 +2,4 @@ hydroTable{}.csv
 gw_catchments_reaches_filtered_addedAttributes{}.tif
 rem_zeroed_masked{}.tif
 usgs_elev_table.csv
+crosswalk_table.csv

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,19 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## v4.0.(pending) - 2023-01-06 - [PR#781](https://github.com/NOAA-OWP/inundation-mapping/pull/781)
+
+Added crosswalk_table.csv from the root output folder as being a file push up to Hydrovis s3 bucket after FIM BED runs.
+
+### Changes
+
+- `config`
+    - `aws_s3_put_fim4_hydrovis_whitelist.lst`:  Added crosswalk_table.csv to whitelist.
+
+
+<br/><br/>
+
 ## v4.0.17.3 - 2022-12-23 - [PR#773](https://github.com/NOAA-OWP/inundation-mapping/pull/773)
 
 Cleans up REM masking of levee-protected areas and fixes associated error.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
-## v4.0.(pending) - 2023-01-06 - [PR#781](https://github.com/NOAA-OWP/inundation-mapping/pull/781)
+## v4.0.17.4 - 2023-01-06 - [PR#781](https://github.com/NOAA-OWP/inundation-mapping/pull/781)
 
 Added crosswalk_table.csv from the root output folder as being a file push up to Hydrovis s3 bucket after FIM BED runs.
 


### PR DESCRIPTION
Added crosswalk_table.csv from the root output folder as being a file push up to Hydrovis s3 bucket after FIM BED runs.

### Changes

- `config`
    - `aws_s3_put_fim4_hydrovis_whitelist.lst`:  Added crosswalk_table.csv to whitelist.

### Testing

Did a test push of a small batch up to Hydrovis s3 bucket and confirmed the crosswalk file was there.
