### PR TITLE
[1pt] PR: Bug fix: combine_crosswalk_tables.py fails if only one HUC is run

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,14 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.X.XX.X - 2023-01-17 - [PR#796](https://github.com/NOAA-OWP/inundation-mapping/pull/796)
+
+### Changes
+
+- `tools/gms_tools/combine_crosswalk_tables.py`: Checks length of dataframe list before concatenating
+
+<br/><br/>
+
 ## v4.0.19.0 - 2023-01-06 - [PR#782](https://github.com/NOAA-OWP/inundation-mapping/pull/782)
 
 Changes the projection of HAND processing to EPSG 5070.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.X.XX.X - 2023-01-17 - [PR#796](https://github.com/NOAA-OWP/inundation-mapping/pull/796)
+## v4.0.19.1 - 2023-01-17 - [PR#796](https://github.com/NOAA-OWP/inundation-mapping/pull/796)
 
 ### Changes
 

--- a/tools/gms_tools/combine_crosswalk_tables.py
+++ b/tools/gms_tools/combine_crosswalk_tables.py
@@ -24,7 +24,10 @@ def combine_crosswalk_tables(data_directory, output_filename):
         else:
             print(f'{filename} is missing.')
 
-    df = pd.concat(dfs)
+    if len(dfs) > 1:
+        df = pd.concat(dfs)
+    else:
+        df = dfs
 
     df.to_csv(output_filename, index=False)
 

--- a/tools/gms_tools/combine_crosswalk_tables.py
+++ b/tools/gms_tools/combine_crosswalk_tables.py
@@ -26,10 +26,8 @@ def combine_crosswalk_tables(data_directory, output_filename):
 
     if len(dfs) > 1:
         df = pd.concat(dfs)
-    else:
-        df = dfs
 
-    df.to_csv(output_filename, index=False)
+        df.to_csv(output_filename, index=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bug fix for `combine_crosswalk_tables.py` fails if only one HUC is run. Fixes #795

## Changes

- `tools/gms_tools/combine_crosswalk_tables.py`: Checks length of dataframe list before concatenating

## Testing

1. Successfully ran `gms_pipeline.sh -u 12030105 -c /foss_fim/config/params_template.env -j 6 -o -n dev`