### PR TITLE
[1pt] PR: Remove Great Lakes clipping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,19 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.X.XX.X - 2023-01-11 - [PR#790](https://github.com/NOAA-OWP/inundation-mapping/pull/790)
+
+Remove Great Lakes clipping
+
+### Changes
+
+- `src/`
+    - `clip_vectors_to_wbd.py`: Removes Great Lakes clipping and references to Great Lakes polygons and lake buffer size
+
+    - `gms/run_by_unit.sh`: Removes Great Lakes polygon and lake buffer size arguments to `src/clip_vectors_to_wbd.py`
+
+<br/><br/>
+
 ## v4.0.18.0 - 2023-01-03 - [PR#780](https://github.com/NOAA-OWP/inundation-mapping/pull/780)
 
 Clips WBD and stream branch buffer polygons to DEM domain.

--- a/src/clip_vectors_to_wbd.py
+++ b/src/clip_vectors_to_wbd.py
@@ -26,8 +26,6 @@ def subset_vector_layers(subset_nwm_lakes,
                          subset_landsea,
                          nwm_headwaters,
                          subset_nld_lines,
-                         great_lakes,
-                         lake_buffer_distance,
                          wbd_buffer_distance,
                          levee_protected_areas,
                          subset_levee_protected_areas):
@@ -52,26 +50,9 @@ def subset_vector_layers(subset_nwm_lakes,
     wbd_streams_buffer = wbd_buffer.copy()
     wbd_streams_buffer.geometry = wbd_streams_buffer.geometry.buffer(-3*dem_cellsize, resolution=32)
 
-    great_lakes = gpd.read_file(great_lakes, mask=wbd_buffer).reset_index(drop=True)
-
-    if not great_lakes.empty:
-        print("Masking Great Lakes for HUC{} {}".format(hucUnitLength, hucCode), flush=True)
-
-        # Clip excess lake area
-        great_lakes = gpd.clip(great_lakes, wbd_buffer)
-
-        # Buffer remaining lake area
-        great_lakes.geometry = great_lakes.buffer(lake_buffer_distance)
-
-        # Removed buffered GL from WBD buffer
-        wbd_buffer = gpd.overlay(wbd_buffer, great_lakes, how='difference')
-        wbd_streams_buffer = gpd.overlay(wbd_streams_buffer, great_lakes, how='difference')
-
     wbd_buffer = wbd_buffer[['geometry']]
     wbd_streams_buffer = wbd_streams_buffer[['geometry']]
     wbd_buffer.to_file(wbd_buffer_filename, driver=getDriver(wbd_buffer_filename), index=False)
-
-    del great_lakes
 
     # Clip ocean water polygon for future masking ocean areas (where applicable)
     landsea = gpd.read_file(landsea, mask=wbd_buffer)
@@ -185,10 +166,6 @@ if __name__ == '__main__':
                         required=True)	 
     parser.add_argument('-z','--subset-nld-lines', help='Subset of NLD levee vectors for HUC',
                         required=True)
-    parser.add_argument('-gl','--great-lakes', help='Great Lakes layer', 
-                        required=True)
-    parser.add_argument('-lb','--lake-buffer-distance', help='Great Lakes Mask buffer distance',
-                        required=True, type=int)
     parser.add_argument('-wb','--wbd-buffer-distance', help='WBD Mask buffer distance', 
                         required=True, type=int)
     parser.add_argument('-lpf','--levee-protected-areas', 

--- a/src/gms/run_by_unit.sh
+++ b/src/gms/run_by_unit.sh
@@ -92,8 +92,6 @@ cmd_args+=" -w $input_nwm_flows"
 cmd_args+=" -x $outputHucDataDir/LandSea_subset.gpkg"
 cmd_args+=" -y $input_nwm_headwaters"
 cmd_args+=" -z $outputHucDataDir/nld_subset_levees.gpkg"
-cmd_args+=" -gl $input_GL_boundaries"
-cmd_args+=" -lb $lakes_buffer_dist_meters"
 cmd_args+=" -wb $wbd_buffer"
 cmd_args+=" -lpf $input_nld_levee_protected_areas"
 cmd_args+=" -lps $outputHucDataDir/LeveeProtectedAreas_subset.gpkg"
@@ -103,7 +101,7 @@ Tcount
 python3 $srcDir/clip_vectors_to_wbd.py $cmd_args
 
 : '
-python3 $srcDir/clip_vectors_to_wbd.py -d $hucNumber -w $input_nwm_flows -l $input_nwm_lakes -r $input_NLD -g $outputHucDataDir/wbd.gpkg -f $outputHucDataDir/wbd_buffered.gpkg -m $input_nwm_catchments -y $input_nwm_headwaters -v $input_LANDSEA -lpf $input_nld_levee_protected_areas -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nwm_headwater_points_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -x $outputHucDataDir/LandSea_subset.gpkg -lps $outputHucDataDir/LeveeProtectedAreas_subset.gpkg -gl $input_GL_boundaries -lb $lakes_buffer_dist_meters -wb $wbd_buffer -i $input_DEM -j $input_DEM_domain
+python3 $srcDir/clip_vectors_to_wbd.py -d $hucNumber -w $input_nwm_flows -l $input_nwm_lakes -r $input_NLD -g $outputHucDataDir/wbd.gpkg -f $outputHucDataDir/wbd_buffered.gpkg -m $input_nwm_catchments -y $input_nwm_headwaters -v $input_LANDSEA -lpf $input_nld_levee_protected_areas -z $outputHucDataDir/nld_subset_levees.gpkg -a $outputHucDataDir/nwm_lakes_proj_subset.gpkg -n $outputHucDataDir/nwm_catchments_proj_subset.gpkg -e $outputHucDataDir/nwm_headwater_points_subset.gpkg -b $outputHucDataDir/nwm_subset_streams.gpkg -x $outputHucDataDir/LandSea_subset.gpkg -lps $outputHucDataDir/LeveeProtectedAreas_subset.gpkg -wb $wbd_buffer -i $input_DEM -j $input_DEM_domain
 '
 
 ## Clip WBD8 ##


### PR DESCRIPTION
Removes Great Lakes clipping. Unnecessary since removal of NHD datasets (PR #744). Closes #783.

## Changes

- `src/`
    - `clip_vectors_to_wbd.py`: Removed Great Lakes clipping section and references to Great Lakes polygon dataset.
    - `gms/run_by_unit.sh`: Removed parameters for Great Lakes polygons and lake buffer size

## Testing

1. `gms_pipeline.sh` produced equivalent results on the original problem HUCs (04040002 and 04060101) with Great Lakes clipping removed.