### PR TITLE
[1pt] PR: Fixed datatype issue in coord accuracy list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,12 +3,12 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## v4.(to be assigned) - 2023-03-20 - [PR#854](https://github.com/NOAA-OWP/inundation-mapping/pull/854)
 
-At least one site (e.g. TRYM7) was not been getting mapped in Stage-Based CatFIM, despite having all of the acceptable accuracy codes. This was caused by a data type issue in the `acceptable_coord_acc_code_list` in `tools_shared_variables.py` having the accuracy code of 5 as a string instead of an integer.
+At least one site (e.g. TRYM7) was not been getting mapped in Stage-Based CatFIM, despite having all of the acceptable accuracy codes. This was caused by a data type issue in the `acceptable_coord_acc_code_list` in `tools_shared_variables.py` having the accuracy codes of 5 and 1 as a strings instead of an integers.
 
 
 ### Changes
 
-- `/tools/tools_shared_variables.py`: Added an integer 5 to the acceptable_coord_acc_code_list, kept the '5' string as well.
+- `/tools/tools_shared_variables.py`: Added integers 5 and 1 to the acceptable_coord_acc_code_list, kept the '5' and '1' strings as well.
 
 <br/><br/>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.(to be assigned) - 2023-03-20 - [PR#854](https://github.com/NOAA-OWP/inundation-mapping/pull/854)
+
+At least one site (e.g. TRYM7) was not been getting mapped in Stage-Based CatFIM, despite having all of the acceptable accuracy codes. This was caused by a data type issue in the `acceptable_coord_acc_code_list` in `tools_shared_variables.py` having the accuracy code of 5 as a string instead of an integer.
+
+
+### Changes
+
+- `/tools/tools_shared_variables.py`: Added an integer 5 to the acceptable_coord_acc_code_list, kept the '5' string as well.
+
+<br/><br/>
+
 ## v4.3.3.0 - 2023-03-02 - [PR#831](https://github.com/NOAA-OWP/inundation-mapping/pull/831)
 
 Addresses bug wherein multiple CatFIM sites in the flow-based service were displaying the same NWS LID. This merge also creates a workaround solution for a slowdown that was observed in the WRDS location API, which may be a temporary workaround, until WRDS addresses the slowdown.

--- a/tools/tools_shared_variables.py
+++ b/tools/tools_shared_variables.py
@@ -65,7 +65,7 @@ CYAN_BOLD = '\033[36;1m'
 # USGS gages acceptance criteria. Likely not constants, so not using all caps.
 # ANY CHANGE TO THESE VALUES SHOULD WARRANT A CODE VERSION CHANGE
 # https://help.waterdata.usgs.gov/code/coord_acy_cd_query?fmt=html
-acceptable_coord_acc_code_list = ['H','1','5','S','R','B','C','D','E']
+acceptable_coord_acc_code_list = ['H','1','5','S','R','B','C','D','E', 5]
 # https://help.waterdata.usgs.gov/code/coord_meth_cd_query?fmt=html
 acceptable_coord_method_code_list = ['C','D','W','X','Y','Z','N','M','L','G','R','F','S']
 # https://help.waterdata.usgs.gov/codes-and-parameters/codes#SI

--- a/tools/tools_shared_variables.py
+++ b/tools/tools_shared_variables.py
@@ -65,7 +65,7 @@ CYAN_BOLD = '\033[36;1m'
 # USGS gages acceptance criteria. Likely not constants, so not using all caps.
 # ANY CHANGE TO THESE VALUES SHOULD WARRANT A CODE VERSION CHANGE
 # https://help.waterdata.usgs.gov/code/coord_acy_cd_query?fmt=html
-acceptable_coord_acc_code_list = ['H','1','5','S','R','B','C','D','E', 5]
+acceptable_coord_acc_code_list = ['H','1','5','S','R','B','C','D','E', 5, 1]
 # https://help.waterdata.usgs.gov/code/coord_meth_cd_query?fmt=html
 acceptable_coord_method_code_list = ['C','D','W','X','Y','Z','N','M','L','G','R','F','S']
 # https://help.waterdata.usgs.gov/codes-and-parameters/codes#SI


### PR DESCRIPTION
At least one site (TRYM7) has not been getting mapped in Stage-Based CatFIM, despite having all of the acceptable accuracy codes. This was caused by a data type issue in the acceptable_coord_acc_code_list in tools_shared_variables.py having 5 as a string instead of an integer.

## Changes

- `/tools/tools_shared_variables.py`: Added an integer `5` to the `acceptable_coord_acc_code_list`

## Testing

1. Ran stage-based catfim for TRYN7 and confirmed that mapping is now occurring.