### PR TITLE
[1pt] PR: Delete intermediate agreedem files

### DIFF
--- a/config/deny_branch_unittests.lst
+++ b/config/deny_branch_unittests.lst
@@ -1,12 +1,15 @@
 # List of files for branches to delete
 # Use comment to allow list the file
 # Use curly braces to denote branch_id
+agree_binary_bufgrid.tif
 agree_bufgrid.tif
 agree_bufgrid_allo.tif
 agree_bufgrid_dist.tif
+agree_bufgrid_zerod.tif
 agree_smogrid.tif
 agree_smogrid_allo.tif
 agree_smogrid_dist.tif
+agree_smogrid_zerod.tif
 catch_list_{}.txt
 coordFile_{}.txt
 crosswalk_table_{}.csv

--- a/config/deny_branch_zero.lst
+++ b/config/deny_branch_zero.lst
@@ -1,12 +1,15 @@
 # List of files for branch zero to delete
 # Use comment to allow list the file
 # Use curly braces to denote branch_id
+agree_binary_bufgrid.tif
 agree_bufgrid.tif
 agree_bufgrid_allo.tif
 agree_bufgrid_dist.tif
+agree_bufgrid_zerod.tif
 agree_smogrid.tif
 agree_smogrid_allo.tif
 agree_smogrid_dist.tif
+agree_smogrid_zerod.tif
 catch_list_{}.txt
 coordFile_{}.txt
 crosswalk_table_{}.csv

--- a/config/deny_branches.lst
+++ b/config/deny_branches.lst
@@ -1,12 +1,15 @@
 # List of files for branches to delete
 # Use comment to allow list the file
 # Use curly braces to denote branch_id
+agree_binary_bufgrid.tif
 agree_bufgrid.tif
 agree_bufgrid_allo.tif
 agree_bufgrid_dist.tif
+agree_bufgrid_zerod.tif
 agree_smogrid.tif
 agree_smogrid_allo.tif
 agree_smogrid_dist.tif
+agree_smogrid_zerod.tif
 catch_list_{}.txt
 coordFile_{}.txt
 crosswalk_table_{}.csv

--- a/config/deny_unit.lst
+++ b/config/deny_unit.lst
@@ -1,5 +1,14 @@
 # List of files for units to delete
 # Use comment to allow list the file
+agree_binary_bufgrid.tif
+agree_bufgrid.tif
+agree_bufgrid_allo.tif
+agree_bufgrid_dist.tif
+agree_bufgrid_zerod.tif
+agree_smogrid.tif
+agree_smogrid_allo.tif
+agree_smogrid_dist.tif
+agree_smogrid_zerod.tif
 #branch_id.lst
 #branch_polygons.gpkg
 #LandSea_subset.gpkg


### PR DESCRIPTION
Deletes intermediate files generated by `src/agreedem.py` by adding them to `config/deny_*.lst`. Closes #839.

## Additions

- `config/`
    - `deny_branch_zero.lst`, `deny_branches.lst`, `deny_branch_unittests.lst`: Added `agree_binary_bufgrid.tif`, `agree_bufgrid_zerod.tif`, and `agree_smogrid_zerod.tif`
    - `deny_unit.lst`: Added `agree_binary_bufgrid.tif`, `agree_bufgrid.tif`, `agree_bufgrid_allo.tif`, `agree_bufgrid_dist.tif`,  `agree_bufgrid_zerod.tif`, `agree_smogrid.tif`, `agree_smogrid_allo.tif`, `agree_smogrid_dist.tif`, `agree_smogrid_zerod.tif`