### PR TITLE
[1pt] PR: Fix DEM misalignment by using pre-buffered HUC8 DEMs

### DIFF
--- a/src/bash_variables.env
+++ b/src/bash_variables.env
@@ -9,8 +9,10 @@ export ALASKA_CRS=EPSG:3338
 
 export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250218/
 
-export                              input_DEM=${inputsDir}/dems/3dep_dems/10m_5070/20240916/hand_seamless_3dep_dem_10m_5070.vrt
-export                       input_DEM_Alaska=${inputsDir}/dems/3dep_dems/10m_South_Alaska/20240912/FIM_3dep_dem_South_Alaska_10m.vrt
+#export                              input_DEM=${inputsDir}/dems/3dep_dems/10m_5070/20240916/hand_seamless_3dep_dem_10m_5070.vrt
+#export                       input_DEM_Alaska=${inputsDir}/dems/3dep_dems/10m_South_Alaska/20240912/FIM_3dep_dem_South_Alaska_10m.vrt
+export                              input_DEM=${outputsDir}/dem/HUC8_5070_buffered_dems/
+export                       input_DEM_Alaska=${outputsDir}/dem/HUC8_South_Alaska_buffered_dems/
 export                       input_DEM_domain=${inputsDir}/dems/3dep_dems/10m_5070/20240916/DEM_Domain.gpkg
 export                input_DEM_domain_Alaska=${inputsDir}/dems/3dep_dems/10m_South_Alaska/20240912/DEM_Domain.gpkg
 

--- a/src/run_unit_wb.sh
+++ b/src/run_unit_wb.sh
@@ -137,18 +137,14 @@ tempCurrentBranchDataDir=$tempBranchDataDir/$branch_zero_id
 mkdir -p $tempCurrentBranchDataDir
 
 ## CLIP RASTERS
-echo -e $startDiv"Clipping rasters to branches $hucNumber $branch_zero_id"
-# Note: don't need to use gdalwarp -cblend as we are using a buffered wbd
-[ ! -f $tempCurrentBranchDataDir/dem_meters.tif ] && {
-gdalwarp -cutline $tempHucDataDir/wbd_buffered.gpkg -crop_to_cutline -ot Float32 -r bilinear -of "GTiff" \
-    -overwrite -co "BLOCKXSIZE=512" -co "BLOCKYSIZE=512" -co "TILED=YES" -co "COMPRESS=LZW" \
-    -co "BIGTIFF=YES" -t_srs $huc_CRS -tr $res $res $input_DEM $tempHucDataDir/dem_meters.tif
+echo -e $startDiv"Copying DEM for HUC8 $hucNumber"
+cp $input_DEM/HUC8_"$hucNumber"_buffered_dem.tif  $tempHucDataDir/dem_meters.tif 
 
 # Clip the bridge elevation diff raster (DEM_diff). Used 'near' to make sure neighboring cells do not get any interpolated value
 gdalwarp -cutline $tempHucDataDir/wbd_buffered.gpkg -crop_to_cutline -ot Float32 -r near -of "GTiff" \
     -overwrite -co "BLOCKXSIZE=512" -co "BLOCKYSIZE=512" -co "TILED=YES" -co "COMPRESS=LZW" \
     -co "BIGTIFF=YES" -t_srs $huc_CRS -tr $res $res $input_bridge_elev_diff $tempHucDataDir/bridge_elev_diff_meters.tif
-}
+
 
 ## GET RASTER METADATA
 echo -e $startDiv"Get DEM Metadata $hucNumber $branch_zero_id"


### PR DESCRIPTION
FIM requires DEMs with a 5 km buffer around HUC8 boundaries. The current workflow for generating these DEMs consists of the following steps:

1. Creating separate DEMs for each HUC8 boundary.
2. Merging them into a VRT file.
3. Cropping the VRT to the buffered boundary.

However, this approach introduces two key issues:

- Misalignment of DEMs: Clipping the VRT to the buffered HUC8 extent results in a misaligned DEM, which propagates into the REM and inundation predictions, as highlighted in issue #1415.
- Interpolation Artifacts: Cropping the VRT involves bilinear interpolation, which alters the original DEM values.

This PR eliminates the need for a VRT by directly creating buffered DEMs for each HUC8. The FIM workflow will now simply use the pre-generated buffered DEMs for each HUC8. This update eliminates misalignment issues by ensuring each HUC8 retains its correct DEM alignment and original elevation values without interpolation artifacts. It also improves efficiency by reducing processing time, as no VRT cropping is needed.



### Changes

- src/bash_variables.env .. Revised the paths to folders containing buffered HUC8 DEMs
- src/bash_variables.env  ... Removed VRT cropping and replaced it with direct copying of pre-existing buffered DEMs.

### Testing
Tested the changes for HUC 02050206. Before this update, the inundation maps did not align with the original USGS DEMs, but after the update, they now correctly follow the original DEM data.

### Deployment Plan (For developer use)

_How does the changes affect the product?_
- [ ] Code only?
- [ ] If applicable, has a deployment plan be created with the deployment person/team?
- [x] Require new or adjusted data inputs? Does it have start, end and duration code (in UTC)?
- [ ] If new or updated data sets, has the FIM code been updated and tested with the new/adjusted data (subset is fine, but must be a subset of the new data)?
- [ ] Require new pre-clip set?
- [ ] Has new or updated python packages?

### Issuer Checklist (For developer use)

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [ ] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [ ] Links are provided if this PR resolves an issue, or depends on another other PR
- [ ] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [ ] `pre-commit` hooks were run locally
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [ ] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
