### PR TITLE
Hotfix to address nrmse error

### DIFF
--- a/tools/rating_curve_comparison.py
+++ b/tools/rating_curve_comparison.py
@@ -303,7 +303,6 @@ def aggregate_metrics(output_dir,procs_list,stat_groups):
         #         usgs_recurr_stats.to_csv(agg_usgs_interp_elev_stats,index=False, mode='a',header=False)
         #     else:
         #         usgs_recurr_stats.to_csv(agg_usgs_interp_elev_stats,index=False)
-
         if os.path.isfile(huc[4]):
             nwm_recurr_data = pd.read_csv(huc[4],dtype={'location_id': str,
                                                         'feature_id': str})
@@ -661,7 +660,7 @@ def calculate_rc_stats_elev(rc,stat_groups=None):
 
     # Calculate nrmse
     def NRMSE(x):
-        if x['n'][0] == 1:      # when n==1, NRME equation will return an `inf` 
+        if x['n'].values == 1:      # when n==1, NRME equation will return an `inf` 
             return x['sum_y_diff'] ** 0.5
         else:
             return ((x['sum_y_diff'] / x['n']) ** 0.5) / (x['y_max'] - x['y_min'])
@@ -681,7 +680,7 @@ def calculate_rc_stats_elev(rc,stat_groups=None):
     percent_bias = station_rc.apply(lambda x: 100 * (x["yhat_minus_y"].sum() / x[usgs_elev].sum()))\
         .reset_index(stat_groups, drop = False).rename({0: "percent_bias"}, axis=1)
 
-    rc_stat_table = reduce(lambda x,y: pd.merge(x,y, on=stat_groups, how='outer'), [nrmse, mean_abs_y_diff, mean_y_diff, percent_bias])
+    rc_stat_table = reduce(lambda x,y: pd.merge(x,y, on=stat_groups, how='outer'), [n, nrmse, mean_abs_y_diff, mean_y_diff, percent_bias])
 
     return rc_stat_table
 


### PR DESCRIPTION
Hotfix for addressing an error during the NRMSE calculation/aggregation step within `tools/rating_curve_comparison.py`. Also added the "n" variable to the agg_nwm_recurr_flow_elev_stats table. Addresses #878 

### Changes  

- `tools/rating_curve_comparison.py`: address error for computing nrmse when n=1; added the "n" variable (sample size) to the output metrics table

### Testing
Example usage: `python3 foss_fim/tools/rating_curve_comparison.py -fim_dir data/outputs/htable_aggreg_post_test_3huc/ -output_dir data/tools/sierra_test/testing_versions/htable_aggreg_post_test_3huc -gages /data/inputs/usgs_gages/usgs_rating_curves.csv -flows /data/inundation_review/inundation_nwm_recurr/nwm_recurr_flow_data/ -catfim /data/inputs/usgs_gages/catfim_flows_cms.csv -j 13`

### Checklist

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [ ] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [ ] Links are provided if this PR resolves an issue, or depends on another other PR
- [ ] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g.: `dev-revise-levee-masking`)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [ ] Changes adhere to [PEP-8 Style Guidelines](https://peps.python.org/pep-0008/)
- [ ] Any _change_ in functionality is tested
- [ ] Passes all unit tests locally (inside interactive Docker container, at `/foss_fim/`, run: `pytest unit_tests/`)
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated ([CHANGELOG](/docs/CHANGELOG.md) and/or [README](/README.md))
- [ ] [Reviewers requested](https://help.github.com/articles/requesting-a-pull-request-review/)
