### PR TITLE
[1pt] Update CatFIM to function properly when lakes GPKG unavailable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
-## v4.6.1.__ - 2025-__-__ - [PR#1489](https://github.com/NOAA-OWP/inundation-mapping/pull/1489)
+## v4.6.1.6 - 2025-05-01 - [PR#1489](https://github.com/NOAA-OWP/inundation-mapping/pull/1489)
 
 Adds a workaround to the CatFIM lake masking code that just returns the unmasked array if the lakes geopackage is not available. It also pulls the lakes geopackage from the FIM output HUC folder, rather than a hard-coded preclip folder, so the lakes geopackage will be the correct lakes file for that FIM run. This update also improves error tracing in `reformat_inundation_maps()` (from `generate_categorical_fim_mapping.py`) so it produces a more descriptive error message if no inundated polygons are found (rather than the misleading CRS error that was previously given). 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## v4.6.1.__ - 2025-__-__ - [PR#1489](https://github.com/NOAA-OWP/inundation-mapping/pull/1489)
 
-Adds a workaround to the CatFIM lake masking code that just returns the unmasked array if the lakes geopackage is not available. It also pulls the lakes geopackage from the FIM output HUC folder, rather than a hard-coded preclip folder, so the lakes geopackage will be the correct lakes file for that FIM run. 
-
+Adds a workaround to the CatFIM lake masking code that just returns the unmasked array if the lakes geopackage is not available. It also pulls the lakes geopackage from the FIM output HUC folder, rather than a hard-coded preclip folder, so the lakes geopackage will be the correct lakes file for that FIM run. This update also improves error tracing in `reformat_inundation_maps()` (from `generate_categorical_fim_mapping.py`) so it produces a more descriptive error message if no inundated polygons are found (rather than the misleading CRS error that was previously given). 
 
 ### Changes
 - `tools/catfim/generate_categorical_fim.py`: Adjustments to spacing.
-- `tools/catfim/generate_categorical_fim_mapping.py`: Updated the two places where `mask_out_lakes()` is run so they have updated inputs and outputs.
-- `tools/tools_shared_functions.py`: Updated the `mask_out_lakes()` function so it properly handles instances where the HUC is missing a lakes GPKG. 
+- `tools/catfim/generate_categorical_fim_mapping.py`: Updated the two places where `mask_out_lakes()` is run so they have the updated additional input (`fim_run_dir` and `mask_status`). Add `mask_status` to be printed in the log. Improved error messaging in `reformat_inundation_maps()`.
+- `tools/tools_shared_functions.py`: Updated the `mask_out_lakes()` function to have `fim_run_dir` as an additional input to the function and `mask_status` as an additional output. Changed pathing of the lakes gpkg so it comes from the FIM results HUC folder rather than a hard-coded preclip folder. Updated function so it checks whether the lakes GPKG exists for a given HUC and, if not, then it just returns the unmasked lake file with the appropriate `mask_status` message.  
+
 
 <br/><br/>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,20 @@ Adds a workaround to the CatFIM lake masking code that just returns the unmasked
 
 <br/><br/>
 
+## v4.6.1.5 - 2025-04-18 - [PR#1490](https://github.com/NOAA-OWP/inundation-mapping/pull/1490)
+
+The segmentation faults we've been experiencing appear to be caused by multiple branches attempting to read the same HUC-level geopackage at the same time. We're not sure why, but the pyogrio/arrow engine seems to be the root cause since changing the engine to fiona for these reads has fixed the issue.
+
+### Changes
+
+The following files are where we've documented the segmentation faults and have changed the HUC-level GPKG reads to have the fiona engine.
+
+- `src/`
+    - `add_crosswalk.py`
+    - `filter_catchments_and_add_attributes.py`
+    - `split_flows.py`
+
+<br/><br/>
 
 ## v4.6.1.4 - 2025-04-01 - [PR#1479](https://github.com/NOAA-OWP/inundation-mapping/pull/1479)
 This PR prevents the removal of the processing duration text file from each HUC to aid in debugging. This tries to fix #1458.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,9 @@ Adds a workaround to the CatFIM lake masking code that just returns the unmasked
 
 
 ### Changes
-- 'tools/catfim/generate_categorical_fim.py`: Adjustments to spacing.
-- `tools/catfim/generate_categorical_fim_mapping.py`: Updated the two places where `mask_out_lakes()` is run so they have the updated additional input (`fim_run_dir` and `mask_status`). Add `mask_status` to be printed in the log. 
-- `tools/tools_shared_functions.py`: Updated the `mask_out_lakes()` function to have `fim_run_dir` as an additional input to the function and `mask_status` as an additional output. Changed pathing of the lakes gpkg so it comes from the FIM results HUC folder rather than a hard-coded preclip folder. Updated function so it checks whether the lakes GPKG exists for a given HUC and, if not, then it just returns the unmasked lake file with the appropriate `mask_status` message.
+- `tools/catfim/generate_categorical_fim.py`: Adjustments to spacing.
+- `tools/catfim/generate_categorical_fim_mapping.py`: Updated the two places where `mask_out_lakes()` is run so they have updated inputs and outputs.
+- `tools/tools_shared_functions.py`: Updated the `mask_out_lakes()` function so it properly handles instances where the HUC is missing a lakes GPKG. 
 
 <br/><br/>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,20 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## v4.6.1.__ - 2025-__-__ - [PR#1489](https://github.com/NOAA-OWP/inundation-mapping/pull/1489)
+
+Adds a workaround to the CatFIM lake masking code that just returns the unmasked array if the lakes geopackage is not available. It also pulls the lakes geopackage from the FIM output HUC folder, rather than a hard-coded preclip folder, so the lakes geopackage will be the correct lakes file for that FIM run. 
+
+
+### Changes
+- 'tools/catfim/generate_categorical_fim.py`: Adjustments to spacing.
+- `tools/catfim/generate_categorical_fim_mapping.py`: Updated the two places where `mask_out_lakes()` is run so they have the updated additional input (`fim_run_dir` and `mask_status`). Add `mask_status` to be printed in the log. 
+- `tools/tools_shared_functions.py`: Updated the `mask_out_lakes()` function to have `fim_run_dir` as an additional input to the function and `mask_status` as an additional output. Changed pathing of the lakes gpkg so it comes from the FIM results HUC folder rather than a hard-coded preclip folder. Updated function so it checks whether the lakes GPKG exists for a given HUC and, if not, then it just returns the unmasked lake file with the appropriate `mask_status` message.
+
+<br/><br/>
+
+
 ## v4.6.1.4 - 2025-04-01 - [PR#1479](https://github.com/NOAA-OWP/inundation-mapping/pull/1479)
 This PR prevents the removal of the processing duration text file from each HUC to aid in debugging. This tries to fix #1458.
 

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -1625,7 +1625,6 @@ def generate_stage_based_categorical_fim(
     all_csv_df = pd.DataFrame()
     refined_csv_files_list = []
     for csv_file in attrib_csv_files:
-
         full_csv_path = os.path.join(attributes_dir, csv_file)
         # HUC has to be read in as string to preserve leading zeros.
         try:
@@ -1637,7 +1636,6 @@ def generate_stage_based_categorical_fim(
             FLOG.error(f"ERROR: loading csv {full_csv_path}")
             FLOG.error(traceback.format_exc())
             pass
-
     # Write to file
     if len(all_csv_df) == 0:
         raise Exception("no csv files found")

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -1638,7 +1638,7 @@ def generate_stage_based_categorical_fim(
             pass
     # Write to file
     if len(all_csv_df) == 0:
-        raise Exception("no csv files found")
+        raise Exception(f"no csv files found - missing attribute CSVs in {attributes_dir}")
 
     all_csv_df.to_csv(os.path.join(attributes_dir, 'nws_lid_attributes.csv'), index=False)
 

--- a/tools/catfim/generate_categorical_fim_mapping.py
+++ b/tools/catfim/generate_categorical_fim_mapping.py
@@ -929,10 +929,18 @@ def reformat_inundation_maps(
             {'properties': {'extent': 1}, 'geometry': s}
             for i, (s, v) in enumerate(shapes(image, mask=mask, transform=src.transform))
         )
+        
+        list_results = list(results)
+
+        # Check whether any shapes were found in the inundated tifs
+        # If not, log a message and return
+        if len(list_results) == 0:
+            MP_LOG.error(f"{huc} : {ahps_lid} : {magnitude} - No values above zero in inundated tif, so zero inundated shapes were found. See GitHub issue #1491 for details.")
+            return
 
         # Convert list of shapes to polygon
         # lots of polys
-        extent_poly = gpd.GeoDataFrame.from_features(list(results), crs=src.crs)
+        extent_poly = gpd.GeoDataFrame.from_features(list_results, crs=src.crs)
 
         # Dissolve polygons
         extent_poly_diss = extent_poly.dissolve(by='extent')

--- a/tools/catfim/generate_categorical_fim_mapping.py
+++ b/tools/catfim/generate_categorical_fim_mapping.py
@@ -584,7 +584,9 @@ def run_inundation(
         # TODO: Update to only run if lake detected?
         with rasterio.open(output_extent_tif, 'r+') as output_extent_src:
             output_extent_array = output_extent_src.read(1)
-            output_extent_array_masked, mask_status = mask_out_lakes(output_extent_array, huc, output_extent_src, fim_run_dir)
+            output_extent_array_masked, mask_status = mask_out_lakes(
+                output_extent_array, huc, output_extent_src, fim_run_dir
+            )
             output_extent_src.write(output_extent_array_masked, 1)
 
         MP_LOG.trace(f"Lake masking complete for {huc} : {ahps_site} : {magnitude}")

--- a/tools/catfim/generate_categorical_fim_mapping.py
+++ b/tools/catfim/generate_categorical_fim_mapping.py
@@ -931,13 +931,16 @@ def reformat_inundation_maps(
             {'properties': {'extent': 1}, 'geometry': s}
             for i, (s, v) in enumerate(shapes(image, mask=mask, transform=src.transform))
         )
-        
+
         list_results = list(results)
 
         # Check whether any shapes were found in the inundated tifs
         # If not, log a message and return
         if len(list_results) == 0:
-            MP_LOG.error(f"{huc} : {ahps_lid} : {magnitude} - No values above zero in inundated tif, so zero inundated shapes were found. See GitHub issue #1491 for details.")
+            MP_LOG.error(
+                f"{huc} : {ahps_lid} : {magnitude} - No values above zero in inundated tif, "
+                "so zero inundated shapes were found. See GitHub issue #1491 for details."
+                )
             return
 
         # Convert list of shapes to polygon

--- a/tools/catfim/generate_categorical_fim_mapping.py
+++ b/tools/catfim/generate_categorical_fim_mapping.py
@@ -247,7 +247,8 @@ def produce_stage_based_lid_tifs(
             summed_array = summed_array + remaining_raster_array
 
         # Mask out the lakes from the inundation array
-        summed_masked_array = mask_out_lakes(summed_array, huc, zero_branch_src)
+        summed_masked_array, mask_status = mask_out_lakes(summed_array, huc, zero_branch_src, fim_dir)
+        MP_LOG.lprint(mask_status)
 
         del zero_branch_array, summed_array  # Clean up
 
@@ -583,7 +584,7 @@ def run_inundation(
         # TODO: Update to only run if lake detected?
         with rasterio.open(output_extent_tif, 'r+') as output_extent_src:
             output_extent_array = output_extent_src.read(1)
-            output_extent_array_masked = mask_out_lakes(output_extent_array, huc, output_extent_src)
+            output_extent_array_masked, mask_status = mask_out_lakes(output_extent_array, huc, output_extent_src, fim_run_dir)
             output_extent_src.write(output_extent_array_masked, 1)
 
         MP_LOG.trace(f"Lake masking complete for {huc} : {ahps_site} : {magnitude}")

--- a/tools/catfim/generate_categorical_fim_mapping.py
+++ b/tools/catfim/generate_categorical_fim_mapping.py
@@ -940,7 +940,7 @@ def reformat_inundation_maps(
             MP_LOG.error(
                 f"{huc} : {ahps_lid} : {magnitude} - No values above zero in inundated tif, "
                 "so zero inundated shapes were found. See GitHub issue #1491 for details."
-                )
+            )
             return
 
         # Convert list of shapes to polygon

--- a/tools/tools_shared_functions.py
+++ b/tools/tools_shared_functions.py
@@ -82,7 +82,7 @@ def filter_nwm_segments_by_stream_order(unfiltered_segments, desired_order, nwm_
     return filtered_segments
 
 
-def mask_out_lakes(input_array, huc, raster_src):
+def mask_out_lakes(input_array, huc, raster_src, fim_run_dir):
     '''
     This function is used in CatFIM to mask out lakes from inundated tifs.
 
@@ -91,29 +91,38 @@ def mask_out_lakes(input_array, huc, raster_src):
     input_array: inundation TIF that needs lakes removed (called summed_array for stage-based)
     huc: HUC8 id (string), needed to get the correct lakes file
     raster_src: src from a raster that should be uses for getting the correct raster dimensions
+    fim_run_dir: path to the fim run directory where the lakes shapefile is located
 
     Outputs:
 
     masked_array: same array as before, but with lakes masked out and the dimensions of raster_src
+    mask_status: string, status of whether lake shapefile was available
 
     '''
 
     # Read in waterbodies geopackage
-    preclip_lakes_path = f'/data/inputs/pre_clip_huc8/20241002/{huc}/nwm_lakes_proj_subset.gpkg'  # TODO: Update to get path from variables
-    preclip_lakes_gdf = gpd.read_file(preclip_lakes_path)
+    preclip_lakes_path = os.path.join(fim_run_dir, huc, 'nwm_lakes_proj_subset.gpkg')
 
-    # Create a binary raster using the shapefile geometry
-    lake_mask = geometry_mask(
-        preclip_lakes_gdf.geometry,
-        transform=raster_src.transform,
-        invert=False,
-        out_shape=(raster_src.height, raster_src.width),
-    )
+    if not os.path.exists(preclip_lakes_path):
+        # If the lakes shapefile does not exist, return the input array without masking
+        mask_status = f'HUC {huc}: No lakes shapefile found, returning original array'
+        return input_array, mask_status
+    else:
+        # Read in the lakes shapefile
+        preclip_lakes_gdf = gpd.read_file(preclip_lakes_path)
 
-    # Set values within the lake geometry to zero, masking them out of the FIM
-    masked_array = input_array * lake_mask
+        # Create a binary raster using the shapefile geometry
+        lake_mask = geometry_mask(
+            preclip_lakes_gdf.geometry,
+            transform=raster_src.transform,
+            invert=False,
+            out_shape=(raster_src.height, raster_src.width),
+        )
 
-    return masked_array
+        # Set values within the lake geometry to zero, masking them out of the FIM
+        masked_array = input_array * lake_mask
+        mask_status = f'HUC {huc}: Lakes shapefile available, masked out lake'
+        return masked_array, mask_status
 
 
 def check_for_regression(


### PR DESCRIPTION
These bugs were found in a full-scale run of flow-based CatFIM in April, 2025.

Previously, stage-based CatFIM would produce an error when a HUC does not have a water bodies geopackage available in the HUC's preclip folder. The lake masking functionality was also hard-coded to access a certain version of pre-clip, which was out of date. This update adds a workaround to the CatFIM lake masking code that just returns the unmasked array if the lakes geopackage is not available. It also pulls the lakes geopackage from the FIM output HUC folder, rather than a hard-coded preclip folder, so the lakes geopackage will be the correct lakes file for that FIM run. 

This update also improves error tracing in `reformat_inundation_maps()` (from `generate_categorical_fim_mapping.py`) so it produces a more descriptive error message if no inundated polygons are found (rather than the misleading CRS error that was previously given). 


### Changes
- `tools/catfim/generate_categorical_fim.py`: Adjustments to spacing.
- `tools/catfim/generate_categorical_fim_mapping.py`: Updated the two places where `mask_out_lakes()` is run so they have the updated additional input (`fim_run_dir` and `mask_status`). Add `mask_status` to be printed in the log. Improved error messaging in `reformat_inundation_maps()`.
- `tools/tools_shared_functions.py`: Updated the `mask_out_lakes()` function to have `fim_run_dir` as an additional input to the function and `mask_status` as an additional output. Changed pathing of the lakes gpkg so it comes from the FIM results HUC folder rather than a hard-coded preclip folder. Updated function so it checks whether the lakes GPKG exists for a given HUC and, if not, then it just returns the unmasked lake file with the appropriate `mask_status` message.  


### Testing
- Tested on results for HUC 04140201 with the lakes GPKG removed and functioned as expected.

### Deployment Plan (For developer use)

_How does the changes affect the product?_
- [x] Code only?
- [ ] If applicable, has a deployment plan be created with the deployment person/team?
- [ ] Require new or adjusted data inputs? Does it have start, end and duration code (in UTC)?
- [ ] If new or updated data sets, has the FIM code been updated and tested with the new/adjusted data (subset is fine, but must be a subset of the new data)?
- [ ] Require new pre-clip set?
- [ ] Has new or updated python packages?

### Issuer Checklist (For developer use)

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] `pre-commit` hooks were run locally
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [x] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
