### PR TITLE
[1pt] PR: Fix for missing branch_id.lst file

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,88 +1,14 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.1.3.0 - 2023-02-13 - [PR#812](https://github.com/NOAA-OWP/inundation-mapping/pull/812)
+## v4.2.0.1 - 2023-02-16 - [PR#827](https://github.com/NOAA-OWP/inundation-mapping/pull/827)
 
-An update was required to adjust host name when in the AWS environment
-
-### Changes
-
-- `fim_post_processing.sh`: Added an "if isAWS" flag system based on the input command args from fim_pipeline.sh or 
-
-- `tools/calibration-db`
-    - `README.md`: Minor text correction.
-
-<br/><br/>
-
-## v4.1.2.0 - 2023-02-15 - [PR#808](https://github.com/NOAA-OWP/inundation-mapping/pull/808)
-
-Add `pytest` package and refactor existing unit tests. Update parameters to unit tests (`/unit_tests/*_params.json`) to valid paths. Add leading slash to paths in `/config/params_template.env`.
-
-### Additions
-
-- `/unit_tests`
-  - `__init__.py`  - needed for `pytest` command line executable to pick up tests.
-  - `pyproject.toml`  - used to specify which warnings are excluded/filtered.
-  - `/gms`  
-    - `__init__.py` - needed for `pytest` command line executable to pick up tests.
-  - `/tools`
-    - `__init__.py`  - needed for `pytest` command line executable to pick up tests.
-    - `inundate_gms_params.json` - file moved up into this directory
-    - `inundate_gms_test.py`     - file moved up into this directory
-    - `inundation_params.json`   - file moved up into this directory
-    - `inundation_test.py`       - file moved up into this directory
-
-### Removals
-
-- `/unit_tests/tools/gms_tools/` directory removed, and files moved up into `/unit_tests/tools`    
- 
-### Changes
-
-- `Pipfile` - updated to include pytest as a dependency
-- `Pipfile.lock` - updated to include pytest as a dependency
-
-- `/config`
-  - `params_template.env` - leading slash added to paths
-  
-- `/unit_tests/` - All of the `*_test.py` files were refactored to follow the `pytest` paradigm.  
-  - `*_params.json` - valid paths on `fim-dev1` provided
-  - `README.md`  - updated to include documentation on pytest.  
-  - `unit_tests_utils.py`  
-  - `__template_unittests.py` -> `__template.py` - exclude the `_test` suffix to remove from test suite. Updated example on new format for pytest.
-  - `check_unit_errors_test.py`  
-  - `clip_vectors_to_wbd_test.py`  
-  - `filter_catchments_and_add_attributes_test.py`  
-  - `rating_curve_comparison_test.py`  
-  - `shared_functions_test.py`  
-  - `split_flow_test.py`  
-  - `usgs_gage_crosswalk_test.py`  
-  - `aggregate_branch_lists_test.py`  
-  - `generate_branch_list_test.py`  
-  - `generate_branch_list_csv_test.py`  
-  - `aggregate_branch_lists_test.py`  
-  - `generate_branch_list_csv_test.py`  
-  - `generate_branch_list_test.py`  
-    - `/gms`  
-      - `derive_level_paths_test.py`  
-      - `outputs_cleanup_test.py`
-    - `/tools`
-      - `inundate_unittests.py` -> `inundation_test.py`  
-      - `inundate_gms_test.py`
-
-
-<br/><br/>
-
-## v4.1.1.0 - 2023-02-16 - [PR#809](https://github.com/NOAA-OWP/inundation-mapping/pull/809)
-
-The CatFIM code was updated to allow 1-foot interval processing across all stage-based AHPS sites ranging from action stage to 5 feet above major stage, along with restart capability for interrupted processing runs.
+FIM 4.2.0.0. was throwing errors for 14 HUCs that did not have any level paths. These are HUCs that have only stream orders 1 and 2 and are covered under branch zero, but no stream orders 3+ (no level paths).  This has now been changed to not throw an error but continue to process of the HUC.
 
 ### Changes
 
-- `tools/generate_categorical_fim.py` (all changes made here)
-    - Added try-except blocks for code that didn't allow most sites to actually get processed because it was trying to check values of some USGS-related variables that most of the sites didn't have
-    - Overwrite abilities of the different outputs for the viz team were not consistent (i.e., one of the files had the ability to be overwritten but another didn't), so that has been made consistent to disallow any overwrites of the existing final outputs for a specified output folder.
-    - The code also has the ability to restart from an interrupted run and resume processing uncompleted HUCs by first checking for a simple "complete" file for each HUC. If a HUC has that file, then it is skipped (because it already completed processing during a run for a particular output folder / run name).
-    - When a HUC is successfully processed, an empty "complete" text file is created / touched.
+- `src`
+    - `run_unit_wb.sh`: Test if branch_id.lst exists, which legitimately might not. Also a bit of text cleanup.
 
 <br/><br/>
 

--- a/src/run_unit_wb.sh
+++ b/src/run_unit_wb.sh
@@ -242,7 +242,13 @@ echo
 echo "---- Start of branch processing for $hucNumber"
 branch_processing_start_time=`date +%s`
 
-parallel --eta --timeout $branch_timeout -j $jobBranchLimit --joblog $branchSummaryLogFile --colsep ',' -- $srcDir/process_branch.sh $runName $hucNumber :::: $branch_list_lst_file
+if [ -f $branch_list_lst_file ]; then
+    # There may not be a branch_ids.lst if there were no level paths (no stream orders 3+)
+    # but there will still be a branch zero
+    parallel --eta --timeout $branch_timeout -j $jobBranchLimit --joblog $branchSummaryLogFile --colsep ',' -- $srcDir/process_branch.sh $runName $hucNumber :::: $branch_list_lst_file
+else
+    echo "No level paths exist with this HUC. Processing branch zero only."
+fi
 
 # -------------------
 ## REMOVE FILES FROM DENY LIST FOR BRANCH ZERO (but using normal branch deny) ##
@@ -256,7 +262,7 @@ else
     $srcDir/outputs_cleanup.py -d $outputHucDataDir -l $deny_branches_list -b 0
 fi
 
-echo "---- All huc for $hucNumber branches have been now processed"
+echo "---- HUC $hucNumber - branches have now been processed"
 Calc_Duration $branch_processing_start_time
 echo
 


### PR DESCRIPTION
FIM 4.2.0.0. was throwing errors for 14 HUCs that did not have any level paths. These are HUCs that have only stream orders 1 and 2 and are covered under branch zero, but no stream orders 3+ (no level paths).  This has now been changed to not throw an error but continue to process of the HUC.

### Changes

- `src`
    - `run_unit_wb.sh`: Test if branch_id.lst exists, which legitimately might not. Also a bit of text cleanup.

## Testing

Ran fim_process_unit_wb.sh with a valid HUC and one invalid HUC to ensure the fix is correct. An invalid HUC is 01010011. Prior to the fix, the unit_errors folder would have a HUC unit log in the folder, but will not exists post fix. Pre-fix will show only partial cleanup of the branch_zero (branches/0) folder and you will specifically  notice the dem_meters_0.tif file will exist. Post fix, the dem_meters_0_tif will not exist as the second branch zero cleanup will have completed.

A few other invalid HUC's are 04160003 and 12110203. 

