### PR TITLE
#832 [1pt] PR: Branch should be get cleaned up with an exit of code 61 

### DIFF
--- a/src/process_branch.sh
+++ b/src/process_branch.sh
@@ -38,6 +38,7 @@ do
         echo
         err_exists=1
         echo "***** Branch has no valid flowlines *****"
+        rm -rf $outputRunDataDir/$hucNumber/branches/$branchId/
     elif [ $code -ne 0 ]; then
         echo
         err_exists=1


### PR DESCRIPTION
There are currently about 164 branches that error out with an error code of 61 because HAND cannot be run on them (a catchment with a lake, for example). This update removes the branch file if it gets an error code of 61. 

## Additions

- `src/process_branch.sh`: Added line 41, which removes the outputs and output folder if Error 61 occurs.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
