### PR TITLE
[1pt] PR: Bug fix - Change .split() to os.path.splitext()

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 Bug fix to change `.split()` to `os.path.splitext()`
 
 ### Changes
-- `src/stream_branches.py`: Changes 3 occurrences of `.split()` to `os.path.splitext()`
+- `src/stream_branches.py`: Change 3 occurrences of `.split()` to `os.path.splitext()`
 
 <br/><br/>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,15 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.3.x.x - 2023-03-20 - [PR#851](https://github.com/NOAA-OWP/inundation-mapping/pull/851)
+
+Bug fix to change `.split()` to `os.path.splitext()`
+
+### Changes
+- `src/stream_branches.py`: Changes 3 occurrences of `.split()` to `os.path.splitext()`
+
+<br/><br/>
+
 ## v4.3.3.0 - 2023-03-02 - [PR#831](https://github.com/NOAA-OWP/inundation-mapping/pull/831)
 
 Addresses bug wherein multiple CatFIM sites in the flow-based service were displaying the same NWS LID. This merge also creates a workaround solution for a slowdown that was observed in the WRDS location API, which may be a temporary workaround, until WRDS addresses the slowdown.

--- a/src/stream_branches.py
+++ b/src/stream_branches.py
@@ -1073,8 +1073,8 @@ class StreamBranchPolygons(StreamNetwork):
             out_records += __find_matching_record(vector,branch_id_attribute,bid,matching='all')
 
         if (out_filename_template is not None) & ( len(out_records) != 0):
-                base,ext = out_filename_template.split('.')
-                out_filename = base + "_{}.".format(bid) + ext
+                base, ext = os.path.splitext(out_filename_template)
+                out_filename = base + "_{}".format(bid) + ext
                 
                 with fiona.open(out_filename,'w',**source_meta) as out_file:
                     out_file.writerecords(out_records)
@@ -1153,8 +1153,8 @@ class StreamBranchPolygons(StreamNetwork):
                 return_list += [out]
                 
                 if (out_filename_template is not None) & (not out.empty):
-                    base,ext = out_filename_template.split('.')
-                    out_filename = base + "_{}.".format(branch_id) + ext
+                    base, ext = os.path.splitext(out_filename_template)
+                    out_filename = base + "_{}".format(branch_id) + ext
                     StreamNetwork.write(out,out_filename)
         
         return(return_list)

--- a/src/stream_branches.py
+++ b/src/stream_branches.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import geopandas as gpd
 import pandas as pd
 import rasterio
@@ -1134,8 +1135,8 @@ class StreamBranchPolygons(StreamNetwork):
                 if out_filename_template is not None:
                     branch_id = row[self.branch_id_attribute]
 
-                    base,ext = out_filename_template.split('.')
-                    out_filename = base + "_{}.".format(branch_id) + ext
+                    base, ext = os.path.splitext(out_filename_template)
+                    out_filename = base + "_{}".format(branch_id) + ext
                     
                     with rasterio.open(out_filename,'w',**buffered_meta) as out:
                         out.write(buffered_array)


### PR DESCRIPTION
Changes `.split()` to `os.path.splitext()` to avoid error where there are multiple periods in the path where `.split()` would return more than two items. Fixes #844.

## Changes

- `src/stream_branches.py`: Changed 3 instances of `.split()` to `os.path.splitext()`

## Testing

Successfully ran `fim_pipeline.sh -u 12050006 -n dev-4.3.1.0 -c /foss_fim/config/params_template.env`