### PR TITLE
[1pt] PR: HUC outputs not be cleaned and erroring out

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,20 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## v4.3.5.1 - 2023-04-01 - [PR#867](https://github.com/NOAA-OWP/inundation-mapping/pull/867)
+
+outputs_cleanup.py was throwing an error saying that the HUC source directory (to be cleaned up), did not exist. This was confirmed in a couple of environments. The src path in run_unit_wb.sh was sending in the "outputs" directory and not the "fim_temp" directory. This might have been a merge issue.
+
+The log file was moved to the unit_errors folder to validate the error, as expected.
+
+### Changes  
+
+- `src/run_unit_wb.sh`: Change the source path being submitted to `outputs_cleanup.py` from the `outputs` HUC directory to the `fim_temp` HUC directory.
+- `fim_process_unit_wb.sh`: Updated the phrase "Copied temp directory" to "Moved temp directory"
+
+<br/><br/>
+
 ## v4.3.5.0 - 2023-03-02 - [PR#857](https://github.com/NOAA-OWP/inundation-mapping/pull/857)
 
 Addresses changes to function calls needed to run upgraded Shapely library plus other related library upgrades. Upgraded libraries include:

--- a/fim_process_unit_wb.sh
+++ b/fim_process_unit_wb.sh
@@ -128,7 +128,7 @@ fi
 echo "============================================================================================="
 echo 
 mv -f $tempHucDataDir $outputHucDataDir
-echo "***** Copied temp directory: $tempHucDataDir to output directory: $outputHucDataDir  *****"
+echo "***** Moved temp directory: $tempHucDataDir to output directory: $outputHucDataDir  *****"
 echo
 echo "============================================================================================="
 

--- a/src/run_unit_wb.sh
+++ b/src/run_unit_wb.sh
@@ -263,7 +263,7 @@ if [ -f $deny_unit_list ]; then
     echo -e $startDiv"Remove files $hucNumber"
     date -u
     Tstart
-    $srcDir/outputs_cleanup.py -d $outputHucDataDir -l $deny_unit_list -b $hucNumber
+    $srcDir/outputs_cleanup.py -d $tempHucDataDir -l $deny_unit_list -b $hucNumber
     Tcount
 fi
 


### PR DESCRIPTION
outputs_cleanup.py was throwing an error saying that the HUC source directory (to be cleaned up), did not exist. This was confirmed in a couple of environments. The src path in run_unit_wb.sh was sending in the "outputs" directory and not the "fim_temp" directory. This might have been a merge issue.

The log file was moved to the unit_errors folder to validate the error, as expected.

Related to [Issue 866]([2pt] FIM 4.3.5.0 error on outputs_cleanup.py #866). 

### Changes  

- `src/run_unit_wb.sh`: Change the source path being submitted to `outputs_cleanup.py` from the `outputs` HUC directory to the `fim_temp` HUC directory.
- `fim_process_unit_wb.sh`: Updated the phrase "Copied temp directory" to "Moved temp directory"

### Testing

Ran a simply fim pipeline for one HUC, watched the screen outputs, ensure the HUC directory files were truly cleaned as per the deny unit list and ensure the HUC log did not show up in the unit_errors folder.

### Checklist

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g.: `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] Changes adhere to [PEP-8 Style Guidelines](https://peps.python.org/pep-0008/)
- [x] Any _change_ in functionality is tested
- [ ] Passes all unit tests locally (inside interactive Docker container, at `/foss_fim/`, run: `pytest unit_tests/`)
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated ([CHANGELOG](/docs/CHANGELOG.md) and/or [README](/README.md))
- [ ] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)
