### PR TITLE
[1pt] PR: Stop trimming outlet levelpaths in waterbodies outside of HUC

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,18 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.5.x.x - 2024-09-12 - [PR#1284](https://github.com/NOAA-OWP/inundation-mapping/pull/1284)
+
+Segments of levelpaths that terminate in waterbodies are removed from the levelpath. If there is a waterbody downstream of the HUC then the outlet reaches may be trimmed such that the outlet no longer reaches the edge of the DEM, which causes a number of cascading issues originating in the pit-filling such that reverse flow in the DEM-derived reaches can result in erroneous flowlines and inundation. This PR stops trimming levelpaths outside of the HUC.
+
+### Changes
+
+- `src/`
+    - `derive_level_paths.py`: Adds WBD as an input to `stream_network.trim_branches_in_waterbodies()`
+    - `stream_network.py`: Selects only segments intersecting the WBD as candidates for removal if they end in waterbodies
+
+<br/><br/>
+
 ## v4.5.6.0 - 2024-08-23 - [PR#1253](https://github.com/NOAA-OWP/inundation-mapping/pull/1253)
 
 Upgrades Python packages and dependencies and fixes backwards incompatibilities with new version of `geopandas`. Major changes include:

--- a/src/derive_level_paths.py
+++ b/src/derive_level_paths.py
@@ -179,7 +179,7 @@ def Derive_level_paths(
 
     if out_stream_network_dissolved is not None:
         stream_network = stream_network.trim_branches_in_waterbodies(
-            branch_id_attribute=branch_id_attribute, verbose=verbose
+            wbd=wbd, branch_id_attribute=branch_id_attribute, verbose=verbose
         )
 
         # dissolve by levelpath

--- a/src/stream_branches.py
+++ b/src/stream_branches.py
@@ -584,7 +584,7 @@ class StreamNetwork(gpd.GeoDataFrame):
 
         return self
 
-    def trim_branches_in_waterbodies(self, branch_id_attribute, verbose=False):
+    def trim_branches_in_waterbodies(self, wbd, branch_id_attribute, verbose=False):
         """
         Recursively trims the reaches from the ends of the branches if they are in a
         waterbody (determined by the Lake attribute).
@@ -644,6 +644,14 @@ class StreamNetwork(gpd.GeoDataFrame):
 
         for branch in self[branch_id_attribute].astype(int).unique():
             tmp_self = self[self[branch_id_attribute].astype(int) == branch]
+
+            # load waterbodies
+            if isinstance(wbd, str):
+                wbd = gpd.read_file(wbd)
+
+            # trim only branches in WBD (to prevent outlet from being trimmed)
+            if isinstance(wbd, gpd.GeoDataFrame):
+                tmp_self = gpd.sjoin(tmp_self, wbd)
 
             # If entire branch is in waterbody
             if all(tmp_self.Lake.values != -9999):


### PR DESCRIPTION
Segments of levelpaths that terminate in waterbodies are removed from the levelpath (#671). If there is a waterbody downstream of the HUC then the outlet reaches may be trimmed such that the outlet no longer reaches the edge of the DEM, which causes a number of cascading issues originating in the pit-filling such that reverse flow in the DEM-derived reaches can result in erroneous flowlines and inundation. This PR stops trimming levelpaths outside of the HUC. Fixes #1280.

### Changes

- `src/`
    - `derive_level_paths.py`: Adds WBD as an input to `stream_network.trim_branches_in_waterbodies()`
    - `stream_network.py`: Selects only segments intersecting the WBD as candidates for removal if they end in waterbodies

### Testing
Tested on branch 1477000010 of HUC 12010005.

### Deployment Plan (For developer use)

_How does the changes affect the product?_
- [x] Code only?
- [ ] If applicable, has a deployment plan be created with the deployment person/team?
- [ ] Require new or adjusted data inputs? Does it have start, end and duration code (in UTC)?
- [ ] If new or updated data sets, has the FIM code been updated and tested with the new/adjusted data (subset is fine, but must be a subset of the new data)?
- [ ] Require new pre-clip set?
- [ ] Has new or updated python packages?

### Issuer Checklist (For developer use)

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] `pre-commit` hooks were run locally
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [x] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations