### PR TITLE
[1pt] WIP: Update stage-based CatFIM to prevent overflooding if stage + elevation is provided in lieu of stage 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,24 @@ Fixed missing osmid in osm_bridge_centroid.gpkg. Also, HUC column is added to ou
 <br/><br/>
 
 
+## v4.5.___ - 2025-___ - [PR#1379](https://github.com/NOAA-OWP/inundation-mapping/pull/1379)
+
+There are many sites in non-CONUS regions (AK, PR, HI) where we would like to run CatFIM but they are being excluded because they are not NWM forecast points. This update brings back the double API pull and adds in some code to filter out duplicate (and NULL) lids from the metadata lists. 
+
+### Additions
+- `inundation-mapping/tools/catfim/vis_categorical_fim.py`: Functions for reading in, processing, and visualizing CatFIM results. 
+-  `inundation-mapping/tools/catfim/notebooks/vis_catfim_cross_section.ipynb`: A new Jupyter notebook for viewing and analyzing CatFIM results.
+- `inundation-mapping/tools/catfim/notebooks/eval_catfim_metadata.ipynb`: A new Jupyter notebook for evaluating metadata and results from CatFIM runs. 
+- `inundation-mapping/tools/catfim/notebooks/.ipynb_checkpoints/vis_catfim_cross_section-checkpoint.ipynb`: Checkpoint file.
+- `inundation-mapping/tools/catfim/notebooks/.ipynb_checkpoints/eval_catfim_metadata-checkpoint.ipynb`: Checkpoint file.
+
+### Changes
+
+- `inundation-mapping/tools/catfim/generate_categorical_fim_flows.py`: Re-implements the dual API call and filters out duplicate sites.
+
+
+<br/><br/>
+
 ## v4.5.13.1 - 2024-12-13 - [PR#1361](https://github.com/NOAA-OWP/inundation-mapping/pull/1361)
 
 This PR was triggered by two dep-bot PR's. One for Tornado, one for aiohttp. Upon further research, these two exist only as dependencies for Jupyter and Jupyterlab which were very out of date. Upgrading Jupyter/JupyterLab took care of the other two.

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -744,9 +744,19 @@ def iterate_through_huc_stage_based(
                 if not os.path.exists(mapping_lid_directory):
                     os.mkdir(mapping_lid_directory)
 
+                # Check whether stage value is actually a WSE value, and fix if needed:
+                # Get lowest stage value
+                lowest_stage_val = stage_values_df['stage_value'].min()
+
+                # Stage value is larger than the elevation value, subtract the elev
+                # from the "stage" value to get the actual stage
+                if lowest_stage_val > lid_altitude:
+                    stage_values_df['stage_value'] = stage_values_df['stage_value'] - lid_altitude
+                    MP_LOG.lprint(f"{huc_lid_id}: Lowest stage val ({lowest_stage_val}) was greater than elev ({lid_altitude}). Subtracted elev from stage vals to fix.")
+
                 # At this point we have at least one valid stage/category
-                # cyle through on the stages that are valid
-                # This are not interval values
+                # Cycle through the stages that are valid
+                # These are not interval values
                 for idx, stage_row in stage_values_df.iterrows():
                     # MP_LOG.lprint(f"{huc_lid_id}: Magnitude is {category}")
                     # Pull stage value and confirm it's valid, then process

--- a/tools/catfim/generate_categorical_fim_flows.py
+++ b/tools/catfim/generate_categorical_fim_flows.py
@@ -646,7 +646,7 @@ def __load_nwm_metadata(
 
     FLOG.trace(metadata_url)
 
-    all_meta_lists = []
+    output_meta_list = []
     # Check to see if meta file already exists
     # This feature means we can copy the pickle file to another enviro (AWS?) as it won't need to call
     # WRDS unless we need a smaller or modified version. This one likely has all nws_lid data.
@@ -655,19 +655,16 @@ def __load_nwm_metadata(
         FLOG.lprint(f"Meta file already downloaded and exists at {nwm_metafile}")
 
         with open(nwm_metafile, "rb") as p_handle:
-            all_meta_lists = pickle.load(p_handle)
+            output_meta_list = pickle.load(p_handle)
 
     else:
         meta_file = os.path.join(output_catfim_dir, "nwm_metafile.pkl")
 
         FLOG.lprint(f"Meta file will be downloaded and saved at {meta_file}")
 
-        if lid_to_run != "all":
-            # single lid for now
-
-            # must_include_value variable not yet tested
-            # must_include_value = 'nws_data.rfc_forecast_point' if lid_to_run not in ['HI', 'PR', 'AK'] else None
-            all_meta_lists, ___ = get_metadata(
+        if lid_to_run != "all":  # TODO: Deprecate LID options (in favor of HUC list functionlity)
+            # Single lid for now (deprecated)
+            output_meta_list, ___ = get_metadata(
                 metadata_url,
                 select_by='nws_lid',
                 selector=[lid_to_run],
@@ -675,20 +672,14 @@ def __load_nwm_metadata(
                 upstream_trace_distance=nwm_us_search,
                 downstream_trace_distance=nwm_ds_search,
             )
+
         else:
-            # This gets all records including AK, HI and PR, but only if they ahve forecast points
+            # Dec 2024: Running two API calls: one to get all forecast points, and another
+            # to get all points (non-forecast and forecast) for the OCONUS regions. Then,
+            # duplicate LIDs are removed.
 
-            # Note: Nov 2024: AK has 152 sites with forecast points, but after research
-            # non of the AK sites that nws_data.rfc_forecast_point = False so we can
-            # exclude them.
-            # Previously we allowed HI and PR sites to come in and most were failing.
-            # So, we will include HI and PR as well here
-
-            # We can not just filter out based on dup lids as depending on which
-            # metadata load they are on, dup lid records will have different data
-
-            # orig_meta_lists, ___ = get_metadata(
-            all_meta_lists, ___ = get_metadata(
+            # Get all forecast points
+            forecast_point_meta_list, ___ = get_metadata(
                 metadata_url,
                 select_by='nws_lid',
                 selector=['all'],
@@ -697,41 +688,53 @@ def __load_nwm_metadata(
                 downstream_trace_distance=nwm_ds_search,
             )
 
-            # If we decided to put HI and PR back in we can do two loads one
-            # with the flag and one without. Then iterate through the meta_lists
-            # results and filtered out based on the state full value. Then
-            # call WRDS again with those specific states and simply concat them.
+            # Get all points for OCONUS regions (HI, PR, and AK)
+            oconus_meta_list, ___ = get_metadata(
+                metadata_url,
+                select_by='state',
+                selector=['HI', 'PR', 'AK'],
+                must_include=None,
+                upstream_trace_distance=nwm_us_search,
+                downstream_trace_distance=nwm_ds_search,
+            )
 
-            # filtered_meta_data = []
-            # for metadata in orig_meta_lists:
-            #     df = pd.json_normalize(metadata)
-            #     state = df['nws_data.state'].item()
-            #     lid = df['identifiers.nws_lid'].item()
-            #     if state.lower() not in ["alaska", "hawaii", "puerto rico"]:
-            #         filtered_meta_data.append(metadata)
-
-            # must_include='nws_data.rfc_forecast_point',
-
-            # Nov 2024: We used to call them site specific and may add them back in but ok to leave then
-
-            # islands_list, ___ = get_metadata(
-            #     metadata_url,
-            #     select_by='state',
-            #     selector=['HI', 'PR'],
-            #     must_include=None,
-            #     upstream_trace_distance=nwm_us_search,
-            #     downstream_trace_distance=nwm_ds_search,
-            # )
-
-            #  Append the lists
-            # all_meta_lists = filtered_all_meta_list + islands_list
+            # Append the lists
+            unfiltered_meta_list = forecast_point_meta_list + oconus_meta_list
 
             # print(f"len(all_meta_lists) is {len(all_meta_lists)}")
 
-        with open(meta_file, "wb") as p_handle:
-            pickle.dump(all_meta_lists, p_handle, protocol=pickle.HIGHEST_PROTOCOL)
+            # Filter the metadata list
+            output_meta_list = []
+            unique_lids, duplicate_lids = [], []  # TODO: remove?
+            duplicate_meta_list = []
+            nonelid_metadata_list = []  # TODO: remove
 
-    return all_meta_lists
+            for i, site in enumerate(unfiltered_meta_list):
+                nws_lid = site['identifiers']['nws_lid']
+
+                if nws_lid is None:
+                    # No LID available
+                    nonelid_metadata_list.append(site)  # TODO: replace with Continue
+
+                elif nws_lid in unique_lids:
+                    # Duplicate LID
+                    duplicate_lids.append(nws_lid)
+                    duplicate_meta_list.append(site)  # TODO: remove extra lists
+
+                else:
+                    # Unique/unseen LID that's not None
+                    unique_lids.append(nws_lid)
+                    output_meta_list.append(site)
+
+            FLOG.lprint(f'{len(duplicate_lids)} duplicate points removed.')
+            FLOG.lprint(f'Filtered metadatada downloaded for {len(output_meta_list)} points.')
+
+        # ----------
+
+        with open(meta_file, "wb") as p_handle:
+            pickle.dump(output_meta_list, p_handle, protocol=pickle.HIGHEST_PROTOCOL)
+
+    return output_meta_list
 
 
 if __name__ == '__main__':

--- a/tools/catfim/notebooks/.ipynb_checkpoints/eval_catfim_metadata-checkpoint.ipynb
+++ b/tools/catfim/notebooks/.ipynb_checkpoints/eval_catfim_metadata-checkpoint.ipynb
@@ -1,0 +1,1315 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "544d20bf-6273-4dd5-bae8-a42935b3e3f1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import argparse\n",
+    "import copy\n",
+    "import glob\n",
+    "import os\n",
+    "import pickle\n",
+    "import random\n",
+    "import shutil\n",
+    "import sys\n",
+    "import time\n",
+    "import traceback\n",
+    "from concurrent.futures import ProcessPoolExecutor, as_completed, wait\n",
+    "from datetime import datetime, timezone\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "from tools_shared_functions import (\n",
+    "    aggregate_wbd_hucs,\n",
+    "    filter_nwm_segments_by_stream_order,\n",
+    "    flow_data,\n",
+    "    get_metadata,\n",
+    "    get_nwm_segs,\n",
+    "    get_thresholds,\n",
+    ")\n",
+    "\n",
+    "import utils.fim_logger as fl\n",
+    "from utils.shared_variables import VIZ_PROJECTION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "1c7d9207-9b2b-431b-ab4e-3dbb3e2107f2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Functions to get process and filter the metadata\n",
+    "\n",
+    "# -------------------------------------------------------\n",
+    "def list_of_lids(conus_list, verbose):\n",
+    "    '''\n",
+    "    Extract a list of LIDs from the conus_list\n",
+    "    \n",
+    "    Example: \n",
+    "    lid_list = list_of_lids(conus_list, True)\n",
+    "    '''\n",
+    "    lid_list = []\n",
+    "    for i, site in enumerate(conus_list):\n",
+    "        nws_lid = site['identifiers']['nws_lid']\n",
+    "        lid_list.append(nws_lid)\n",
+    "    if verbose == True:\n",
+    "        print(f'List of LIDs: {lid_list}')\n",
+    "        \n",
+    "    return lid_list\n",
+    "\n",
+    "# lid_list = list_of_lids(conus_list, True)\n",
+    "\n",
+    "# -------------------------------------------------------\n",
+    "def list_duplicate_lids(conus_list, verbose):\n",
+    "    '''\n",
+    "    Extract a list of duplicate LIDs from the conus_list\n",
+    "    \n",
+    "    Example: \n",
+    "    lid_list, duplicate_lid_list = list_duplicate_lids(conus_list, True)\n",
+    "    '''\n",
+    "    lid_list = []\n",
+    "    duplicate_lid_list = []\n",
+    "     \n",
+    "    \n",
+    "    for i, site in enumerate(conus_list):\n",
+    "        nws_lid = site['identifiers']['nws_lid']\n",
+    "\n",
+    "        if nws_lid in lid_list:\n",
+    "            duplicate_lid_list.append(nws_lid)\n",
+    "        else: \n",
+    "            lid_list.append(nws_lid)\n",
+    "\n",
+    "    if verbose == True:\n",
+    "        print(f'Length of unique LID list: {len(lid_list)}')\n",
+    "        print(f'List of duplicate LIDs: {duplicate_lid_list}')\n",
+    "\n",
+    "        \n",
+    "    return lid_list, duplicate_lid_list\n",
+    "\n",
+    "# lid_list, duplicate_lid_list = list_duplicate_lids(conus_list, True)\n",
+    "\n",
+    "# -------------------------------------------------------\n",
+    "def filter_by_lid(lid_filter, conus_list, verbose):\n",
+    "    '''\n",
+    "    Function to filter conus_list by LID\n",
+    "    \n",
+    "    Example:\n",
+    "    conus_list_filt = filter_by_lid('None', conus_list, True)\n",
+    "    '''\n",
+    "    conus_list_filt = []\n",
+    "    for i, site in enumerate(conus_list):\n",
+    "        lid = site['identifiers']['nws_lid']\n",
+    "        if lid == lid_filter:\n",
+    "            conus_list_filt.append(site)\n",
+    "    if verbose == True:\n",
+    "        print(f'LID filter: {lid_filter} \\nNumber of sites: {len(conus_list_filt)}')\n",
+    "        \n",
+    "    return conus_list_filt\n",
+    "\n",
+    "# conus_list_filt = filter_by_lid('None', conus_list, True)\n",
+    "\n",
+    "# -------------------------------------------------------\n",
+    "def filter_by_state(state_filter, conus_list, verbose):\n",
+    "    '''\n",
+    "    Function to filter conus_list by state\n",
+    "    \n",
+    "    Example: \n",
+    "    conus_list_filt = filter_by_state('Alaska', conus_list, True)\n",
+    "    '''\n",
+    "    conus_list_filt = []\n",
+    "    for i, site in enumerate(conus_list):\n",
+    "        state = site['nws_data']['state']\n",
+    "        if state == state_filter:\n",
+    "            conus_list_filt.append(site)\n",
+    "    if verbose == True:\n",
+    "        print(f'State: {state_filter} \\nNumber of sites: {len(conus_list_filt)}')\n",
+    "        \n",
+    "    return conus_list_filt\n",
+    "\n",
+    "# conus_list_filt = filter_by_state('Alaska', conus_list, True)\n",
+    "\n",
+    "# -------------------------------------------------------"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c91fa68a-a711-4431-bf8d-7b20aeb93823",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# --------- Inputs --------- \n",
+    "\n",
+    "search = 5\n",
+    "\n",
+    "nwm_us_search, nwm_ds_search = search, search\n",
+    "\n",
+    "\n",
+    "# output_catfim_dir = \n",
+    "API_BASE_URL = 'https://nwcal-wrds.nwc.nws.noaa.gov/api/location/v3.0'\n",
+    "metadata_url = f'{API_BASE_URL}/metadata'\n",
+    "\n",
+    "# Get metadata for Islands and Alaska\n",
+    "ak_test_list, ___ = get_metadata(\n",
+    "    metadata_url,\n",
+    "    select_by='state',\n",
+    "    selector=['AK'],\n",
+    "    must_include='nws_data.rfc_forecast_point',\n",
+    "    upstream_trace_distance=nwm_us_search,\n",
+    "    downstream_trace_distance=nwm_ds_search,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6591fb1-5591-4f0f-8f7f-d74fd9ad337f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ak_test_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "9dca1b28-976d-4487-9fd3-96253e1e83f2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Testing get_metadata() functionality\n",
+    "\n",
+    "# --------- Inputs --------- \n",
+    "\n",
+    "search = 5\n",
+    "\n",
+    "nwm_us_search, nwm_ds_search = search, search\n",
+    "\n",
+    "\n",
+    "# output_catfim_dir = \n",
+    "API_BASE_URL = 'https://nwcal-wrds.nwc.nws.noaa.gov/api/location/v3.0'\n",
+    "metadata_url = f'{API_BASE_URL}/metadata'\n",
+    "\n",
+    "\n",
+    "# lid_to_run = \n",
+    "# nwm_metafile = \n",
+    "\n",
+    "# --------- Code --------- \n",
+    "\n",
+    "all_meta_lists = []\n",
+    "\n",
+    "\n",
+    "conus_list, ___ = get_metadata(\n",
+    "    metadata_url,\n",
+    "    select_by='nws_lid',\n",
+    "    selector=['all'],\n",
+    "    must_include='nws_data.rfc_forecast_point',\n",
+    "    upstream_trace_distance=nwm_us_search,\n",
+    "    downstream_trace_distance=nwm_ds_search,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Get metadata for Islands and Alaska\n",
+    "islands_list, ___ = get_metadata(\n",
+    "    metadata_url,\n",
+    "    select_by='state',\n",
+    "    selector=['HI', 'PR', 'AK'],\n",
+    "    must_include=None,\n",
+    "    upstream_trace_distance=nwm_us_search,\n",
+    "    downstream_trace_distance=nwm_ds_search,\n",
+    ")\n",
+    "# Append the lists\n",
+    "all_meta_lists = conus_list + islands_list\n",
+    "\n",
+    "# print(islands_list)\n",
+    "\n",
+    "# with open(meta_file, \"wb\") as p_handle:\n",
+    "#     pickle.dump(all_meta_lists, p_handle, protocol=pickle.HIGHEST_PROTOCOL)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "d25a4979-2b0c-4f4f-ae41-6fec3768d39b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input metadata list length: 7631\n",
+      "Output (unique) metadata list length: 7214\n",
+      "Number of unique LIDs: 7214 \n",
+      "Number of duplicate LIDs: 152 \n",
+      "Number of None LIDs: 265\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ------ New addition: filtering ------\n",
+    "\n",
+    "# -- function --\n",
+    "def filter_metadata_list (metadata_list, verbose):\n",
+    "    '''\n",
+    "    \n",
+    "    Filter metadata list to remove: \n",
+    "    - sites where the nws_lid = None\n",
+    "    - duplicate sites\n",
+    "    \n",
+    "    '''\n",
+    "\n",
+    "    unique_lids, duplicate_lids = [], []\n",
+    "    duplicate_metadata_list, unique_metadata_list = [], []\n",
+    "\n",
+    "    nonelid_metadata_list = [] # TODO: remove eventually?    \n",
+    "\n",
+    "    for i, site in enumerate(metadata_list):\n",
+    "        nws_lid = site['identifiers']['nws_lid']\n",
+    "\n",
+    "        if nws_lid == None:\n",
+    "            # No LID available\n",
+    "            nonelid_metadata_list.append(site)\n",
+    "\n",
+    "            # TODO: replace this with Continue, eventually we wont need this list\n",
+    "\n",
+    "        elif nws_lid in unique_lids:\n",
+    "            # Duplicate LID\n",
+    "            duplicate_lids.append(nws_lid)\n",
+    "            duplicate_metadata_list.append(site)\n",
+    "\n",
+    "        else: \n",
+    "            # Unique/unseen LID that's not None\n",
+    "            unique_lids.append(nws_lid)\n",
+    "            unique_metadata_list.append(site)\n",
+    "\n",
+    "    if verbose == True:\n",
+    "        print(f'Input metadata list length: {len(metadata_list)}')\n",
+    "        print(f'Output (unique) metadata list length: {len(unique_metadata_list)}')\n",
+    "        print(f'Number of unique LIDs: {len(unique_lids)} \\nNumber of duplicate LIDs: {len(duplicate_lids)} \\nNumber of None LIDs: {len(nonelid_metadata_list)}')\n",
+    "\n",
+    "    return unique_lids, duplicate_lids, nonelid_metadata_list, duplicate_metadata_list, unique_metadata_list # TODO: eventually, have it only return necessary objects\n",
+    "\n",
+    "\n",
+    "\n",
+    "unique_lids, duplicate_lids, nonelid_metadata_list, duplicate_metadata_list, unique_metadata_list =  filter_metadata_list(all_meta_lists, True)\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "9ffc3b60-18de-4825-8766-80f3904fd6cf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current Code: Single API call (only forecast points)\n",
+      "State: Puerto Rico \n",
+      "Number of sites: 5\n",
+      "\n",
+      "State: Hawaii \n",
+      "Number of sites: 2\n",
+      "\n",
+      "State: Alaska \n",
+      "Number of sites: 145\n",
+      "\n",
+      "\n",
+      "Proposed Update: Double API call (forecast points + all HI, AK, and PR points)\n",
+      "\n",
+      "AFTER filtering out duplicates:\n",
+      "State: Puerto Rico \n",
+      "Number of sites: 238\n",
+      "\n",
+      "AFTER filtering out duplicates:\n",
+      "State: Hawaii \n",
+      "Number of sites: 495\n",
+      "\n",
+      "AFTER filtering out duplicates:\n",
+      "State: Alaska \n",
+      "Number of sites: 1950\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Get state counts\n",
+    "\n",
+    "state_list = ['Puerto Rico', 'Hawaii', 'Alaska']\n",
+    "\n",
+    "print('Current Code: Single API call (only forecast points)')\n",
+    "for state in state_list: \n",
+    "    currentcode_state = filter_by_state(state, conus_list, True)\n",
+    "    print()\n",
+    "\n",
+    "print()\n",
+    "print('Proposed Update: Double API call (forecast points + all HI, AK, and PR points)')\n",
+    "print()\n",
+    "for state in state_list: \n",
+    "    # print('Before filtering out duplicates:')\n",
+    "    # prefilt_state = filter_by_state(state, all_meta_lists, True)\n",
+    "    print('AFTER filtering out duplicates:')\n",
+    "    postfilt_state = filter_by_state(state, unique_metadata_list, True)\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8d2ad926-105c-4326-980c-3e4793b7b58a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State: Connecticut \n",
+      "Number of sites: 23\n",
+      "State: New York \n",
+      "Number of sites: 142\n",
+      "State: Texas \n",
+      "Number of sites: 380\n"
+     ]
+    }
+   ],
+   "source": [
+    "postfilt_state = filter_by_state('Connecticut', unique_metadata_list, True)\n",
+    "postfilt_state = filter_by_state('New York', unique_metadata_list, True)\n",
+    "postfilt_state = filter_by_state('Texas', unique_metadata_list, True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "65996d68-b060-4cd3-b575-3e3d4172c532",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input metadata list length: 4679\n",
+      "Output (unique) metadata list length: 4679\n",
+      "Number of unique LIDs: 4679 \n",
+      "Number of duplicate LIDs: 0 \n",
+      "Number of None LIDs: 0\n",
+      "\n",
+      "State: Alaska \n",
+      "Number of sites: 145\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Current code formulation\n",
+    "\n",
+    "\n",
+    "unique_lids, duplicate_lids, nonelid_metadata_list, duplicate_metadata_list, unique_metadata_list =  filter_metadata_list(conus_list, True)\n",
+    "print()\n",
+    "conus_list_filt = filter_by_state('Alaska', conus_list, True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "dcd1a64b-35c3-4f75-9e08-e936c17da1bb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LID filter: None \n",
+      "Number of sites: 265\n"
+     ]
+    }
+   ],
+   "source": [
+    "# lid_list, duplicate_lid_list = list_duplicate_lids(all_meta_lists, True)\n",
+    "\n",
+    "conus_list_filt = filter_by_lid(None, islands_list, True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "id": "ec188992-fda6-4f8b-876f-be78c48c67cc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# state_list, ___ = get_metadata(\n",
+    "#     metadata_url,\n",
+    "#     select_by='state',\n",
+    "#     # selector=['HI', 'PR', 'AK'],\n",
+    "#     selector=['AK'],\n",
+    "\n",
+    "#     # must_include='identifiers.nws_lid', ## ddin't work oh well\n",
+    "#     must_include=None,\n",
+    "\n",
+    "#     # must_include='nws_data.rfc_forecast_point',\n",
+    "#     upstream_trace_distance=nwm_us_search,\n",
+    "#     downstream_trace_distance=nwm_ds_search,\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ba42000-3855-47eb-9f1c-f3c805f45b96",
+   "metadata": {},
+   "source": [
+    "### Get a HUC list for a given HUC02 region "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "034acbe3-d096-4dfd-a358-4ca409bfef64",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "19020101\n",
+      "19020102\n",
+      "19020103\n",
+      "19020104\n",
+      "19020201\n",
+      "19020202\n",
+      "19020203\n",
+      "19020301\n",
+      "19020302\n",
+      "19020401\n",
+      "19020402\n",
+      "19020501\n",
+      "19020502\n",
+      "19020503\n",
+      "19020504\n",
+      "19020505\n",
+      "19020601\n",
+      "19020602\n",
+      "19020800\n"
+     ]
+    }
+   ],
+   "source": [
+    "fim_output_path = '/data/previous_fim/fim_4_5_2_11/'\n",
+    "\n",
+    "# huc2 = '20' # Hawaii\n",
+    "# huc2 = '21' # Puerto Rico\n",
+    "huc2 = '19' # Alaska\n",
+    "\n",
+    "all_hucs = os.listdir(fim_output_path)\n",
+    "\n",
+    "subsetted_hucs = [x for x in all_hucs if x.startswith(huc2)]\n",
+    "\n",
+    "for i in subsetted_hucs:\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29a52847-3189-41b7-a755-3063512a96e0",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Get stats for current CatFIM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ca99d060-3963-497f-a8c0-cb117bbcd818",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Inputs\n",
+    "states = ['AK', 'PR', 'HI']\n",
+    "\n",
+    "## Previous runs\n",
+    "catfim_folder_prev = '/data/catfim/'\n",
+    "result_folders_prev = ['hand_4_5_11_1_flow_based', 'hand_4_5_11_1_stage_based', 'fim_4_5_2_11_flow_based', 'fim_4_5_2_11_stage_based']\n",
+    "\n",
+    "## Current test runs\n",
+    "catfim_folder_testing = '/data/catfim/emily_test'\n",
+    "result_folders_testing = ['site_filtering_HI_flow_based', 'site_filtering_HI_stage_based', \n",
+    "                  'site_filtering_PR_flow_based', 'site_filtering_PR_stage_based', \n",
+    "                  'site_filtering_AK_flow_based', 'site_filtering_AK_stage_based']\n",
+    "\n",
+    "def count_mapped_for_state(catfim_folder, result_folders, states):\n",
+    "    # Read in CatFIM outputs\n",
+    "    for result_folder in result_folders:\n",
+    "        print()\n",
+    "        print('-----' + result_folder + '-----')\n",
+    "        \n",
+    "        catfim_points_path = 'None'\n",
+    "        \n",
+    "        catfim_outputs_mapping_path = os.path.join(catfim_folder, result_folder, 'mapping')\n",
+    "            \n",
+    "        # Get filepath\n",
+    "        for file in os.listdir(catfim_outputs_mapping_path):\n",
+    "            if file.endswith('catfim_sites.csv'):\n",
+    "                catfim_points_path = os.path.join(catfim_outputs_mapping_path, file)\n",
+    "\n",
+    "        if catfim_points_path == 'None':\n",
+    "            print(f'No site csv found in {catfim_outputs_mapping_path}')\n",
+    "            continue\n",
+    "        \n",
+    "        # Open points file\n",
+    "        try:\n",
+    "            catfim_points = gpd.read_file(catfim_points_path)\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            print('An error occurred', e)\n",
+    "            continue\n",
+    "\n",
+    "        # Get mapped vs unmapped data for the listed states\n",
+    "        for state in states:\n",
+    "            catfim_points_state = catfim_points[catfim_points['states'] == state]\n",
+    "            \n",
+    "            if len(catfim_points_state) != 0:\n",
+    "                num_not_mapped = len(catfim_points_state[catfim_points_state['mapped'] == 'no'])\n",
+    "                \n",
+    "                catfim_points_state_mapped = catfim_points_state[catfim_points_state['mapped'] == 'yes']\n",
+    "                num_mapped = len(catfim_points_state_mapped)\n",
+    "                \n",
+    "                huc_list = catfim_points_state['HUC8']\n",
+    "                \n",
+    "                if 'ahps_lid' in catfim_points_state.columns:\n",
+    "                    lid_list = catfim_points_state['ahps_lid']\n",
+    "                    lid_list_mapped = catfim_points_state_mapped['ahps_lid']\n",
+    "                elif 'nws_lid' in catfim_points_state.columns:\n",
+    "                    lid_list = catfim_points_state['nws_lid']\n",
+    "                    lid_list_mapped = catfim_points_state_mapped['nws_lid']\n",
+    "                else:\n",
+    "                    print('Could not find ahps_lid or nws_lid column in csv.')                   \n",
+    "                    print(catfim_points_state.columns)\n",
+    "                    continue\n",
+    "                \n",
+    "                huc_list_unique = set(huc_list)\n",
+    "                lid_list_unique = set(lid_list)\n",
+    "                \n",
+    "                num_duplicate_sites = len(lid_list) - len(lid_list_unique)\n",
+    "                num_duplicate_sites_mapped = len(lid_list_mapped) - len(set(lid_list_mapped))\n",
+    "\n",
+    "                print(f'{state} \\n   Mapped: {num_mapped} \\n   Not mapped: {num_not_mapped}')\n",
+    "                \n",
+    "                \n",
+    "                print(f'   Number of duplicate LIDs: {num_duplicate_sites}')\n",
+    "                print(f'   Number of duplicate LIDs mapped: {num_duplicate_sites_mapped}')\n",
+    "\n",
+    "                print(f'   {len(huc_list_unique)} hucs: {huc_list_unique}')\n",
+    "\n",
+    "        return catfim_points, #catfim_points_state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9808a93c-aee4-465a-8faa-18e941f5923a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# catfim_points_pr = count_mapped_for_state('/data/catfim/emily_test/', ['site_filtering_PR_stage_based'], 'PR')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6255a914-3c44-4e02-8c20-a6f11eb5a12e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "-----hand_4_5_11_1_flow_based-----\n",
+      "AK \n",
+      "   Mapped: 14 \n",
+      "   Not mapped: 39\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   14 hucs: {'19020202', '19020502', '19020201', '19020101', '19020504', '19020301', '19020402', '19020503', '19020104', '19020102', '19020505', '19020302', '19020401', '19020501'}\n",
+      "PR \n",
+      "   Mapped: 4 \n",
+      "   Not mapped: 1\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   2 hucs: {'21010002', '21010005'}\n",
+      "HI \n",
+      "   Mapped: 1 \n",
+      "   Not mapped: 1\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   2 hucs: {'20020000', '20010000'}\n",
+      "\n",
+      "-----hand_4_5_11_1_stage_based-----\n",
+      "AK \n",
+      "   Mapped: 13 \n",
+      "   Not mapped: 40\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   14 hucs: {'19020202', '19020502', '19020201', '19020101', '19020504', '19020301', '19020402', '19020503', '19020104', '19020102', '19020505', '19020302', '19020401', '19020501'}\n",
+      "PR \n",
+      "   Mapped: 0 \n",
+      "   Not mapped: 5\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   2 hucs: {'21010002', '21010005'}\n",
+      "HI \n",
+      "   Mapped: 0 \n",
+      "   Not mapped: 2\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   2 hucs: {'20020000', '20010000'}\n",
+      "\n",
+      "-----fim_4_5_2_11_flow_based-----\n",
+      "PR \n",
+      "   Mapped: 68 \n",
+      "   Not mapped: 177\n",
+      "   Number of duplicate LIDs: 5\n",
+      "   Number of duplicate LIDs mapped: 4\n",
+      "   5 hucs: {'21010005', '21010002', '21010004', '21010003', '21010008'}\n",
+      "HI \n",
+      "   Mapped: 50 \n",
+      "   Not mapped: 441\n",
+      "   Number of duplicate LIDs: 2\n",
+      "   Number of duplicate LIDs mapped: 2\n",
+      "   7 hucs: {'20060000', '20020000', '20030000', '20050000', '20070000', '20010000', '20040000'}\n",
+      "\n",
+      "-----fim_4_5_2_11_stage_based-----\n",
+      "PR \n",
+      "   Mapped: 0 \n",
+      "   Not mapped: 245\n",
+      "   Number of duplicate LIDs: 5\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   5 hucs: {'21010005', '21010002', '21010004', '21010003', '21010008'}\n",
+      "HI \n",
+      "   Mapped: 0 \n",
+      "   Not mapped: 491\n",
+      "   Number of duplicate LIDs: 2\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   7 hucs: {'20060000', '20020000', '20030000', '20050000', '20070000', '20010000', '20040000'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "count_mapped_for_state(catfim_folder_prev, result_folders_prev, states)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "68f45696-893c-4709-9fe6-d1c223bd9020",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "-----site_filtering_HI_flow_based-----\n",
+      "HI \n",
+      "   Mapped: 47 \n",
+      "   Not mapped: 442\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   7 hucs: {'20060000', '20020000', '20030000', '20050000', '20070000', '20010000', '20040000'}\n",
+      "\n",
+      "-----site_filtering_HI_stage_based-----\n",
+      "No site csv found in /data/catfim/emily_test/site_filtering_HI_stage_based/mapping\n",
+      "\n",
+      "-----site_filtering_PR_flow_based-----\n",
+      "PR \n",
+      "   Mapped: 59 \n",
+      "   Not mapped: 181\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   5 hucs: {'21010005', '21010002', '21010004', '21010003', '21010008'}\n",
+      "\n",
+      "-----site_filtering_PR_stage_based-----\n",
+      "No site csv found in /data/catfim/emily_test/site_filtering_PR_stage_based/mapping\n",
+      "\n",
+      "-----site_filtering_AK_flow_based-----\n",
+      "AK \n",
+      "   Mapped: 30 \n",
+      "   Not mapped: 615\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   18 hucs: {'19020202', '19020502', '19020201', '19020101', '19020504', '19020601', '19020203', '19020301', '19020402', '19020503', '19020104', '19020800', '19020102', '19020505', '19020302', '19020602', '19020401', '19020501'}\n",
+      "\n",
+      "-----site_filtering_AK_stage_based-----\n",
+      "AK \n",
+      "   Mapped: 5 \n",
+      "   Not mapped: 209\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   7 hucs: {'19020202', '19020203', '19020201', '19020101', '19020301', '19020104', '19020102'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "count_mapped_for_state(catfim_folder_testing, result_folders_testing, states)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 194,
+   "id": "04988eab-2866-4d5b-882a-abb76e072df0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of duplicate LIDs: 0\n",
+      "7 hucs: {'20050000', '20060000', '20030000', '20020000', '20010000', '20070000', '20040000'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "huc_list = catfim_points_state['HUC8']\n",
+    "lid_list = catfim_points_state['ahps_lid']\n",
+    "\n",
+    "huc_list_unique = set(huc_list)\n",
+    "lid_list_unique = set(lid_list)\n",
+    "num_duplicate_sites = len(lid_list) - len(lid_list_unique)\n",
+    "\n",
+    "print(f'Number of duplicate LIDs: {num_duplicate_sites}')\n",
+    "print(f'{len(huc_list_unique)} hucs: {huc_list_unique}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae429a31-f83e-4594-9245-66cfb452b2be",
+   "metadata": {},
+   "source": [
+    "### Test state column instablility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "id": "cce08d89-cf96-4905-a090-3ba3a09695b1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "input_meta_list = conus_list # conus_list or islands_list\n",
+    "\n",
+    "# -----\n",
+    "\n",
+    "state_data = []\n",
+    "\n",
+    "for i, site in enumerate(input_meta_list):\n",
+    "    lid = site['identifiers']['nws_lid']\n",
+    "\n",
+    "    nws_data_state = site['nws_data']['state']\n",
+    "    usgs_data_state = site['usgs_data']['state']\n",
+    "    nws_preferred_state = site['nws_preferred']['state']\n",
+    "    usgs_preferred_state = site['usgs_preferred']['state']\n",
+    "\n",
+    "    row = {'index': i, 'lid': lid, \n",
+    "           'nws_data_state':nws_data_state,\n",
+    "           'usgs_data_state':usgs_data_state,\n",
+    "           'nws_preferred_state':nws_preferred_state,\n",
+    "           'usgs_preferred_state':usgs_preferred_state}\n",
+    "\n",
+    "    state_data.append(row)\n",
+    "\n",
+    "state_data_df = pd.DataFrame(state_data)\n",
+    "\n",
+    "summary_df = pd.DataFrame({\n",
+    "    'nws_data_state': state_data_df['nws_data_state'].isna().sum(),\n",
+    "    'usgs_data_state': state_data_df['usgs_data_state'].isna().sum(),\n",
+    "    'nws_preferred_state': state_data_df['nws_preferred_state'].isna().sum(),\n",
+    "    'usgs_preferred_state': state_data_df['usgs_preferred_state'].isna().sum()}, index=[f'Number of NA Values in State Column, out of {len(state_data_df)} rows'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "id": "007eb617-d224-46e4-ab8e-aab28679cf43",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>index</th>\n",
+       "      <th>lid</th>\n",
+       "      <th>nws_data_state</th>\n",
+       "      <th>usgs_data_state</th>\n",
+       "      <th>nws_preferred_state</th>\n",
+       "      <th>usgs_preferred_state</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>302</th>\n",
+       "      <td>302</td>\n",
+       "      <td>BEAA3</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     index    lid nws_data_state usgs_data_state nws_preferred_state  \\\n",
+       "302    302  BEAA3           None            None                None   \n",
+       "\n",
+       "    usgs_preferred_state  \n",
+       "302                 None  "
+      ]
+     },
+     "execution_count": 171,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# state_data_df[state_data_df['nws_data_state'].isna()]\n",
+    "# state_data_df.loc[(state_data_df['nws_data_state'].isna()) & (state_data_df['usgs_data_state'].isna())]\n",
+    "state_data_df.loc[(state_data_df['nws_preferred_state'].isna()) & (state_data_df['usgs_preferred_state'].isna())]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c98a678-555e-47a9-bc64-87fd41883cda",
+   "metadata": {},
+   "source": [
+    "### Review CatFIM Logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "afe1c3fd-4b84-4574-b9bf-e89ec5bda6b2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "run_path = '/data/catfim/emily_test/site_filtering_PR_stage_based/'\n",
+    "log_file = 'catfim_2024_12_12-19_24_09.log'\n",
+    "\n",
+    "log_path = os.path.join(run_path, 'logs', log_file)\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "8323d4db-3cde-4029-9d06-f807a9419523",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "out_df = []\n",
+    "\n",
+    "with open(log_path) as f:\n",
+    "    for line in f:\n",
+    "        # print(line)\n",
+    "        \n",
+    "        # Initialize variables\n",
+    "        huc, lid, message_type, message = '', '', '', ''\n",
+    "\n",
+    "        # Get the HUC8\n",
+    "        match = re.search(r\"\\d{8}\", line)\n",
+    "\n",
+    "        if match:\n",
+    "            huc = match.group()\n",
+    "            \n",
+    "            # Get the LID\n",
+    "            match2 = re.search(r\"(?<= : ).{5}\", line)\n",
+    "            if match2:\n",
+    "                lid = match2.group()\n",
+    "                \n",
+    "                if 'WARNING' in line:\n",
+    "            \n",
+    "                    # print(line)\n",
+    "                    \n",
+    "                    # Get the text\n",
+    "                    pattern = lid+':'\n",
+    "                    match3 = re.search(f\"(?<={pattern})(.*)\", line)\n",
+    "                    if match3:\n",
+    "                        message = match3.group()\n",
+    "                        message_type = 'WARNING'\n",
+    "\n",
+    "                elif 'TRACE' in line: \n",
+    "                    # Get the text\n",
+    "                    pattern = lid+':'\n",
+    "                    match3 = re.search(f\"(?<={pattern})(.*)\", line)\n",
+    "                    if match3:\n",
+    "                        message = match3.group()\n",
+    "                        message_type = 'TRACE'\n",
+    "                        \n",
+    "                else:\n",
+    "                    continue\n",
+    "                        \n",
+    "                new_line = {'huc': huc, 'lid':lid, 'message_type':message_type, 'message':message}\n",
+    "\n",
+    "                out_df.append(new_line)\n",
+    "                        \n",
+    "                        \n",
+    "                \n",
+    "out_df = pd.DataFrame(out_df)\n",
+    "\n",
+    "                \n",
+    "# out_df.to_csv('PR_error_logs.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "a7b763ad-00eb-43f2-944a-2fceb2b96e69",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## __create_acceptable_usgs_elev_df from generate_categorical_fim.py\n",
+    "\n",
+    "import argparse\n",
+    "import glob\n",
+    "import math\n",
+    "import os\n",
+    "import shutil\n",
+    "import sys\n",
+    "import time\n",
+    "import traceback\n",
+    "from concurrent.futures import ProcessPoolExecutor, as_completed, wait\n",
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "from catfim.generate_categorical_fim_flows import generate_flows\n",
+    "from catfim.generate_categorical_fim_mapping import (\n",
+    "    manage_catfim_mapping,\n",
+    "    post_process_cat_fim_for_viz,\n",
+    "    produce_stage_based_lid_tifs,\n",
+    ")\n",
+    "from tools_shared_functions import (\n",
+    "    filter_nwm_segments_by_stream_order,\n",
+    "    get_datum,\n",
+    "    get_nwm_segs,\n",
+    "    get_thresholds,\n",
+    "    ngvd_to_navd_ft,\n",
+    ")\n",
+    "from tools_shared_variables import (\n",
+    "    acceptable_alt_acc_thresh,\n",
+    "    acceptable_alt_meth_code_list,\n",
+    "    acceptable_coord_acc_code_list,\n",
+    "    acceptable_coord_method_code_list,\n",
+    "    acceptable_site_type_list,\n",
+    ")\n",
+    "\n",
+    "import utils.fim_logger as fl\n",
+    "from utils.shared_variables import VIZ_PROJECTION\n",
+    "\n",
+    "\n",
+    "# from itertools import repeat\n",
+    "# from pathlib import Path\n",
+    "\n",
+    "\n",
+    "# global RLOG\n",
+    "FLOG = fl.FIM_logger()  # the non mp version\n",
+    "MP_LOG = fl.FIM_logger()  # the Multi Proc version\n",
+    "\n",
+    "gpd.options.io_engine = \"pyogrio\"\n",
+    "\n",
+    "def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):\n",
+    "    acceptable_usgs_elev_df = None\n",
+    "    try:\n",
+    "        # Drop columns that offend acceptance criteria\n",
+    "        print(len(usgs_elev_df)) ## TEMP DEBUG\n",
+    "        usgs_elev_df['acceptable_codes'] = (\n",
+    "            # usgs_elev_df['usgs_data_coord_accuracy_code'].isin(acceptable_coord_acc_code_list)\n",
+    "            # & usgs_elev_df['usgs_data_coord_method_code'].isin(acceptable_coord_method_code_list)\n",
+    "            usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list)\n",
+    "            & usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list)\n",
+    "        )\n",
+    "        \n",
+    "        print(len(usgs_elev_df)) ## TEMP DEBUG\n",
+    "        \n",
+    "        usgs_elev_df = usgs_elev_df.astype({'usgs_data_alt_accuracy_code': float})\n",
+    "        usgs_elev_df['acceptable_alt_error'] = np.where(\n",
+    "            usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh, True, False\n",
+    "        )\n",
+    "        \n",
+    "        print('after \n",
+    "        print(len(usgs_elev_df)) ## TEMP DEBUG\n",
+    "              \n",
+    "        acceptable_usgs_elev_df = usgs_elev_df[\n",
+    "            (usgs_elev_df['acceptable_codes'] == True) & (usgs_elev_df['acceptable_alt_error'] == True)\n",
+    "        ]\n",
+    "\n",
+    "        # # TEMP DEBUG Record row difference and write it to a CSV or something\n",
+    "        # label = 'Old code' ## TEMP DEBUG\n",
+    "        # num_potential_rows = usgs_elev_df.shape[0]\n",
+    "        # num_acceptable_rows = acceptable_usgs_elev_df.shape[0]\n",
+    "        # out_message = f'{label}: kept {num_acceptable_rows} rows out of {num_potential_rows} available rows.'\n",
+    "\n",
+    "    except Exception:\n",
+    "        # Not sure any of the sites actually have those USGS-related\n",
+    "        # columns in this particular file, so just assume it's fine to use\n",
+    "\n",
+    "        # print(\"(Various columns related to USGS probably not in this csv)\")\n",
+    "        # print(f\"Exception: \\n {repr(e)} \\n\")\n",
+    "        MP_LOG.error(f\"{huc_lid_id}: An error has occurred while working with the usgs_elev table\")\n",
+    "        MP_LOG.error(traceback.format_exc())\n",
+    "        acceptable_usgs_elev_df = usgs_elev_df\n",
+    "\n",
+    "    return acceptable_usgs_elev_df\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "560c9420-b0c0-40c2-895b-6546bbb51365",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>nws_lid</th>\n",
+       "      <th>feature_id</th>\n",
+       "      <th>HydroID</th>\n",
+       "      <th>levpa_id</th>\n",
+       "      <th>dem_elevation</th>\n",
+       "      <th>dem_adj_elevation</th>\n",
+       "      <th>order_</th>\n",
+       "      <th>LakeID</th>\n",
+       "      <th>HUC8</th>\n",
+       "      <th>...</th>\n",
+       "      <th>mainstem</th>\n",
+       "      <th>acceptable_codes</th>\n",
+       "      <th>acceptable_alt_error</th>\n",
+       "      <th>source</th>\n",
+       "      <th>stream_stn</th>\n",
+       "      <th>fid_xs</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>index_right</th>\n",
+       "      <th>geometry_ln</th>\n",
+       "      <th>geometry_snapped</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>0 rows × 104 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [location_id, nws_lid, feature_id, HydroID, levpa_id, dem_elevation, dem_adj_elevation, order_, LakeID, HUC8, snap_distance, wrds_timestamp, nrldb_timestamp, nwis_timestamp, metadata_sources, goes_id, env_can_gage_id, nws_data_name, nws_data_wfo, nws_data_rfc, nws_data_geo_rfc, nws_data_latitude, nws_data_longitude, nws_data_map_link, nws_data_horizontal_datum_name, nws_data_state, nws_data_county, nws_data_county_code, nws_data_huc, nws_data_hsa, nws_data_zero_datum, nws_data_vertical_datum_name, nws_data_rfc_forecast_point, nws_data_rfc_defined_fcst_point, nws_data_riverpoint, usgs_data_name, usgs_data_geo_rfc, usgs_data_latitude, usgs_data_longitude, usgs_data_map_link, usgs_data_coord_accuracy_code, usgs_data_latlon_datum_name, usgs_data_coord_method_code, usgs_data_state, usgs_data_huc, usgs_data_site_type, usgs_data_altitude, usgs_data_alt_accuracy_code, usgs_data_alt_datum_code, usgs_data_alt_method_code, usgs_data_drainage_area, usgs_data_drainage_area_units, usgs_data_contrib_drainage_area, usgs_data_active, usgs_data_gages_ii_reference, nwm_feature_data_downstream_feature_id, nwm_feature_data_latitude, nwm_feature_data_longitude, nwm_feature_data_altitude, nwm_feature_data_stream_length, nwm_feature_data_stream_order, nwm_feature_data_mannings_roughness, nwm_feature_data_slope, nwm_feature_data_channel_side_slope, nwm_feature_data_nhd_waterbody_comid, env_can_gage_data_name, env_can_gage_data_latitude, env_can_gage_data_longitude, env_can_gage_data_map_link, env_can_gage_data_drainage_area, env_can_gage_data_contrib_drainage_area, env_can_gage_data_water_course, nws_preferred_name, nws_preferred_latitude, nws_preferred_longitude, nws_preferred_latlon_datum_name, nws_preferred_state, nws_preferred_huc, usgs_preferred_name, usgs_preferred_latitude, usgs_preferred_longitude, usgs_preferred_latlon_datum_name, usgs_preferred_state, usgs_preferred_huc, crosswalk_datasets_location_nwm_crosswalk_dataset_location_nwm_crosswalk_dataset_id, crosswalk_datasets_location_nwm_crosswalk_dataset_name, crosswalk_datasets_location_nwm_crosswalk_dataset_description, crosswalk_datasets_nws_usgs_crosswalk_dataset_nws_usgs_crosswalk_dataset_id, crosswalk_datasets_nws_usgs_crosswalk_dataset_name, crosswalk_datasets_nws_usgs_crosswalk_dataset_description, assigned_crs, name, states, curve, mainstem, acceptable_codes, acceptable_alt_error, source, stream_stn, fid_xs, ...]\n",
+       "Index: []\n",
+       "\n",
+       "[0 rows x 104 columns]"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "usgs_elev_table = '/data/previous_fim/fim_4_5_2_11/21010005/usgs_elev_table.csv'\n",
+    "huc_lid_id = 'bzap4'\n",
+    "\n",
+    "\n",
+    "usgs_elev_df = pd.read_csv(usgs_elev_table)\n",
+    "\n",
+    "\n",
+    "\n",
+    "acceptable_usgs_elev_df = __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id)\n",
+    "\n",
+    "acceptable_usgs_elev_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "9b8d4fc4-0733-4eca-952f-60f53305a7a4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "236"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(set(out_df['lid']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "a6cce11a-27b7-4302-b0b7-ba304fa8087c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "# message_string = 'Unable to find gage data'\n",
+    "message_string = 'stage values'\n",
+    "\n",
+    "stage_val_lids = out_df[out_df['message'].str.contains('stage values')]['lid']\n",
+    "no_gage_data_lids = out_df[out_df['message'].str.contains('Unable to find gage data')]['lid']\n",
+    "\n",
+    "\n",
+    "\n",
+    "# # Using set intersection\n",
+    "lids_stageval_nogagedata = list(set(stage_val_lids) & set(no_gage_data_lids))\n",
+    "\n",
+    "# len(stage_val_lids)\n",
+    "# len(no_gage_data_lids)\n",
+    "# len(lids_stageval_nogagedata)\n",
+    "\n",
+    "# print(stage_val_lids)\n",
+    "# lids_stageval_nogagedata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f7d3712-c9ae-45d5-9fd5-e49ca29e194b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "742c6bb5-c24b-4de6-8645-d2aabd61be26",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tools/catfim/notebooks/.ipynb_checkpoints/vis_catfim_cross_section-checkpoint.ipynb
+++ b/tools/catfim/notebooks/.ipynb_checkpoints/vis_catfim_cross_section-checkpoint.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6eb53c55-02a3-4172-9026-8a1ddbc05a72",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from catfim.vis_categorical_fim import (read_catfim_outputs, \n",
+    "                                        subset_catfim_geom_by_site, \n",
+    "                                        subset_apply_symbology_catfim_library, \n",
+    "                                        map_catfim_full_extent, \n",
+    "                                        map_catfim_at_site, \n",
+    "                                        map_catfim_full_extent, \n",
+    "                                        create_perpendicular_cross_section, \n",
+    "                                        map_cross_section_geometry, \n",
+    "                                        generate_dem_path, \n",
+    "                                        create_cross_section_points, \n",
+    "                                        get_elevation_for_cross_section_points, \n",
+    "                                        apply_catfim_library_to_points, \n",
+    "                                        plot_catfim_cross_section, \n",
+    "                                        map_catfim_cross_section_points)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ac6692c-262d-4d4b-9a62-f2cbcea83f6d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "EPSG = 5070\n",
+    "\n",
+    "## Viewing cross-section example\n",
+    "\n",
+    "# Inputs\n",
+    "lid = 'bltn7'\n",
+    "huc = '06010105'\n",
+    "catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "catfim_outputs_path = '/data/catfim/emily_test/hand_4_5_11_1_catfim_datavis_flow_based/'\n",
+    "\n",
+    "# Viewing AUON6 \n",
+    "\n",
+    "# # Inputs\n",
+    "# lid = 'AUON6'\n",
+    "# huc = '04140201'\n",
+    "# # catfim_inputs_path = '/data/outputs/hand_4_5_11_1_catfim'\n",
+    "# catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "# catfim_outputs_path = '/data/catfim/hand_4_5_11_1_stage_based/'\n",
+    "\n",
+    "# Viewing PACI1\n",
+    "\n",
+    "# Inputs\n",
+    "# lid = 'paci1'\n",
+    "# huc = '17060108'\n",
+    "# catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "# catfim_outputs_path = '/data/catfim/hand_4_5_11_1_stage_based/'\n",
+    "\n",
+    "# ## Viewing Alaska BEFORE updates\n",
+    "\n",
+    "# # Inputs\n",
+    "# lid = 'apta2'\n",
+    "# huc = '19020301'\n",
+    "# catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "# catfim_outputs_path = '/data/catfim/hand_4_5_11_1_flow_based'\n",
+    "\n",
+    "## Viewing Alaska updates\n",
+    "\n",
+    "# # Inputs\n",
+    "# lid = 'apta2'\n",
+    "# huc = '19020301'\n",
+    "# catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "# catfim_outputs_path = '/data/catfim/emily_test/AK_new_wrds_flow_based/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3683983c-a5af-4c99-9863-b09f213d371c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Reading in and processing CatFIM library and geospatial data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d0c27b8-f47d-4543-9471-c6d2f0e799a0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Read in the CatFIM outputs\n",
+    "catfim_library, catfim_points, flowline_gdf = read_catfim_outputs(catfim_inputs_path, catfim_outputs_path, huc)\n",
+    "\n",
+    "# Subset the CatFIM geometries by site and enforce projection\n",
+    "catfim_library_filt, points_filt_gdf, flowline_filt_gdf = subset_catfim_geom_by_site(lid, catfim_library, catfim_points, flowline_gdf, EPSG)\n",
+    "\n",
+    "# Filter CatFIM library and create the symbology columns\n",
+    "catfim_library_filt, colordict = subset_apply_symbology_catfim_library(catfim_library, points_filt_gdf, lid, include_record=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a29618a-7133-43f0-9e8c-568014986ffc",
+   "metadata": {},
+   "source": [
+    "### Plotting CatFIM library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e66e0adb-cb23-4a8b-ba58-eb35bc197dde",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "map_catfim_full_extent(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', legend=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85da45bd-51b8-40d0-af52-07c22f8ad08b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "map_catfim_at_site(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', EPSG=5070, basemap=True, site_view=True, legend = True) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7860f8c9-e878-4122-a5ef-288972e1ce5f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "map_catfim_full_extent(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', legend=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba427afc-2290-4867-ab60-43c48b0c890a",
+   "metadata": {},
+   "source": [
+    "### Generate and Plot CatFIM Elevation Cross-section"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d7e18d3-d291-4bb3-b689-4a1bc9c966e7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Function Inputs ------------------------------------\n",
+    "\n",
+    "xsection_length = 1000 # cross-section length, meters or feet, 1000 suggested\n",
+    "EPSG = 5070\n",
+    "dist_between_points = 10 # distance between points on cross-section line, 10 suggested\n",
+    "\n",
+    "\n",
+    "## Run Functions ------------------------------------\n",
+    "\n",
+    "# Create cross-section\n",
+    "xsection_gdf = create_perpendicular_cross_section(flowline_filt_gdf, points_filt_gdf, xsection_length, EPSG)\n",
+    "\n",
+    "# Map the cross-section\n",
+    "map_cross_section_geometry(xsection_gdf, points_filt_gdf, flowline_filt_gdf, modifier=100, plot_title=f'Flowline cross-section at site {lid}')\n",
+    "\n",
+    "# Get DEM path\n",
+    "dem_path = generate_dem_path(huc, root_dem_path='/data/inputs/3dep_dems/')\n",
+    "\n",
+    "# Create points along cross-section line\n",
+    "xsection_points_gdf, xsection_midpoint = create_cross_section_points(xsection_gdf, dist_between_points)\n",
+    "\n",
+    "# Apply elevation to points\n",
+    "xsection_points_gdf = get_elevation_for_cross_section_points(dem_path, xsection_points_gdf, EPSG)\n",
+    "\n",
+    "# Apply CatFIM stages to points\n",
+    "xsection_catfim_filt_gdf = apply_catfim_library_to_points(xsection_points_gdf, catfim_library_filt)\n",
+    "\n",
+    "# Plot the CatFIM stage cross-section\n",
+    "plot_catfim_cross_section(xsection_points_gdf, xsection_catfim_filt_gdf, xsection_midpoint, colordict, elev_upper_buffer_ft=10, \n",
+    "                          num_points_buffer=5, dist_between_points=10, save_plot=False, \n",
+    "                          plot_title = f'CatFIM library elevation cross-section at site {lid}', \n",
+    "                          file_label='')\n",
+    "\n",
+    "# Map the CatFIM stage cross-section\n",
+    "map_catfim_cross_section_points(catfim_library_filt, flowline_filt_gdf, xsection_catfim_filt_gdf, colordict, \n",
+    "                                modifier=100, EPSG = 5070, plot_title=f'CatFIM library elevation cross-section at site {lid}', \n",
+    "                                basemap=True, legend=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d46976cd-a892-4f82-a3b4-ba59eb125b91",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Map the CatFIM stage cross-section\n",
+    "map_catfim_cross_section_points(catfim_library_filt, flowline_filt_gdf, xsection_catfim_filt_gdf, colordict, \n",
+    "                                modifier=100, EPSG=5070, plot_title=f'CatFIM library elevation cross-section at site {lid}', \n",
+    "                                basemap=False, legend=True)\n",
+    "\n",
+    "# Map the CatFIM stage cross-section\n",
+    "map_catfim_cross_section_points(catfim_library_filt, flowline_filt_gdf, xsection_catfim_filt_gdf, colordict, \n",
+    "                                modifier=100, EPSG=5070, plot_title=f'CatFIM library elevation cross-section at site {lid}', \n",
+    "                                basemap=True, legend=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tools/catfim/notebooks/eval_catfim_metadata.ipynb
+++ b/tools/catfim/notebooks/eval_catfim_metadata.ipynb
@@ -1,0 +1,1315 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "544d20bf-6273-4dd5-bae8-a42935b3e3f1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import argparse\n",
+    "import copy\n",
+    "import glob\n",
+    "import os\n",
+    "import pickle\n",
+    "import random\n",
+    "import shutil\n",
+    "import sys\n",
+    "import time\n",
+    "import traceback\n",
+    "from concurrent.futures import ProcessPoolExecutor, as_completed, wait\n",
+    "from datetime import datetime, timezone\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "from tools_shared_functions import (\n",
+    "    aggregate_wbd_hucs,\n",
+    "    filter_nwm_segments_by_stream_order,\n",
+    "    flow_data,\n",
+    "    get_metadata,\n",
+    "    get_nwm_segs,\n",
+    "    get_thresholds,\n",
+    ")\n",
+    "\n",
+    "import utils.fim_logger as fl\n",
+    "from utils.shared_variables import VIZ_PROJECTION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "1c7d9207-9b2b-431b-ab4e-3dbb3e2107f2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Functions to get process and filter the metadata\n",
+    "\n",
+    "# -------------------------------------------------------\n",
+    "def list_of_lids(conus_list, verbose):\n",
+    "    '''\n",
+    "    Extract a list of LIDs from the conus_list\n",
+    "    \n",
+    "    Example: \n",
+    "    lid_list = list_of_lids(conus_list, True)\n",
+    "    '''\n",
+    "    lid_list = []\n",
+    "    for i, site in enumerate(conus_list):\n",
+    "        nws_lid = site['identifiers']['nws_lid']\n",
+    "        lid_list.append(nws_lid)\n",
+    "    if verbose == True:\n",
+    "        print(f'List of LIDs: {lid_list}')\n",
+    "        \n",
+    "    return lid_list\n",
+    "\n",
+    "# lid_list = list_of_lids(conus_list, True)\n",
+    "\n",
+    "# -------------------------------------------------------\n",
+    "def list_duplicate_lids(conus_list, verbose):\n",
+    "    '''\n",
+    "    Extract a list of duplicate LIDs from the conus_list\n",
+    "    \n",
+    "    Example: \n",
+    "    lid_list, duplicate_lid_list = list_duplicate_lids(conus_list, True)\n",
+    "    '''\n",
+    "    lid_list = []\n",
+    "    duplicate_lid_list = []\n",
+    "     \n",
+    "    \n",
+    "    for i, site in enumerate(conus_list):\n",
+    "        nws_lid = site['identifiers']['nws_lid']\n",
+    "\n",
+    "        if nws_lid in lid_list:\n",
+    "            duplicate_lid_list.append(nws_lid)\n",
+    "        else: \n",
+    "            lid_list.append(nws_lid)\n",
+    "\n",
+    "    if verbose == True:\n",
+    "        print(f'Length of unique LID list: {len(lid_list)}')\n",
+    "        print(f'List of duplicate LIDs: {duplicate_lid_list}')\n",
+    "\n",
+    "        \n",
+    "    return lid_list, duplicate_lid_list\n",
+    "\n",
+    "# lid_list, duplicate_lid_list = list_duplicate_lids(conus_list, True)\n",
+    "\n",
+    "# -------------------------------------------------------\n",
+    "def filter_by_lid(lid_filter, conus_list, verbose):\n",
+    "    '''\n",
+    "    Function to filter conus_list by LID\n",
+    "    \n",
+    "    Example:\n",
+    "    conus_list_filt = filter_by_lid('None', conus_list, True)\n",
+    "    '''\n",
+    "    conus_list_filt = []\n",
+    "    for i, site in enumerate(conus_list):\n",
+    "        lid = site['identifiers']['nws_lid']\n",
+    "        if lid == lid_filter:\n",
+    "            conus_list_filt.append(site)\n",
+    "    if verbose == True:\n",
+    "        print(f'LID filter: {lid_filter} \\nNumber of sites: {len(conus_list_filt)}')\n",
+    "        \n",
+    "    return conus_list_filt\n",
+    "\n",
+    "# conus_list_filt = filter_by_lid('None', conus_list, True)\n",
+    "\n",
+    "# -------------------------------------------------------\n",
+    "def filter_by_state(state_filter, conus_list, verbose):\n",
+    "    '''\n",
+    "    Function to filter conus_list by state\n",
+    "    \n",
+    "    Example: \n",
+    "    conus_list_filt = filter_by_state('Alaska', conus_list, True)\n",
+    "    '''\n",
+    "    conus_list_filt = []\n",
+    "    for i, site in enumerate(conus_list):\n",
+    "        state = site['nws_data']['state']\n",
+    "        if state == state_filter:\n",
+    "            conus_list_filt.append(site)\n",
+    "    if verbose == True:\n",
+    "        print(f'State: {state_filter} \\nNumber of sites: {len(conus_list_filt)}')\n",
+    "        \n",
+    "    return conus_list_filt\n",
+    "\n",
+    "# conus_list_filt = filter_by_state('Alaska', conus_list, True)\n",
+    "\n",
+    "# -------------------------------------------------------"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c91fa68a-a711-4431-bf8d-7b20aeb93823",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# --------- Inputs --------- \n",
+    "\n",
+    "search = 5\n",
+    "\n",
+    "nwm_us_search, nwm_ds_search = search, search\n",
+    "\n",
+    "\n",
+    "# output_catfim_dir = \n",
+    "API_BASE_URL = 'https://nwcal-wrds.nwc.nws.noaa.gov/api/location/v3.0'\n",
+    "metadata_url = f'{API_BASE_URL}/metadata'\n",
+    "\n",
+    "# Get metadata for Islands and Alaska\n",
+    "ak_test_list, ___ = get_metadata(\n",
+    "    metadata_url,\n",
+    "    select_by='state',\n",
+    "    selector=['AK'],\n",
+    "    must_include='nws_data.rfc_forecast_point',\n",
+    "    upstream_trace_distance=nwm_us_search,\n",
+    "    downstream_trace_distance=nwm_ds_search,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6591fb1-5591-4f0f-8f7f-d74fd9ad337f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ak_test_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "9dca1b28-976d-4487-9fd3-96253e1e83f2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Testing get_metadata() functionality\n",
+    "\n",
+    "# --------- Inputs --------- \n",
+    "\n",
+    "search = 5\n",
+    "\n",
+    "nwm_us_search, nwm_ds_search = search, search\n",
+    "\n",
+    "\n",
+    "# output_catfim_dir = \n",
+    "API_BASE_URL = 'https://nwcal-wrds.nwc.nws.noaa.gov/api/location/v3.0'\n",
+    "metadata_url = f'{API_BASE_URL}/metadata'\n",
+    "\n",
+    "\n",
+    "# lid_to_run = \n",
+    "# nwm_metafile = \n",
+    "\n",
+    "# --------- Code --------- \n",
+    "\n",
+    "all_meta_lists = []\n",
+    "\n",
+    "\n",
+    "conus_list, ___ = get_metadata(\n",
+    "    metadata_url,\n",
+    "    select_by='nws_lid',\n",
+    "    selector=['all'],\n",
+    "    must_include='nws_data.rfc_forecast_point',\n",
+    "    upstream_trace_distance=nwm_us_search,\n",
+    "    downstream_trace_distance=nwm_ds_search,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Get metadata for Islands and Alaska\n",
+    "islands_list, ___ = get_metadata(\n",
+    "    metadata_url,\n",
+    "    select_by='state',\n",
+    "    selector=['HI', 'PR', 'AK'],\n",
+    "    must_include=None,\n",
+    "    upstream_trace_distance=nwm_us_search,\n",
+    "    downstream_trace_distance=nwm_ds_search,\n",
+    ")\n",
+    "# Append the lists\n",
+    "all_meta_lists = conus_list + islands_list\n",
+    "\n",
+    "# print(islands_list)\n",
+    "\n",
+    "# with open(meta_file, \"wb\") as p_handle:\n",
+    "#     pickle.dump(all_meta_lists, p_handle, protocol=pickle.HIGHEST_PROTOCOL)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "d25a4979-2b0c-4f4f-ae41-6fec3768d39b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input metadata list length: 7631\n",
+      "Output (unique) metadata list length: 7214\n",
+      "Number of unique LIDs: 7214 \n",
+      "Number of duplicate LIDs: 152 \n",
+      "Number of None LIDs: 265\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ------ New addition: filtering ------\n",
+    "\n",
+    "# -- function --\n",
+    "def filter_metadata_list (metadata_list, verbose):\n",
+    "    '''\n",
+    "    \n",
+    "    Filter metadata list to remove: \n",
+    "    - sites where the nws_lid = None\n",
+    "    - duplicate sites\n",
+    "    \n",
+    "    '''\n",
+    "\n",
+    "    unique_lids, duplicate_lids = [], []\n",
+    "    duplicate_metadata_list, unique_metadata_list = [], []\n",
+    "\n",
+    "    nonelid_metadata_list = [] # TODO: remove eventually?    \n",
+    "\n",
+    "    for i, site in enumerate(metadata_list):\n",
+    "        nws_lid = site['identifiers']['nws_lid']\n",
+    "\n",
+    "        if nws_lid == None:\n",
+    "            # No LID available\n",
+    "            nonelid_metadata_list.append(site)\n",
+    "\n",
+    "            # TODO: replace this with Continue, eventually we wont need this list\n",
+    "\n",
+    "        elif nws_lid in unique_lids:\n",
+    "            # Duplicate LID\n",
+    "            duplicate_lids.append(nws_lid)\n",
+    "            duplicate_metadata_list.append(site)\n",
+    "\n",
+    "        else: \n",
+    "            # Unique/unseen LID that's not None\n",
+    "            unique_lids.append(nws_lid)\n",
+    "            unique_metadata_list.append(site)\n",
+    "\n",
+    "    if verbose == True:\n",
+    "        print(f'Input metadata list length: {len(metadata_list)}')\n",
+    "        print(f'Output (unique) metadata list length: {len(unique_metadata_list)}')\n",
+    "        print(f'Number of unique LIDs: {len(unique_lids)} \\nNumber of duplicate LIDs: {len(duplicate_lids)} \\nNumber of None LIDs: {len(nonelid_metadata_list)}')\n",
+    "\n",
+    "    return unique_lids, duplicate_lids, nonelid_metadata_list, duplicate_metadata_list, unique_metadata_list # TODO: eventually, have it only return necessary objects\n",
+    "\n",
+    "\n",
+    "\n",
+    "unique_lids, duplicate_lids, nonelid_metadata_list, duplicate_metadata_list, unique_metadata_list =  filter_metadata_list(all_meta_lists, True)\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "9ffc3b60-18de-4825-8766-80f3904fd6cf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current Code: Single API call (only forecast points)\n",
+      "State: Puerto Rico \n",
+      "Number of sites: 5\n",
+      "\n",
+      "State: Hawaii \n",
+      "Number of sites: 2\n",
+      "\n",
+      "State: Alaska \n",
+      "Number of sites: 145\n",
+      "\n",
+      "\n",
+      "Proposed Update: Double API call (forecast points + all HI, AK, and PR points)\n",
+      "\n",
+      "AFTER filtering out duplicates:\n",
+      "State: Puerto Rico \n",
+      "Number of sites: 238\n",
+      "\n",
+      "AFTER filtering out duplicates:\n",
+      "State: Hawaii \n",
+      "Number of sites: 495\n",
+      "\n",
+      "AFTER filtering out duplicates:\n",
+      "State: Alaska \n",
+      "Number of sites: 1950\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Get state counts\n",
+    "\n",
+    "state_list = ['Puerto Rico', 'Hawaii', 'Alaska']\n",
+    "\n",
+    "print('Current Code: Single API call (only forecast points)')\n",
+    "for state in state_list: \n",
+    "    currentcode_state = filter_by_state(state, conus_list, True)\n",
+    "    print()\n",
+    "\n",
+    "print()\n",
+    "print('Proposed Update: Double API call (forecast points + all HI, AK, and PR points)')\n",
+    "print()\n",
+    "for state in state_list: \n",
+    "    # print('Before filtering out duplicates:')\n",
+    "    # prefilt_state = filter_by_state(state, all_meta_lists, True)\n",
+    "    print('AFTER filtering out duplicates:')\n",
+    "    postfilt_state = filter_by_state(state, unique_metadata_list, True)\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8d2ad926-105c-4326-980c-3e4793b7b58a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State: Connecticut \n",
+      "Number of sites: 23\n",
+      "State: New York \n",
+      "Number of sites: 142\n",
+      "State: Texas \n",
+      "Number of sites: 380\n"
+     ]
+    }
+   ],
+   "source": [
+    "postfilt_state = filter_by_state('Connecticut', unique_metadata_list, True)\n",
+    "postfilt_state = filter_by_state('New York', unique_metadata_list, True)\n",
+    "postfilt_state = filter_by_state('Texas', unique_metadata_list, True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "65996d68-b060-4cd3-b575-3e3d4172c532",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input metadata list length: 4679\n",
+      "Output (unique) metadata list length: 4679\n",
+      "Number of unique LIDs: 4679 \n",
+      "Number of duplicate LIDs: 0 \n",
+      "Number of None LIDs: 0\n",
+      "\n",
+      "State: Alaska \n",
+      "Number of sites: 145\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Current code formulation\n",
+    "\n",
+    "\n",
+    "unique_lids, duplicate_lids, nonelid_metadata_list, duplicate_metadata_list, unique_metadata_list =  filter_metadata_list(conus_list, True)\n",
+    "print()\n",
+    "conus_list_filt = filter_by_state('Alaska', conus_list, True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "dcd1a64b-35c3-4f75-9e08-e936c17da1bb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LID filter: None \n",
+      "Number of sites: 265\n"
+     ]
+    }
+   ],
+   "source": [
+    "# lid_list, duplicate_lid_list = list_duplicate_lids(all_meta_lists, True)\n",
+    "\n",
+    "conus_list_filt = filter_by_lid(None, islands_list, True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "id": "ec188992-fda6-4f8b-876f-be78c48c67cc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# state_list, ___ = get_metadata(\n",
+    "#     metadata_url,\n",
+    "#     select_by='state',\n",
+    "#     # selector=['HI', 'PR', 'AK'],\n",
+    "#     selector=['AK'],\n",
+    "\n",
+    "#     # must_include='identifiers.nws_lid', ## ddin't work oh well\n",
+    "#     must_include=None,\n",
+    "\n",
+    "#     # must_include='nws_data.rfc_forecast_point',\n",
+    "#     upstream_trace_distance=nwm_us_search,\n",
+    "#     downstream_trace_distance=nwm_ds_search,\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ba42000-3855-47eb-9f1c-f3c805f45b96",
+   "metadata": {},
+   "source": [
+    "### Get a HUC list for a given HUC02 region "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "034acbe3-d096-4dfd-a358-4ca409bfef64",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "19020101\n",
+      "19020102\n",
+      "19020103\n",
+      "19020104\n",
+      "19020201\n",
+      "19020202\n",
+      "19020203\n",
+      "19020301\n",
+      "19020302\n",
+      "19020401\n",
+      "19020402\n",
+      "19020501\n",
+      "19020502\n",
+      "19020503\n",
+      "19020504\n",
+      "19020505\n",
+      "19020601\n",
+      "19020602\n",
+      "19020800\n"
+     ]
+    }
+   ],
+   "source": [
+    "fim_output_path = '/data/previous_fim/fim_4_5_2_11/'\n",
+    "\n",
+    "# huc2 = '20' # Hawaii\n",
+    "# huc2 = '21' # Puerto Rico\n",
+    "huc2 = '19' # Alaska\n",
+    "\n",
+    "all_hucs = os.listdir(fim_output_path)\n",
+    "\n",
+    "subsetted_hucs = [x for x in all_hucs if x.startswith(huc2)]\n",
+    "\n",
+    "for i in subsetted_hucs:\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29a52847-3189-41b7-a755-3063512a96e0",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Get stats for current CatFIM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ca99d060-3963-497f-a8c0-cb117bbcd818",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Inputs\n",
+    "states = ['AK', 'PR', 'HI']\n",
+    "\n",
+    "## Previous runs\n",
+    "catfim_folder_prev = '/data/catfim/'\n",
+    "result_folders_prev = ['hand_4_5_11_1_flow_based', 'hand_4_5_11_1_stage_based', 'fim_4_5_2_11_flow_based', 'fim_4_5_2_11_stage_based']\n",
+    "\n",
+    "## Current test runs\n",
+    "catfim_folder_testing = '/data/catfim/emily_test'\n",
+    "result_folders_testing = ['site_filtering_HI_flow_based', 'site_filtering_HI_stage_based', \n",
+    "                  'site_filtering_PR_flow_based', 'site_filtering_PR_stage_based', \n",
+    "                  'site_filtering_AK_flow_based', 'site_filtering_AK_stage_based']\n",
+    "\n",
+    "def count_mapped_for_state(catfim_folder, result_folders, states):\n",
+    "    # Read in CatFIM outputs\n",
+    "    for result_folder in result_folders:\n",
+    "        print()\n",
+    "        print('-----' + result_folder + '-----')\n",
+    "        \n",
+    "        catfim_points_path = 'None'\n",
+    "        \n",
+    "        catfim_outputs_mapping_path = os.path.join(catfim_folder, result_folder, 'mapping')\n",
+    "            \n",
+    "        # Get filepath\n",
+    "        for file in os.listdir(catfim_outputs_mapping_path):\n",
+    "            if file.endswith('catfim_sites.csv'):\n",
+    "                catfim_points_path = os.path.join(catfim_outputs_mapping_path, file)\n",
+    "\n",
+    "        if catfim_points_path == 'None':\n",
+    "            print(f'No site csv found in {catfim_outputs_mapping_path}')\n",
+    "            continue\n",
+    "        \n",
+    "        # Open points file\n",
+    "        try:\n",
+    "            catfim_points = gpd.read_file(catfim_points_path)\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            print('An error occurred', e)\n",
+    "            continue\n",
+    "\n",
+    "        # Get mapped vs unmapped data for the listed states\n",
+    "        for state in states:\n",
+    "            catfim_points_state = catfim_points[catfim_points['states'] == state]\n",
+    "            \n",
+    "            if len(catfim_points_state) != 0:\n",
+    "                num_not_mapped = len(catfim_points_state[catfim_points_state['mapped'] == 'no'])\n",
+    "                \n",
+    "                catfim_points_state_mapped = catfim_points_state[catfim_points_state['mapped'] == 'yes']\n",
+    "                num_mapped = len(catfim_points_state_mapped)\n",
+    "                \n",
+    "                huc_list = catfim_points_state['HUC8']\n",
+    "                \n",
+    "                if 'ahps_lid' in catfim_points_state.columns:\n",
+    "                    lid_list = catfim_points_state['ahps_lid']\n",
+    "                    lid_list_mapped = catfim_points_state_mapped['ahps_lid']\n",
+    "                elif 'nws_lid' in catfim_points_state.columns:\n",
+    "                    lid_list = catfim_points_state['nws_lid']\n",
+    "                    lid_list_mapped = catfim_points_state_mapped['nws_lid']\n",
+    "                else:\n",
+    "                    print('Could not find ahps_lid or nws_lid column in csv.')                   \n",
+    "                    print(catfim_points_state.columns)\n",
+    "                    continue\n",
+    "                \n",
+    "                huc_list_unique = set(huc_list)\n",
+    "                lid_list_unique = set(lid_list)\n",
+    "                \n",
+    "                num_duplicate_sites = len(lid_list) - len(lid_list_unique)\n",
+    "                num_duplicate_sites_mapped = len(lid_list_mapped) - len(set(lid_list_mapped))\n",
+    "\n",
+    "                print(f'{state} \\n   Mapped: {num_mapped} \\n   Not mapped: {num_not_mapped}')\n",
+    "                \n",
+    "                \n",
+    "                print(f'   Number of duplicate LIDs: {num_duplicate_sites}')\n",
+    "                print(f'   Number of duplicate LIDs mapped: {num_duplicate_sites_mapped}')\n",
+    "\n",
+    "                print(f'   {len(huc_list_unique)} hucs: {huc_list_unique}')\n",
+    "\n",
+    "        return catfim_points, #catfim_points_state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9808a93c-aee4-465a-8faa-18e941f5923a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# catfim_points_pr = count_mapped_for_state('/data/catfim/emily_test/', ['site_filtering_PR_stage_based'], 'PR')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6255a914-3c44-4e02-8c20-a6f11eb5a12e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "-----hand_4_5_11_1_flow_based-----\n",
+      "AK \n",
+      "   Mapped: 14 \n",
+      "   Not mapped: 39\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   14 hucs: {'19020202', '19020502', '19020201', '19020101', '19020504', '19020301', '19020402', '19020503', '19020104', '19020102', '19020505', '19020302', '19020401', '19020501'}\n",
+      "PR \n",
+      "   Mapped: 4 \n",
+      "   Not mapped: 1\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   2 hucs: {'21010002', '21010005'}\n",
+      "HI \n",
+      "   Mapped: 1 \n",
+      "   Not mapped: 1\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   2 hucs: {'20020000', '20010000'}\n",
+      "\n",
+      "-----hand_4_5_11_1_stage_based-----\n",
+      "AK \n",
+      "   Mapped: 13 \n",
+      "   Not mapped: 40\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   14 hucs: {'19020202', '19020502', '19020201', '19020101', '19020504', '19020301', '19020402', '19020503', '19020104', '19020102', '19020505', '19020302', '19020401', '19020501'}\n",
+      "PR \n",
+      "   Mapped: 0 \n",
+      "   Not mapped: 5\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   2 hucs: {'21010002', '21010005'}\n",
+      "HI \n",
+      "   Mapped: 0 \n",
+      "   Not mapped: 2\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   2 hucs: {'20020000', '20010000'}\n",
+      "\n",
+      "-----fim_4_5_2_11_flow_based-----\n",
+      "PR \n",
+      "   Mapped: 68 \n",
+      "   Not mapped: 177\n",
+      "   Number of duplicate LIDs: 5\n",
+      "   Number of duplicate LIDs mapped: 4\n",
+      "   5 hucs: {'21010005', '21010002', '21010004', '21010003', '21010008'}\n",
+      "HI \n",
+      "   Mapped: 50 \n",
+      "   Not mapped: 441\n",
+      "   Number of duplicate LIDs: 2\n",
+      "   Number of duplicate LIDs mapped: 2\n",
+      "   7 hucs: {'20060000', '20020000', '20030000', '20050000', '20070000', '20010000', '20040000'}\n",
+      "\n",
+      "-----fim_4_5_2_11_stage_based-----\n",
+      "PR \n",
+      "   Mapped: 0 \n",
+      "   Not mapped: 245\n",
+      "   Number of duplicate LIDs: 5\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   5 hucs: {'21010005', '21010002', '21010004', '21010003', '21010008'}\n",
+      "HI \n",
+      "   Mapped: 0 \n",
+      "   Not mapped: 491\n",
+      "   Number of duplicate LIDs: 2\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   7 hucs: {'20060000', '20020000', '20030000', '20050000', '20070000', '20010000', '20040000'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "count_mapped_for_state(catfim_folder_prev, result_folders_prev, states)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "68f45696-893c-4709-9fe6-d1c223bd9020",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "-----site_filtering_HI_flow_based-----\n",
+      "HI \n",
+      "   Mapped: 47 \n",
+      "   Not mapped: 442\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   7 hucs: {'20060000', '20020000', '20030000', '20050000', '20070000', '20010000', '20040000'}\n",
+      "\n",
+      "-----site_filtering_HI_stage_based-----\n",
+      "No site csv found in /data/catfim/emily_test/site_filtering_HI_stage_based/mapping\n",
+      "\n",
+      "-----site_filtering_PR_flow_based-----\n",
+      "PR \n",
+      "   Mapped: 59 \n",
+      "   Not mapped: 181\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   5 hucs: {'21010005', '21010002', '21010004', '21010003', '21010008'}\n",
+      "\n",
+      "-----site_filtering_PR_stage_based-----\n",
+      "No site csv found in /data/catfim/emily_test/site_filtering_PR_stage_based/mapping\n",
+      "\n",
+      "-----site_filtering_AK_flow_based-----\n",
+      "AK \n",
+      "   Mapped: 30 \n",
+      "   Not mapped: 615\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   18 hucs: {'19020202', '19020502', '19020201', '19020101', '19020504', '19020601', '19020203', '19020301', '19020402', '19020503', '19020104', '19020800', '19020102', '19020505', '19020302', '19020602', '19020401', '19020501'}\n",
+      "\n",
+      "-----site_filtering_AK_stage_based-----\n",
+      "AK \n",
+      "   Mapped: 5 \n",
+      "   Not mapped: 209\n",
+      "   Number of duplicate LIDs: 0\n",
+      "   Number of duplicate LIDs mapped: 0\n",
+      "   7 hucs: {'19020202', '19020203', '19020201', '19020101', '19020301', '19020104', '19020102'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "count_mapped_for_state(catfim_folder_testing, result_folders_testing, states)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 194,
+   "id": "04988eab-2866-4d5b-882a-abb76e072df0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of duplicate LIDs: 0\n",
+      "7 hucs: {'20050000', '20060000', '20030000', '20020000', '20010000', '20070000', '20040000'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "huc_list = catfim_points_state['HUC8']\n",
+    "lid_list = catfim_points_state['ahps_lid']\n",
+    "\n",
+    "huc_list_unique = set(huc_list)\n",
+    "lid_list_unique = set(lid_list)\n",
+    "num_duplicate_sites = len(lid_list) - len(lid_list_unique)\n",
+    "\n",
+    "print(f'Number of duplicate LIDs: {num_duplicate_sites}')\n",
+    "print(f'{len(huc_list_unique)} hucs: {huc_list_unique}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae429a31-f83e-4594-9245-66cfb452b2be",
+   "metadata": {},
+   "source": [
+    "### Test state column instablility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "id": "cce08d89-cf96-4905-a090-3ba3a09695b1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "input_meta_list = conus_list # conus_list or islands_list\n",
+    "\n",
+    "# -----\n",
+    "\n",
+    "state_data = []\n",
+    "\n",
+    "for i, site in enumerate(input_meta_list):\n",
+    "    lid = site['identifiers']['nws_lid']\n",
+    "\n",
+    "    nws_data_state = site['nws_data']['state']\n",
+    "    usgs_data_state = site['usgs_data']['state']\n",
+    "    nws_preferred_state = site['nws_preferred']['state']\n",
+    "    usgs_preferred_state = site['usgs_preferred']['state']\n",
+    "\n",
+    "    row = {'index': i, 'lid': lid, \n",
+    "           'nws_data_state':nws_data_state,\n",
+    "           'usgs_data_state':usgs_data_state,\n",
+    "           'nws_preferred_state':nws_preferred_state,\n",
+    "           'usgs_preferred_state':usgs_preferred_state}\n",
+    "\n",
+    "    state_data.append(row)\n",
+    "\n",
+    "state_data_df = pd.DataFrame(state_data)\n",
+    "\n",
+    "summary_df = pd.DataFrame({\n",
+    "    'nws_data_state': state_data_df['nws_data_state'].isna().sum(),\n",
+    "    'usgs_data_state': state_data_df['usgs_data_state'].isna().sum(),\n",
+    "    'nws_preferred_state': state_data_df['nws_preferred_state'].isna().sum(),\n",
+    "    'usgs_preferred_state': state_data_df['usgs_preferred_state'].isna().sum()}, index=[f'Number of NA Values in State Column, out of {len(state_data_df)} rows'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "id": "007eb617-d224-46e4-ab8e-aab28679cf43",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>index</th>\n",
+       "      <th>lid</th>\n",
+       "      <th>nws_data_state</th>\n",
+       "      <th>usgs_data_state</th>\n",
+       "      <th>nws_preferred_state</th>\n",
+       "      <th>usgs_preferred_state</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>302</th>\n",
+       "      <td>302</td>\n",
+       "      <td>BEAA3</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     index    lid nws_data_state usgs_data_state nws_preferred_state  \\\n",
+       "302    302  BEAA3           None            None                None   \n",
+       "\n",
+       "    usgs_preferred_state  \n",
+       "302                 None  "
+      ]
+     },
+     "execution_count": 171,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# state_data_df[state_data_df['nws_data_state'].isna()]\n",
+    "# state_data_df.loc[(state_data_df['nws_data_state'].isna()) & (state_data_df['usgs_data_state'].isna())]\n",
+    "state_data_df.loc[(state_data_df['nws_preferred_state'].isna()) & (state_data_df['usgs_preferred_state'].isna())]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c98a678-555e-47a9-bc64-87fd41883cda",
+   "metadata": {},
+   "source": [
+    "### Review CatFIM Logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "afe1c3fd-4b84-4574-b9bf-e89ec5bda6b2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "run_path = '/data/catfim/emily_test/site_filtering_PR_stage_based/'\n",
+    "log_file = 'catfim_2024_12_12-19_24_09.log'\n",
+    "\n",
+    "log_path = os.path.join(run_path, 'logs', log_file)\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "8323d4db-3cde-4029-9d06-f807a9419523",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "out_df = []\n",
+    "\n",
+    "with open(log_path) as f:\n",
+    "    for line in f:\n",
+    "        # print(line)\n",
+    "        \n",
+    "        # Initialize variables\n",
+    "        huc, lid, message_type, message = '', '', '', ''\n",
+    "\n",
+    "        # Get the HUC8\n",
+    "        match = re.search(r\"\\d{8}\", line)\n",
+    "\n",
+    "        if match:\n",
+    "            huc = match.group()\n",
+    "            \n",
+    "            # Get the LID\n",
+    "            match2 = re.search(r\"(?<= : ).{5}\", line)\n",
+    "            if match2:\n",
+    "                lid = match2.group()\n",
+    "                \n",
+    "                if 'WARNING' in line:\n",
+    "            \n",
+    "                    # print(line)\n",
+    "                    \n",
+    "                    # Get the text\n",
+    "                    pattern = lid+':'\n",
+    "                    match3 = re.search(f\"(?<={pattern})(.*)\", line)\n",
+    "                    if match3:\n",
+    "                        message = match3.group()\n",
+    "                        message_type = 'WARNING'\n",
+    "\n",
+    "                elif 'TRACE' in line: \n",
+    "                    # Get the text\n",
+    "                    pattern = lid+':'\n",
+    "                    match3 = re.search(f\"(?<={pattern})(.*)\", line)\n",
+    "                    if match3:\n",
+    "                        message = match3.group()\n",
+    "                        message_type = 'TRACE'\n",
+    "                        \n",
+    "                else:\n",
+    "                    continue\n",
+    "                        \n",
+    "                new_line = {'huc': huc, 'lid':lid, 'message_type':message_type, 'message':message}\n",
+    "\n",
+    "                out_df.append(new_line)\n",
+    "                        \n",
+    "                        \n",
+    "                \n",
+    "out_df = pd.DataFrame(out_df)\n",
+    "\n",
+    "                \n",
+    "# out_df.to_csv('PR_error_logs.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "a7b763ad-00eb-43f2-944a-2fceb2b96e69",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## __create_acceptable_usgs_elev_df from generate_categorical_fim.py\n",
+    "\n",
+    "import argparse\n",
+    "import glob\n",
+    "import math\n",
+    "import os\n",
+    "import shutil\n",
+    "import sys\n",
+    "import time\n",
+    "import traceback\n",
+    "from concurrent.futures import ProcessPoolExecutor, as_completed, wait\n",
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "from catfim.generate_categorical_fim_flows import generate_flows\n",
+    "from catfim.generate_categorical_fim_mapping import (\n",
+    "    manage_catfim_mapping,\n",
+    "    post_process_cat_fim_for_viz,\n",
+    "    produce_stage_based_lid_tifs,\n",
+    ")\n",
+    "from tools_shared_functions import (\n",
+    "    filter_nwm_segments_by_stream_order,\n",
+    "    get_datum,\n",
+    "    get_nwm_segs,\n",
+    "    get_thresholds,\n",
+    "    ngvd_to_navd_ft,\n",
+    ")\n",
+    "from tools_shared_variables import (\n",
+    "    acceptable_alt_acc_thresh,\n",
+    "    acceptable_alt_meth_code_list,\n",
+    "    acceptable_coord_acc_code_list,\n",
+    "    acceptable_coord_method_code_list,\n",
+    "    acceptable_site_type_list,\n",
+    ")\n",
+    "\n",
+    "import utils.fim_logger as fl\n",
+    "from utils.shared_variables import VIZ_PROJECTION\n",
+    "\n",
+    "\n",
+    "# from itertools import repeat\n",
+    "# from pathlib import Path\n",
+    "\n",
+    "\n",
+    "# global RLOG\n",
+    "FLOG = fl.FIM_logger()  # the non mp version\n",
+    "MP_LOG = fl.FIM_logger()  # the Multi Proc version\n",
+    "\n",
+    "gpd.options.io_engine = \"pyogrio\"\n",
+    "\n",
+    "def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):\n",
+    "    acceptable_usgs_elev_df = None\n",
+    "    try:\n",
+    "        # Drop columns that offend acceptance criteria\n",
+    "        print(len(usgs_elev_df)) ## TEMP DEBUG\n",
+    "        usgs_elev_df['acceptable_codes'] = (\n",
+    "            # usgs_elev_df['usgs_data_coord_accuracy_code'].isin(acceptable_coord_acc_code_list)\n",
+    "            # & usgs_elev_df['usgs_data_coord_method_code'].isin(acceptable_coord_method_code_list)\n",
+    "            usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list)\n",
+    "            & usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list)\n",
+    "        )\n",
+    "        \n",
+    "        print(len(usgs_elev_df)) ## TEMP DEBUG\n",
+    "        \n",
+    "        usgs_elev_df = usgs_elev_df.astype({'usgs_data_alt_accuracy_code': float})\n",
+    "        usgs_elev_df['acceptable_alt_error'] = np.where(\n",
+    "            usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh, True, False\n",
+    "        )\n",
+    "        \n",
+    "        print('after \n",
+    "        print(len(usgs_elev_df)) ## TEMP DEBUG\n",
+    "              \n",
+    "        acceptable_usgs_elev_df = usgs_elev_df[\n",
+    "            (usgs_elev_df['acceptable_codes'] == True) & (usgs_elev_df['acceptable_alt_error'] == True)\n",
+    "        ]\n",
+    "\n",
+    "        # # TEMP DEBUG Record row difference and write it to a CSV or something\n",
+    "        # label = 'Old code' ## TEMP DEBUG\n",
+    "        # num_potential_rows = usgs_elev_df.shape[0]\n",
+    "        # num_acceptable_rows = acceptable_usgs_elev_df.shape[0]\n",
+    "        # out_message = f'{label}: kept {num_acceptable_rows} rows out of {num_potential_rows} available rows.'\n",
+    "\n",
+    "    except Exception:\n",
+    "        # Not sure any of the sites actually have those USGS-related\n",
+    "        # columns in this particular file, so just assume it's fine to use\n",
+    "\n",
+    "        # print(\"(Various columns related to USGS probably not in this csv)\")\n",
+    "        # print(f\"Exception: \\n {repr(e)} \\n\")\n",
+    "        MP_LOG.error(f\"{huc_lid_id}: An error has occurred while working with the usgs_elev table\")\n",
+    "        MP_LOG.error(traceback.format_exc())\n",
+    "        acceptable_usgs_elev_df = usgs_elev_df\n",
+    "\n",
+    "    return acceptable_usgs_elev_df\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "560c9420-b0c0-40c2-895b-6546bbb51365",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>location_id</th>\n",
+       "      <th>nws_lid</th>\n",
+       "      <th>feature_id</th>\n",
+       "      <th>HydroID</th>\n",
+       "      <th>levpa_id</th>\n",
+       "      <th>dem_elevation</th>\n",
+       "      <th>dem_adj_elevation</th>\n",
+       "      <th>order_</th>\n",
+       "      <th>LakeID</th>\n",
+       "      <th>HUC8</th>\n",
+       "      <th>...</th>\n",
+       "      <th>mainstem</th>\n",
+       "      <th>acceptable_codes</th>\n",
+       "      <th>acceptable_alt_error</th>\n",
+       "      <th>source</th>\n",
+       "      <th>stream_stn</th>\n",
+       "      <th>fid_xs</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>index_right</th>\n",
+       "      <th>geometry_ln</th>\n",
+       "      <th>geometry_snapped</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>0 rows × 104 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [location_id, nws_lid, feature_id, HydroID, levpa_id, dem_elevation, dem_adj_elevation, order_, LakeID, HUC8, snap_distance, wrds_timestamp, nrldb_timestamp, nwis_timestamp, metadata_sources, goes_id, env_can_gage_id, nws_data_name, nws_data_wfo, nws_data_rfc, nws_data_geo_rfc, nws_data_latitude, nws_data_longitude, nws_data_map_link, nws_data_horizontal_datum_name, nws_data_state, nws_data_county, nws_data_county_code, nws_data_huc, nws_data_hsa, nws_data_zero_datum, nws_data_vertical_datum_name, nws_data_rfc_forecast_point, nws_data_rfc_defined_fcst_point, nws_data_riverpoint, usgs_data_name, usgs_data_geo_rfc, usgs_data_latitude, usgs_data_longitude, usgs_data_map_link, usgs_data_coord_accuracy_code, usgs_data_latlon_datum_name, usgs_data_coord_method_code, usgs_data_state, usgs_data_huc, usgs_data_site_type, usgs_data_altitude, usgs_data_alt_accuracy_code, usgs_data_alt_datum_code, usgs_data_alt_method_code, usgs_data_drainage_area, usgs_data_drainage_area_units, usgs_data_contrib_drainage_area, usgs_data_active, usgs_data_gages_ii_reference, nwm_feature_data_downstream_feature_id, nwm_feature_data_latitude, nwm_feature_data_longitude, nwm_feature_data_altitude, nwm_feature_data_stream_length, nwm_feature_data_stream_order, nwm_feature_data_mannings_roughness, nwm_feature_data_slope, nwm_feature_data_channel_side_slope, nwm_feature_data_nhd_waterbody_comid, env_can_gage_data_name, env_can_gage_data_latitude, env_can_gage_data_longitude, env_can_gage_data_map_link, env_can_gage_data_drainage_area, env_can_gage_data_contrib_drainage_area, env_can_gage_data_water_course, nws_preferred_name, nws_preferred_latitude, nws_preferred_longitude, nws_preferred_latlon_datum_name, nws_preferred_state, nws_preferred_huc, usgs_preferred_name, usgs_preferred_latitude, usgs_preferred_longitude, usgs_preferred_latlon_datum_name, usgs_preferred_state, usgs_preferred_huc, crosswalk_datasets_location_nwm_crosswalk_dataset_location_nwm_crosswalk_dataset_id, crosswalk_datasets_location_nwm_crosswalk_dataset_name, crosswalk_datasets_location_nwm_crosswalk_dataset_description, crosswalk_datasets_nws_usgs_crosswalk_dataset_nws_usgs_crosswalk_dataset_id, crosswalk_datasets_nws_usgs_crosswalk_dataset_name, crosswalk_datasets_nws_usgs_crosswalk_dataset_description, assigned_crs, name, states, curve, mainstem, acceptable_codes, acceptable_alt_error, source, stream_stn, fid_xs, ...]\n",
+       "Index: []\n",
+       "\n",
+       "[0 rows x 104 columns]"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "usgs_elev_table = '/data/previous_fim/fim_4_5_2_11/21010005/usgs_elev_table.csv'\n",
+    "huc_lid_id = 'bzap4'\n",
+    "\n",
+    "\n",
+    "usgs_elev_df = pd.read_csv(usgs_elev_table)\n",
+    "\n",
+    "\n",
+    "\n",
+    "acceptable_usgs_elev_df = __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id)\n",
+    "\n",
+    "acceptable_usgs_elev_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "9b8d4fc4-0733-4eca-952f-60f53305a7a4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "236"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(set(out_df['lid']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "a6cce11a-27b7-4302-b0b7-ba304fa8087c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "# message_string = 'Unable to find gage data'\n",
+    "message_string = 'stage values'\n",
+    "\n",
+    "stage_val_lids = out_df[out_df['message'].str.contains('stage values')]['lid']\n",
+    "no_gage_data_lids = out_df[out_df['message'].str.contains('Unable to find gage data')]['lid']\n",
+    "\n",
+    "\n",
+    "\n",
+    "# # Using set intersection\n",
+    "lids_stageval_nogagedata = list(set(stage_val_lids) & set(no_gage_data_lids))\n",
+    "\n",
+    "# len(stage_val_lids)\n",
+    "# len(no_gage_data_lids)\n",
+    "# len(lids_stageval_nogagedata)\n",
+    "\n",
+    "# print(stage_val_lids)\n",
+    "# lids_stageval_nogagedata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f7d3712-c9ae-45d5-9fd5-e49ca29e194b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "742c6bb5-c24b-4de6-8645-d2aabd61be26",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tools/catfim/notebooks/vis_catfim_cross_section.ipynb
+++ b/tools/catfim/notebooks/vis_catfim_cross_section.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6eb53c55-02a3-4172-9026-8a1ddbc05a72",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from catfim.vis_categorical_fim import (read_catfim_outputs, \n",
+    "                                        subset_catfim_geom_by_site, \n",
+    "                                        subset_apply_symbology_catfim_library, \n",
+    "                                        map_catfim_full_extent, \n",
+    "                                        map_catfim_at_site, \n",
+    "                                        map_catfim_full_extent, \n",
+    "                                        create_perpendicular_cross_section, \n",
+    "                                        map_cross_section_geometry, \n",
+    "                                        generate_dem_path, \n",
+    "                                        create_cross_section_points, \n",
+    "                                        get_elevation_for_cross_section_points, \n",
+    "                                        apply_catfim_library_to_points, \n",
+    "                                        plot_catfim_cross_section, \n",
+    "                                        map_catfim_cross_section_points)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ac6692c-262d-4d4b-9a62-f2cbcea83f6d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "EPSG = 5070\n",
+    "\n",
+    "## Viewing cross-section example\n",
+    "\n",
+    "# Inputs\n",
+    "lid = 'bltn7'\n",
+    "huc = '06010105'\n",
+    "catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "catfim_outputs_path = '/data/catfim/emily_test/hand_4_5_11_1_catfim_datavis_flow_based/'\n",
+    "\n",
+    "# Viewing AUON6 \n",
+    "\n",
+    "# # Inputs\n",
+    "# lid = 'AUON6'\n",
+    "# huc = '04140201'\n",
+    "# # catfim_inputs_path = '/data/outputs/hand_4_5_11_1_catfim'\n",
+    "# catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "# catfim_outputs_path = '/data/catfim/hand_4_5_11_1_stage_based/'\n",
+    "\n",
+    "# Viewing PACI1\n",
+    "\n",
+    "# Inputs\n",
+    "# lid = 'paci1'\n",
+    "# huc = '17060108'\n",
+    "# catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "# catfim_outputs_path = '/data/catfim/hand_4_5_11_1_stage_based/'\n",
+    "\n",
+    "# ## Viewing Alaska BEFORE updates\n",
+    "\n",
+    "# # Inputs\n",
+    "# lid = 'apta2'\n",
+    "# huc = '19020301'\n",
+    "# catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "# catfim_outputs_path = '/data/catfim/hand_4_5_11_1_flow_based'\n",
+    "\n",
+    "## Viewing Alaska updates\n",
+    "\n",
+    "# # Inputs\n",
+    "# lid = 'apta2'\n",
+    "# huc = '19020301'\n",
+    "# catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'\n",
+    "# catfim_outputs_path = '/data/catfim/emily_test/AK_new_wrds_flow_based/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3683983c-a5af-4c99-9863-b09f213d371c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Reading in and processing CatFIM library and geospatial data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d0c27b8-f47d-4543-9471-c6d2f0e799a0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Read in the CatFIM outputs\n",
+    "catfim_library, catfim_points, flowline_gdf = read_catfim_outputs(catfim_inputs_path, catfim_outputs_path, huc)\n",
+    "\n",
+    "# Subset the CatFIM geometries by site and enforce projection\n",
+    "catfim_library_filt, points_filt_gdf, flowline_filt_gdf = subset_catfim_geom_by_site(lid, catfim_library, catfim_points, flowline_gdf, EPSG)\n",
+    "\n",
+    "# Filter CatFIM library and create the symbology columns\n",
+    "catfim_library_filt, colordict = subset_apply_symbology_catfim_library(catfim_library, points_filt_gdf, lid, include_record=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a29618a-7133-43f0-9e8c-568014986ffc",
+   "metadata": {},
+   "source": [
+    "### Plotting CatFIM library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e66e0adb-cb23-4a8b-ba58-eb35bc197dde",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "map_catfim_full_extent(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', legend=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85da45bd-51b8-40d0-af52-07c22f8ad08b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "map_catfim_at_site(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', EPSG=5070, basemap=True, site_view=True, legend = True) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7860f8c9-e878-4122-a5ef-288972e1ce5f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "map_catfim_full_extent(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', legend=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba427afc-2290-4867-ab60-43c48b0c890a",
+   "metadata": {},
+   "source": [
+    "### Generate and Plot CatFIM Elevation Cross-section"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d7e18d3-d291-4bb3-b689-4a1bc9c966e7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Function Inputs ------------------------------------\n",
+    "\n",
+    "xsection_length = 1000 # cross-section length, meters or feet, 1000 suggested\n",
+    "EPSG = 5070\n",
+    "dist_between_points = 10 # distance between points on cross-section line, 10 suggested\n",
+    "\n",
+    "\n",
+    "## Run Functions ------------------------------------\n",
+    "\n",
+    "# Create cross-section\n",
+    "xsection_gdf = create_perpendicular_cross_section(flowline_filt_gdf, points_filt_gdf, xsection_length, EPSG)\n",
+    "\n",
+    "# Map the cross-section\n",
+    "map_cross_section_geometry(xsection_gdf, points_filt_gdf, flowline_filt_gdf, modifier=100, plot_title=f'Flowline cross-section at site {lid}')\n",
+    "\n",
+    "# Get DEM path\n",
+    "dem_path = generate_dem_path(huc, root_dem_path='/data/inputs/3dep_dems/')\n",
+    "\n",
+    "# Create points along cross-section line\n",
+    "xsection_points_gdf, xsection_midpoint = create_cross_section_points(xsection_gdf, dist_between_points)\n",
+    "\n",
+    "# Apply elevation to points\n",
+    "xsection_points_gdf = get_elevation_for_cross_section_points(dem_path, xsection_points_gdf, EPSG)\n",
+    "\n",
+    "# Apply CatFIM stages to points\n",
+    "xsection_catfim_filt_gdf = apply_catfim_library_to_points(xsection_points_gdf, catfim_library_filt)\n",
+    "\n",
+    "# Plot the CatFIM stage cross-section\n",
+    "plot_catfim_cross_section(xsection_points_gdf, xsection_catfim_filt_gdf, xsection_midpoint, colordict, elev_upper_buffer_ft=10, \n",
+    "                          num_points_buffer=5, dist_between_points=10, save_plot=False, \n",
+    "                          plot_title = f'CatFIM library elevation cross-section at site {lid}', \n",
+    "                          file_label='')\n",
+    "\n",
+    "# Map the CatFIM stage cross-section\n",
+    "map_catfim_cross_section_points(catfim_library_filt, flowline_filt_gdf, xsection_catfim_filt_gdf, colordict, \n",
+    "                                modifier=100, EPSG = 5070, plot_title=f'CatFIM library elevation cross-section at site {lid}', \n",
+    "                                basemap=True, legend=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d46976cd-a892-4f82-a3b4-ba59eb125b91",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Map the CatFIM stage cross-section\n",
+    "map_catfim_cross_section_points(catfim_library_filt, flowline_filt_gdf, xsection_catfim_filt_gdf, colordict, \n",
+    "                                modifier=100, EPSG=5070, plot_title=f'CatFIM library elevation cross-section at site {lid}', \n",
+    "                                basemap=False, legend=True)\n",
+    "\n",
+    "# Map the CatFIM stage cross-section\n",
+    "map_catfim_cross_section_points(catfim_library_filt, flowline_filt_gdf, xsection_catfim_filt_gdf, colordict, \n",
+    "                                modifier=100, EPSG=5070, plot_title=f'CatFIM library elevation cross-section at site {lid}', \n",
+    "                                basemap=True, legend=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tools/catfim/vis_categorical_fim.py
+++ b/tools/catfim/vis_categorical_fim.py
@@ -1,0 +1,829 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from os import listdir
+
+import geopandas as gpd
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import rasterio
+import requests
+import shapely
+from PIL import Image
+from rasterio.plot import show
+from shapely import segmentize
+from shapely.geometry import LineString, Point
+from shapely.geometry.polygon import Polygon
+from shapely.ops import substring
+
+
+'''
+This script contains functions that are useful for exploring Categorical FIM outputs. The
+functions are designed to be run in a Juputer notebook so that the plots and maps can be
+easily viewed.
+
+'''
+
+# -------------------------------------------------------------
+# Reading in and processing CatFIM library and geospatial data
+# -------------------------------------------------------------
+'''
+# Inputs ---
+
+lid = 'bltn7'
+huc = '06010105'
+catfim_inputs_path = '/data/previous_fim/fim_4_5_2_11'
+catfim_outputs_path = '/data/catfim/emily_test/hand_4_5_11_1_catfim_datavis_flow_based/'
+EPSG = 5070
+
+# Data processing functions ---
+
+# Read in the CatFIM outputs
+catfim_library, catfim_points, flowline_gdf = read_catfim_outputs(catfim_inputs_path, huc)
+
+# Subset the CatFIM geometries by site and enforce projection
+catfim_library_filt, points_filt_gdf, flowline_filt_gdf = subset_catfim_geom_by_site(lid, catfim_library, catfim_points, EPSG)
+
+# Filter CatFIM library and create the symbology columns
+catfim_library_filt, colordict = subset_apply_symbology_catfim_library(catfim_library, lid, include_record=True)
+
+
+# Mapping functions ---
+
+map_catfim_full_extent(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', legend=True)
+
+map_catfim_at_site(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', EPSG=5070, basemap=True, site_view=True, legend = True)
+
+map_catfim_full_extent(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', legend=False)
+
+'''
+
+
+def read_catfim_outputs(catfim_inputs_path, catfim_outputs_path, huc):
+    '''
+    Read in HAND and CatFIM data, constructing filepaths as needed.
+
+    Inputs:
+    - catfim_inputs_path
+    - catfim_outputs_path
+    - huc
+
+    Outputs:
+    - catfim_library
+    - catfim_points
+    - flowline_gdf
+
+    catfim_library, catfim_points, flowline_gdf = read_catfim_outputs(catfim_inputs_path, huc)
+
+    '''
+
+    # Read in HAND output flowlines
+    flowline_path = os.path.join(catfim_inputs_path, huc, 'nwm_subset_streams_levelPaths_dissolved.gpkg')
+    flowline_gdf = gpd.read_file(flowline_path)
+
+    # Read in CatFIM outputs
+    catfim_outputs_mapping_path = os.path.join(catfim_outputs_path, 'mapping')
+
+    for file in os.listdir(catfim_outputs_mapping_path):
+        if file.endswith('catfim_library.gpkg'):
+            catfim_library_path = os.path.join(catfim_outputs_path, 'mapping', file)
+        elif file.endswith('catfim_sites.gpkg'):
+            catfim_points_path = os.path.join(catfim_outputs_mapping_path, file)
+
+    try:
+        catfim_library = gpd.read_file(catfim_library_path)
+        catfim_points = gpd.read_file(catfim_points_path)
+
+    except IOError:
+        print(f'Error opening CatFIM outputs from {catfim_outputs_path}:')
+        print(IOError)
+        sys.exit()
+
+    print('HAND-FIM and CatFIM outputs have been read in.')
+
+    return catfim_library, catfim_points, flowline_gdf
+
+
+def subset_catfim_geom_by_site(lid, catfim_library, catfim_points, flowline_gdf, EPSG):
+    '''
+    Subset CatFIM library and points for a specific site.
+
+    Inputs:
+    - lid
+    - catfim_library
+    - catfim_points
+    - EPSG
+
+    Outputs:
+    - catfim_library_filt
+    - points_filt_gdf
+    - flowline_filt_gdf
+
+    catfim_library_filt, points_filt_gdf, flowline_filt_gdf = subset_catfim_geom_by_site(lid, catfim_library, catfim_points, flowline_gdf, EPSG)
+
+    '''
+
+    # Filter points to LID
+    points_filt_gdf = catfim_points[catfim_points['ahps_lid'] == lid]
+
+    if len(points_filt_gdf) > 1:
+        print(f'ERROR: Multiple points found for lid {lid}.')
+        sys.exit()
+
+    # Put the point into the projection of the flowlines
+    points_filt_gdf = points_filt_gdf.to_crs(EPSG)
+
+    # Find the flowline nearest to the point
+    flowline_filt_gdf = gpd.sjoin_nearest(flowline_gdf, points_filt_gdf, max_distance=100)
+
+    catfim_library_filt = catfim_library[catfim_library['ahps_lid'] == lid]
+    catfim_library_filt = catfim_library_filt.to_crs(points_filt_gdf.crs)
+
+    # Put the geometries into a unified projection
+    points_filt_gdf = points_filt_gdf.to_crs(EPSG)
+    flowline_filt_gdf = flowline_filt_gdf.to_crs(EPSG)
+    catfim_library_filt = catfim_library_filt.to_crs(EPSG)
+
+    print(f'Filtered points and flowlines for {lid}.')
+
+    return catfim_library_filt, points_filt_gdf, flowline_filt_gdf
+
+
+def subset_apply_symbology_catfim_library(catfim_library, points_filt_gdf, lid, include_record):
+    '''
+    Subset CatFIM library by site and apply the appropriate symbology.
+
+    Inputs:
+    - catfim_library
+    - points_filt_gdf
+    - lid
+    - include_record (True or False)
+
+    Outputs:
+    - catfim_library_filt
+
+    catfim_library_filt = subset_apply_symbology_catfim_library(catfim_library, points_filt_gdf, lid, include_record=True)
+
+    '''
+
+    catfim_library_filt = catfim_library[catfim_library['ahps_lid'] == lid]
+    catfim_library_filt = catfim_library_filt.to_crs(
+        points_filt_gdf.crs
+    )  # TODO: check that this is doing what we want it to
+
+    # Create dictionary of color and orders
+    if include_record == True:
+        categories = ['action', 'minor', 'moderate', 'major', 'record']
+        colors = ['yellow', 'orange', 'red', 'purple', 'cyan']
+        orders = [5, 4, 3, 2, 1]
+    elif include_record == False:
+        categories = ['action', 'minor', 'moderate', 'major']
+        colors = ['yellow', 'orange', 'red', 'purple']
+        orders = [5, 4, 3, 2]
+    else:
+        sys.exit('Invalid input for include_record parameter.')
+
+    colordict = dict(zip(categories, colors))
+    orderdict = dict(zip(categories, orders))
+
+    catfim_library_filt['color'] = catfim_library_filt['magnitude'].apply(lambda x: colordict[x])
+    catfim_library_filt['plot_order'] = catfim_library_filt['magnitude'].apply(lambda x: orderdict[x])
+
+    catfim_library_filt = catfim_library_filt.sort_values(by='plot_order')
+
+    print('Subsetted, filtered, and applied visualization preferences to CatFIM library.')
+
+    return catfim_library_filt, colordict
+
+
+def map_catfim_at_site(
+    catfim_library_filt,
+    flowline_filt_gdf,
+    points_filt_gdf,
+    colordict,
+    plot_title,
+    EPSG,
+    basemap,
+    site_view,
+    legend,
+):
+    '''
+    Plot data layers on top of a ESRI basemap in a square bounding box.
+    The bounding box determined by a site centroid OR the extent of the
+    CatFIM library for the site.
+
+    Inputs:
+    - catfim_library_filt
+    - flowline_filt_gdf
+    - points_filt_gdf (CatFIM site geodataframe, used as centroid if site_view = True)
+    - colordict
+    - plot_title (string, title of plot)
+    - EPSG (5070 suggested)
+    - basemap (True or False, determines whether an ESRI basemap is imported)
+    - site_view (True or False, if true then it will zoom in on site, if False it will show the full CatFIM library for the site)
+
+    map_catfim_at_site(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', EPSG=5070, basemap=True, site_view=True, legend = True)
+
+    '''
+    # Create the bounding box
+    if site_view == True:
+
+        map_centroid = points_filt_gdf
+
+        # Reproject centroid
+        map_centroid = map_centroid.to_crs(EPSG)
+
+        # Input information to calculate bounding box
+        map_length = 1000  # 100 ft/m buffer around point, hard-coded for now
+
+        # Calculate bounding box
+        ycoord = int(map_centroid.get_coordinates()['y'].iloc[0])
+        xcoord = int(map_centroid.get_coordinates()['x'].iloc[0])
+
+        map_length_half = map_length / 2
+
+        xleft = xcoord - map_length_half
+        xright = xcoord + map_length_half
+        ybottom = ycoord - map_length_half
+        ytop = ycoord + map_length_half
+
+        x = (xleft, xright)
+        y = (ybottom, ytop)
+
+    elif site_view == False:
+
+        # Get bounding rectangle of filtered CatFIM library
+        xmin_bounds, ymin_bounds, xmax_bounds, ymax_bounds = catfim_library_filt.total_bounds
+
+        # Get max length of CatFIM bounding rectangle
+        xlen = xmax_bounds - xmin_bounds
+        ylen = ymax_bounds - ymin_bounds
+        max_len = max(xlen, ylen)
+
+        # Create centroid coords
+        xcoord = xmin_bounds + xlen / 2
+        ycoord = ymin_bounds + ylen / 2
+
+        # Make a new bounding square, using CatFIM centroid and the max rectangle length
+        map_length_half = max_len / 2
+
+        xleft = xcoord - map_length_half
+        xright = xcoord + map_length_half
+        ybottom = ycoord - map_length_half
+        ytop = ycoord + map_length_half
+
+        # Organize new bounding box coordinates
+        x = (xleft, xright)
+        y = (ybottom, ytop)
+
+    # Assmeble baseplot
+    f, ax = plt.subplots(figsize=(10, 10))
+
+    if basemap == True:
+        # Pull aerial imagery basemap from ESRI API
+        esri_url = f"https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/export?bbox={x[0]}%2C{y[0]}%2C{x[1]}%2C{y[1]}&bboxSR={EPSG}&layers=0&size=&imageSR=5070&transparent=true&dpi=200&f=image"
+        esri_aerial = Image.open(requests.get(esri_url, stream=True).raw).convert('RGBA')
+        ax.imshow(esri_aerial, extent=(x[0], x[1], y[0], y[1]))
+
+    if legend == True:
+        # Create legend from the color dictionary
+        stages = list(colordict.keys())
+        patches = []
+        for stage in stages:
+            patch = mpatches.Patch(color=colordict[stage], label=stage)
+            patches.append(patch)
+
+        ax.legend(handles=patches)
+
+    # Add additional geodataframe layers
+    catfim_library_filt.plot(ax=ax, color=catfim_library_filt.color, alpha=0.5)
+    flowline_filt_gdf.plot(ax=ax, color='black', alpha=0.5)
+    points_filt_gdf.plot(ax=ax, color='black', alpha=0.5)
+
+    # Set bounds and labels
+    ax.set_xbound([x[0], x[1]])
+    ax.set_ybound([y[0], y[1]])
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_title(plot_title)
+
+    plt.show()
+
+
+def map_catfim_full_extent(
+    catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title, legend
+):
+    '''
+    Plot data layers on top of a ESRI basemap... bounding box determined by a centroid.
+
+    Inputs:
+    - catfim_library_filt
+    - flowline_filt_gdf
+    - points_filt_gdf
+    - colordict
+    - plot_title (string, title of plot)
+    - legend (True or False)
+
+    map_catfim_full_extent(catfim_library_filt, flowline_filt_gdf, points_filt_gdf, colordict, plot_title='', legend=True)
+
+    '''
+
+    # Set up CatFIM plot
+    f, ax = plt.subplots()
+    catfim_library_filt.plot(ax=ax, color=catfim_library_filt.color, alpha=0.75)
+
+    # Additional geodataframe layers
+    flowline_filt_gdf.plot(ax=ax, color='blue', alpha=0.8)
+    points_filt_gdf.plot(ax=ax, color='black', alpha=1)
+
+    if legend == True:
+        # Create legend from the color dictionary
+        stages = list(colordict.keys())
+        patches = []
+        for stage in stages:
+            patch = mpatches.Patch(color=colordict[stage], label=stage)
+            patches.append(patch)
+
+        ax.legend(handles=patches)
+
+    # Set the plot extent to the bounds of the CatFIM section
+    minx, miny, maxx, maxy = catfim_library_filt.total_bounds
+    modifier = 10  # how much to widen the extent by
+    ax.set_xlim(minx - modifier, maxx + modifier)
+    ax.set_ylim(miny - modifier, maxy + modifier)
+
+    ax.set_title(plot_title)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    plt.show()
+
+
+# -------------------------------------------------------------
+# Generate and Plot CatFIM Elevation Cross-section
+# -------------------------------------------------------------
+
+'''
+# Example Usage:
+
+# Inputs ---
+
+xsection_length = 1000 # cross-section length, meters or feet, 1000 suggested
+EPSG = 5070
+dist_between_points = 10 # distance between points on cross-section line, 10 suggested
+
+
+# Run functions ---
+
+# Create cross-section
+xsection_gdf = create_perpendicular_cross_section(flowline_filt_gdf, points_filt_gdf, xsection_length, EPSG)
+
+# Map the cross-section
+map_cross_section_geometry(xsection_gdf, points_filt_gdf, flowline_filt_gdf, modifier=100, plot_title=f'Flowline cross-section at site {lid}')
+
+# Get DEM path
+dem_path = generate_dem_path(huc, root_dem_path='/data/inputs/3dep_dems/')
+
+# Create points along cross-section line
+xsection_points_gdf, xsection_midpoint = create_cross_section_points(xsection_gdf, dist_between_points)
+
+# Apply elevation to points
+xsection_points_gdf = get_elevation_for_cross_section_points(dem_path, xsection_points_gdf, EPSG)
+
+# Apply CatFIM stages to points
+xsection_catfim_filt_gdf = apply_catfim_library_to_points(xsection_points_gdf, catfim_library_filt)
+
+# Plot the CatFIM stage cross-section
+plot_catfim_cross_section(xsection_points_gdf, xsection_catfim_filt_gdf, xsection_midpoint, colordict, elev_upper_buffer_ft=10,
+                          num_points_buffer=5, dist_between_points=10, save_plot=False, plot_title = f'CatFIM library elevation cross-section at site {lid}',
+                          file_label='')
+
+# Map the CatFIM stage cross-section
+map_catfim_cross_section_points(catfim_library_filt, flowline_filt_gdf, xsection_catfim_filt_gdf, colordict,
+                                modifier=100, plot_title=f'CatFIM library elevation cross-section at site {lid}',
+                                basemap=True, legend=True)
+
+'''
+
+
+def create_perpendicular_cross_section(flowline_filt_gdf, points_filt_gdf, xsection_length, EPSG):
+    '''
+    Creates a perpendicular cross-section of a single flowline with a specified length.
+
+    Inputs:
+    - flowline_filt_gdf
+    - points_filt_gdf
+    - xsection_length (in the projection units, 1000 is suggested)
+    - EPSG (number, 5070 is suggested)
+
+    Outputs:
+    - xsection_gdf
+
+    xsection_gdf = create_perpendicular_cross_section(flowline_filt_gdf, points_filt_gdf, xsection_length, EPSG)
+
+    '''
+
+    # Extract the line and the point
+    line = flowline_filt_gdf.geometry.iloc[0]
+    point = points_filt_gdf.geometry.iloc[0]
+
+    # Find the segment of the line near the point of interest
+    segment_length = 20  # meters or feet
+    segment_start_distance = max(0, line.project(point) - segment_length / 2)
+    segment_end_distance = min(line.length, segment_start_distance + segment_length)
+
+    # Create a shorter segment from the original line
+    short_segment = LineString(
+        [line.interpolate(segment_start_distance), line.interpolate(segment_end_distance)]
+    )
+
+    # Calculate the slope of the shorter line segment
+    line_vector = np.array(short_segment.xy[1]) - np.array(short_segment.xy[0])
+    line_vector /= np.linalg.norm(line_vector)  # Normalize
+    perpendicular_vector = np.array([-line_vector[1], line_vector[0]])  # Perpendicular vector
+
+    # Create the cross section line (10 meters long)
+    half_length = xsection_length / 2
+    start_point = (
+        point.x + half_length * perpendicular_vector[0],
+        point.y + half_length * perpendicular_vector[1],
+    )
+    end_point = (
+        point.x - half_length * perpendicular_vector[0],
+        point.y - half_length * perpendicular_vector[1],
+    )
+    new_line = LineString([start_point, end_point])
+
+    # Create a GeoDataFrame for the new line
+    xsection_gdf = gpd.GeoDataFrame({'geometry': [new_line]}, crs=flowline_filt_gdf.crs)
+
+    # Project geodataframe
+    xsection_gdf = xsection_gdf.to_crs(EPSG)
+
+    print(f'Created cross-section of length {xsection_length}.')
+
+    return xsection_gdf
+
+
+def map_cross_section_geometry(xsection_gdf, points_filt_gdf, flowline_filt_gdf, modifier, plot_title):
+    '''
+    Inputs:
+    - xsection_gdf
+    - points_filt_gdf
+    - flowline_filt_gdf
+    - modifier (buffer distance around cross-section bounds for map bounds, 100 suggested)
+    - plot_title
+
+    Outputs:
+    - a simple map of the cross-section geometry
+
+    map_cross_section_geometry(xsection_gdf, points_filt_gdf, flowline_filt_gdf, modifier=100, plot_title=f'Flowline cross-section at site {lid}')
+    '''
+
+    # Plot xsection_gdf first to set the extent
+    ax = xsection_gdf.plot(figsize=(6, 6), color='lightgray')
+
+    # Add data
+    points_filt_gdf.plot(ax=ax, color='blue', alpha=0.5, zorder=5)  # Adjust color and alpha as needed
+    flowline_filt_gdf.plot(ax=ax, color='green', alpha=0.5)  # Adjust color and alpha as needed
+
+    # Set the plot extent to the bounds of the line segment
+    minx, miny, maxx, maxy = xsection_gdf.total_bounds
+    ax.set_xlim(minx - modifier, maxx + modifier)
+    ax.set_ylim(miny - modifier, maxy + modifier)
+    ax.set_title(plot_title)
+    ax.set_xticks([])
+    ax.set_yticks([])
+
+    plt.show()
+
+
+def create_cross_section_points(xsection_gdf, dist_between_points):
+    '''
+    Creates points at a specified distance along a cross-section line.
+
+    Inputs:
+    - xsection_gdf: Cross-section line
+    - dist_between_points: Distance interval with which to create points.
+
+    Outputs:
+    - xsection_points_gdf: Points along the cross-section line.
+    - xsection_midpoint: Distance of halfway point.
+
+    xsection_points_gdf, xsection_midpoint = create_cross_section_points(xsection_gdf, dist_between_points)
+
+    '''
+
+    # Create points along cross-section line
+    xsection_line = xsection_gdf.geometry.iloc[0]
+
+    # Initialize cross-section points geometry
+    xsection_points = shapely.geometry.MultiPoint()
+
+    # Initialize the dist_along_line list
+    half_dist_between_points = [dist_between_points / 2]
+    dist_along_line = []
+
+    # Iterate through cross-section line length and create points along the line
+    for i in np.arange(0, xsection_line.length, dist_between_points):
+
+        # Get midpoint geometry
+        s = substring(xsection_line, i, i + dist_between_points)
+
+        # Add value to cross-section points geometry
+        xsection_points = xsection_points.union(s.boundary)
+
+        # dist_along_line.append(i+dist_between_points) # TODO: should this be dist_between_points/2? to get the middle?
+        dist_along_line.append(i + half_dist_between_points)  # changed so it's the halfway value
+
+    # Turn the multipoint object into a geodataframe
+    xsection_points_gdf = gpd.GeoDataFrame(
+        {'geometry': [xsection_points], 'elev': -9999}, crs=xsection_gdf.crs
+    ).explode(index_parts=True)
+
+    # Add line distance column
+    xsection_points_gdf['dist_along_line'] = dist_along_line
+
+    # Calculate the cross section halfway point
+    xsection_midpoint = dist_along_line[int(len(dist_along_line) / 2)]
+
+    print(f'Generated {len(xsection_points_gdf)} cross-section points.')
+
+    return xsection_points_gdf, xsection_midpoint
+
+
+def generate_dem_path(huc, root_dem_path):
+    '''
+    Generates a DEM path using the HUC and the root DEM path.
+
+    Inputs:
+    - huc (string)
+    - root DEM path (string, probably /data/inputs/3dep_dems/)
+
+    Outputs:
+    - HUC DEM path
+
+    dem_path = generate_dem_path(huc, root_dem_path='/data/inputs/3dep_dems/')
+
+    '''
+    if huc[0:2] == '19':
+        dem_name = f'HUC8_{huc}_dem.tif'
+        dem_path = os.path.join(root_dem_path, '10m_South_Alaska', '23_11_07', dem_name)
+    else:
+        huc6 = huc[0:6]
+        dem_name = f'HUC6_{huc6}_dem.tif'
+        dem_path = os.path.join(root_dem_path, '10m_5070', dem_name)
+
+    print(f'DEM path generated: {dem_path}')
+
+    return dem_path
+
+
+def get_elevation_for_cross_section_points(dem_path, xsection_points_gdf, EPSG):
+    '''
+    Gets the elevation for at each point from the DEM.
+
+    Inputs:
+    - dem_path (string)
+    - xsection_points_gdf
+    - EPSG (numerical, i.e. 5070)
+
+    Outputs:
+    - xsection_points_elev_gdf
+
+    xsection_points_gdf = get_elevation_for_cross_section_points(dem_path, xsection_points_gdf, EPSG)
+
+    '''
+
+    # Read the raster file
+    with rasterio.open(dem_path) as src:
+
+        # Get raster projection
+        rast_proj = src.crs
+
+        # Temporarily project cross-section points to match raster (it's easier this way)
+        xsection_points_temp_proj_gdf = xsection_points_gdf.to_crs(rast_proj)
+
+        # Extract raster values at point locations
+        values = []
+        for point in xsection_points_temp_proj_gdf.geometry:
+            x, y = point.x, point.y
+            row, col = src.index(x, y)
+            value = src.read(1, window=((row, row + 1), (col, col + 1)))[0, 0]
+            values.append(value)
+
+        # Add values to the point dataframe
+        xsection_points_temp_proj_gdf['elev'] = values
+
+    # Overwrite the old crosssection points gdf with the new elevation one
+    xsection_points_elev_gdf = xsection_points_temp_proj_gdf.to_crs(EPSG)
+
+    print('Got elevation for each cross-section point.')
+    return xsection_points_elev_gdf
+
+
+def apply_catfim_library_to_points(xsection_points_gdf, catfim_library_filt):
+    '''
+    Overlays the filtered CatFIM library onto the cross-section points to provide the lowest potential flood stage for each point.
+
+    Inputs:
+    - xsection_points_gdf
+    - catfim_library_filt
+
+    Outputs:
+    - xsection_catfim_filt_gdf
+
+    xsection_catfim_filt_gdf = apply_catfim_library_to_points(xsection_points_gdf, catfim_library_filt)
+    '''
+
+    xsection_points_overlay_gdf = gpd.overlay(xsection_points_gdf, catfim_library_filt, how='intersection')
+
+    distances_list = []
+    for i, x in enumerate(xsection_points_overlay_gdf['dist_along_line']):
+        distances_list.append(xsection_points_overlay_gdf['dist_along_line'][i][0])
+
+    # Iterate through each distance marker and filter so there's only one row per point (with smallest flood level kept)
+    xsection_catfim_filt = []
+
+    for dist in distances_list:
+        # Filter the rows given distance
+        filtered_df = xsection_points_overlay_gdf[xsection_points_overlay_gdf['dist_along_line'] == dist]
+
+        # Get the row with the highest plot order (color plotted on top)
+        min_row = filtered_df.loc[filtered_df['plot_order'].idxmax()]
+
+        # Append the result for this distance marker
+        xsection_catfim_filt.append(min_row)
+
+    # Convert the results list into a DataFrame to view all results
+    xsection_catfim_filt_gdf = gpd.GeoDataFrame(xsection_catfim_filt)
+
+    print('Intersected and overlaid cross section points with CatFIM library.')
+    return xsection_catfim_filt_gdf
+
+
+def plot_catfim_cross_section(
+    xsection_points_gdf,
+    xsection_catfim_filt_gdf,
+    xsection_midpoint,
+    colordict,
+    elev_upper_buffer_ft,
+    num_points_buffer,
+    dist_between_points,
+    save_plot,
+    plot_title,
+    file_label,
+):
+    '''
+    Plots the CatFIM cross section points with the inundation category.
+
+    Inputs:
+    - xsection_points_gdf
+    - xsection_catfim_filt_gdf
+    - xsection_midpoint
+    - colordict
+    - elev_upper_buffer_ft (Number of ft above highest CatFIM library point to show, 10 suggested)
+    - num_points_buffer (Number of points to show on either side of CatFIM library, 5 suggested)
+    - dist_between_points (Distance between points along the cross-section, 10 suggested)
+    - save_plot (Whether to save the plot (True/False)
+    - plot_label (Additional label for plot title, if needed)
+    - file_label (Additional label for plot file, if needed)
+
+    plot_catfim_cross_section(xsection_points_gdf, xsection_catfim_filt_gdf, xsection_midpoint, colordict, elev_upper_buffer_ft=10,
+                            num_points_buffer=5, save_plot=False, plot_title = f'CatFIM library elevation cross-section at site {lid}',
+                            file_label='')
+
+    '''
+
+    # Set up map
+    f, ax = plt.subplots(figsize=(10, 4))
+
+    # Add elevation line
+    plt.plot(xsection_points_gdf.dist_along_line, xsection_points_gdf.elev, color='gray', alpha=0.8, zorder=2)
+
+    # Add CatFIM points
+    plt.scatter(
+        x=xsection_catfim_filt_gdf.dist_along_line,
+        y=xsection_catfim_filt_gdf.elev,
+        color=xsection_catfim_filt_gdf.color,
+        alpha=0.9,
+        edgecolor='black',
+        lw=0.7,
+        zorder=3,
+    )
+
+    # Add a dotted line at the approximate LID location
+    plt.axvline(x=xsection_midpoint, color='gray', linestyle='--', alpha=0.4)
+
+    # Calculate x axis bounds with points buffer
+    x_buffer = dist_between_points * num_points_buffer
+    x_min = xsection_catfim_filt_gdf['dist_along_line'].min() - x_buffer
+    x_max = xsection_catfim_filt_gdf['dist_along_line'].max() + x_buffer
+
+    # Calculate y axis bounds with an elevation buffer
+    y_min = xsection_catfim_filt_gdf['elev'].min() - 1
+    y_max = xsection_catfim_filt_gdf['elev'].max() + elev_upper_buffer_ft
+
+    # Create legend from the color dictionary
+    stages = list(colordict.keys())
+    patches = []
+    for stage in stages:
+        patch = mpatches.Patch(color=colordict[stage], label=stage)
+        patches.append(patch)
+
+    ax.legend(handles=patches)
+
+    # Set labels and axis bounds
+    ax.set_xlabel('')
+    ax.set_ylabel('Elevation, ft')
+    ax.set_xbound([x_min, x_max])
+    ax.set_ybound([y_min, y_max])
+    ax.set_title(plot_title)
+
+    # Save and display plot
+    if save_plot == True:
+        # Create plot filename
+        plot_name = 'catfim_crosssection_' + file_label + '.png'
+        plt.savefig(plot_name)
+        print(f'Saved plot as {plot_name}')
+
+    else:
+        plt.show()
+
+
+def map_catfim_cross_section_points(
+    catfim_library_filt,
+    flowline_filt_gdf,
+    xsection_catfim_filt_gdf,
+    colordict,
+    modifier,
+    EPSG,
+    plot_title,
+    basemap,
+    legend,
+):
+    '''
+    Plot data layers on top of a ESRI basemap... bounding box determined by the CatFIM cross section extent.
+
+    Inputs:
+    - catfim_library_filt
+    - flowline_filt_gdf
+    - xsection_catfim_filt_gdf
+    - colordict
+    - modifier
+    - plot_title
+    - basemap (True or False, depending on if you want the ESRI basemap)
+    - legend (True or False, depending on if you want a legend)
+
+    map_catfim_cross_section_points(catfim_library_filt, flowline_filt_gdf, xsection_catfim_filt_gdf, colordict,
+                                modifier=100, EPSG=5070, plot_title=f'CatFIM library elevation cross-section at site {lid}',
+                                basemap=True, legend=True)
+
+    '''
+
+    # Get bounding rectangle of filtered CatFIM library
+    xmin_bounds, ymin_bounds, xmax_bounds, ymax_bounds = xsection_catfim_filt_gdf.total_bounds
+
+    # Organize new bounding box coordinates
+    x = (xmin_bounds - modifier, xmax_bounds + modifier)
+    y = (ymin_bounds - modifier, ymax_bounds + modifier)
+
+    # Assmeble baseplot
+    f, ax = plt.subplots(figsize=(10, 10))
+
+    if basemap == True:
+        # Pull aerial imagery basemap from ESRI API
+        esri_url = f"https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/export?bbox={x[0]}%2C{y[0]}%2C{x[1]}%2C{y[1]}&bboxSR={EPSG}&layers=0&size=&imageSR=5070&transparent=true&dpi=200&f=image"
+        esri_aerial = Image.open(requests.get(esri_url, stream=True).raw).convert('RGBA')
+
+        ax.imshow(esri_aerial, extent=(x[0], x[1], y[0], y[1]))
+
+    if legend == True:
+        # Create legend from the color dictionary
+        stages = list(colordict.keys())
+        patches = []
+        for stage in stages:
+            patch = mpatches.Patch(color=colordict[stage], label=stage)
+            patches.append(patch)
+
+        ax.legend(handles=patches)
+
+    # Plot filtered CatFIM library
+    catfim_library_filt.plot(ax=ax, color=catfim_library_filt.color, alpha=0.6)
+
+    # Add additional geodataframe layers
+    flowline_filt_gdf.plot(ax=ax, color='black', alpha=1)
+    xsection_catfim_filt_gdf.plot(
+        ax=ax, color=xsection_catfim_filt_gdf['color'], edgecolor='black', lw=0.7, zorder=5
+    )
+
+    # Set bounds and labels
+    ax.set_xbound([x[0], x[1]])
+    ax.set_ybound([y[0], y[1]])
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_title(plot_title)
+
+    plt.show()


### PR DESCRIPTION
There are some CatFIM sites where the stage values that are provided in the WRDS API actually have the water surface elevation (WSE) rather than the stage value. One site where this is true is site prdk2 in Paradise, KY. At this site, the action stage is listed as 378 ft, which has caused very intense over inundation (as showen in the "before" example below). This code update detects that this issue is occurring and subtracts the elevation from the incorrect "stage" value to produce the actual stage value. In the case of site prdk2, the listed "stage" value is 378 ft, so the gage elevation (363.19 ft) is subtracted to produce the much more reasonable stage value of 14.81 ft. This results in a much more reasonable stage-based CatFIM result, as shown in the "after" example below. 

** **This PR includes the changes from `dev-catfim-v2-2-site-filtering`, so should be merged after that one!** **

_Addresses vlab ticket #141569._

### Changes
- `inundation-mapping/tools/catfim/generate_categorical_fim.py`: Added an update to detect and fix cases where WSE is provided in lieu of stage.

### Testing
- I've tested this on site prdk2 (HUC 05110003)
- I suggest that the reviewer tests this on site pvlk2  (HUC 05130101), because that site has an action stage listed at 995 ft. 

**Site prdk2 before this update:**
![prdk2_BEFORE_update](https://github.com/user-attachments/assets/69eb68b0-8576-47d1-8926-eb61a3462310)

**Site prdk2 after this update:**
![prdk2_after_update](https://github.com/user-attachments/assets/22ce19a0-0507-4b02-afc7-15e3c8ee1d13)


### Deployment Plan (For developer use)

_How does the changes affect the product?_
- [x] Code only?
- [ ] If applicable, has a deployment plan be created with the deployment person/team?
- [ ] Require new or adjusted data inputs? Does it have start, end and duration code (in UTC)?
- [ ] If new or updated data sets, has the FIM code been updated and tested with the new/adjusted data (subset is fine, but must be a subset of the new data)?
- [ ] Require new pre-clip set?
- [ ] Has new or updated python packages?

### Issuer Checklist (For developer use)

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [ ] `pre-commit` hooks were run locally
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [x] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
