### PR TITLE
[5pt] PR: Implement general-purpose multiprocessing runner with logging

### DIFF
--- a/data/bridges/make_dem_dif_for_bridges.py
+++ b/data/bridges/make_dem_dif_for_bridges.py
@@ -6,9 +6,7 @@ import sys
 
 # import time
 import traceback
-from concurrent.futures import ProcessPoolExecutor, as_completed, wait
 from datetime import datetime, timezone
-from multiprocessing import Pool
 
 import geopandas as gpd
 import numpy as np
@@ -21,10 +19,8 @@ from rasterio.features import rasterize
 from rasterio.merge import merge
 from shapely.geometry import Point
 
-import utils.shared_functions as sf
 from data.create_vrt_file import create_vrt_file
-from src.utils.shared_functions import run_with_multiprocessing, setup_file_logger
-from utils.shared_functions import FIM_Helpers as fh
+from src.utils.shared_functions import run_with_multiprocessing, setup_multiprocessing_file_logger
 
 
 """
@@ -184,7 +180,7 @@ def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number
 
     file_dt_string = start_time.strftime("%Y_%m_%d-%H_%M_%S")
     log_file_path = os.path.join(output_dir, f"DEM_diff_rasters-{file_dt_string}.log")
-    file_logger = setup_file_logger(log_file_path)
+    file_logger = setup_multiprocessing_file_logger(log_file_path)
 
     try:
         print('Reading osm bridge lines...')

--- a/data/bridges/make_dem_dif_for_bridges.py
+++ b/data/bridges/make_dem_dif_for_bridges.py
@@ -23,8 +23,8 @@ from shapely.geometry import Point
 
 import utils.shared_functions as sf
 from data.create_vrt_file import create_vrt_file
-from utils.shared_functions import FIM_Helpers as fh
 from src.utils.shared_functions import run_with_multiprocessing, setup_file_logger
+from utils.shared_functions import FIM_Helpers as fh
 
 
 """
@@ -45,7 +45,7 @@ def identify_bridges_with_lidar(OSM_bridge_lines_gdf, lidar_tif_dir):
     return OSM_bridge_lines_gdf
 
 
-def rasters_to_point(tif_paths):
+def rasters_to_point(tif_paths, file_logger, screen_queue, task_id):
     gdf_list = []
     for tif_file in tif_paths:
         with rasterio.open(tif_file) as src:
@@ -72,13 +72,25 @@ def rasters_to_point(tif_paths):
         gdf_list.append(gdf)
 
     combined_gdf = gpd.GeoDataFrame(pd.concat(gdf_list, ignore_index=True))
+    file_logger.info(f"{len(combined_gdf)} points for {task_id}")
+    screen_queue.put(f"{len(combined_gdf)} points for {task_id}")
     return combined_gdf
 
 
-def make_one_diff(dem_file, OSM_bridge_lines_gdf, lidar_tif_dir, HUC, HUC_choice, output_diff_path,file_logger, screen_queue):
+def make_one_diff(
+    dem_file,
+    OSM_bridge_lines_gdf,
+    lidar_tif_dir,
+    HUC,
+    HUC_choice,
+    output_diff_path,
+    file_logger,
+    screen_queue,
+    task_id,
+):
 
     try:
-        screen_queue.put(f"Start processing {HUC}")
+        screen_queue.put(f"Start processing {task_id}")
         HUC_lidar_tif_osmids = OSM_bridge_lines_gdf[
             (OSM_bridge_lines_gdf['huc%d' % HUC_choice] == HUC)
             & (OSM_bridge_lines_gdf['has_lidar_tif'] == 'Y')
@@ -89,7 +101,7 @@ def make_one_diff(dem_file, OSM_bridge_lines_gdf, lidar_tif_dir, HUC, HUC_choice
             file_logger.info(
                 'working on HUC%d %s with %d osm rasters: ' % (HUC_choice, str(HUC), len(HUC_lidar_tif_paths))
             )
-            HUC_lidar_points_gdf = rasters_to_point(HUC_lidar_tif_paths)
+            HUC_lidar_points_gdf = rasters_to_point(HUC_lidar_tif_paths, file_logger, screen_queue, task_id)
 
             temp_buffer = OSM_bridge_lines_gdf[OSM_bridge_lines_gdf['osmid'].isin(HUC_lidar_tif_osmids)]
 
@@ -137,7 +149,9 @@ def make_one_diff(dem_file, OSM_bridge_lines_gdf, lidar_tif_dir, HUC, HUC_choice
                 dst.write(updated_raster, 1)
 
         else:
-            screen_queue.put('Making a diff raster file only with values of zero for HUC%d:' % HUC_choice + str(HUC))
+            screen_queue.put(
+                'Making a diff raster file only with values of zero for HUC%d:' % HUC_choice + str(HUC)
+            )
             file_logger.info(
                 'Making a diff raster file only with values of zero for HUC%d:' % HUC_choice + str(HUC)
             )
@@ -154,21 +168,20 @@ def make_one_diff(dem_file, OSM_bridge_lines_gdf, lidar_tif_dir, HUC, HUC_choice
             raster_meta.update({'compress': 'lzw'})  # Update metadata to compress
             with rasterio.open(output_diff_path, 'w', **raster_meta) as dst:
                 dst.write(updated_raster, 1)
-        screen_queue.put(f"End of processing {HUC}")
+        screen_queue.put(f"End of processing {task_id}")
         return True
 
     except Exception as e:
-        file_logger.error(f"❌ Exception in HUC {HUC}: {str(e)}")
-        file_logger.error(traceback.format_exc()) 
+        file_logger.error(f"❌ Exception in HUC {task_id}: {str(e)}")
+        file_logger.error(traceback.format_exc())
         return False
-
 
 
 def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number_jobs):
     start_time = datetime.now(timezone.utc)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    
+
     file_dt_string = start_time.strftime("%Y_%m_%d-%H_%M_%S")
     log_file_path = os.path.join(output_dir, f"DEM_diff_rasters-{file_dt_string}.log")
     file_logger = setup_file_logger(log_file_path)
@@ -189,7 +202,7 @@ def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number
             os.path.splitext(os.path.basename(path))[0].split('_')[1] for path in available_dif_files
         ]
 
-        tasks_args_list =[]
+        tasks_args_list = []
         for dem_file in dem_files:
             # prepare path for output diff file
             base_name, extension = os.path.splitext(os.path.basename(dem_file))
@@ -201,34 +214,39 @@ def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number
 
             if HUC not in base_names_no_ext:
 
-                tasks_args_list.append({
-                    'dem_file': dem_file,
-                    'OSM_bridge_lines_gdf': OSM_bridge_lines_gdf,
-                    'lidar_tif_dir': lidar_tif_dir,
-                    'HUC': HUC,
-                    'HUC_choice': HUC_choice,
-                    'output_diff_path': output_diff_path,
-                })
+                tasks_args_list.append(
+                    {
+                        'dem_file': dem_file,
+                        'OSM_bridge_lines_gdf': OSM_bridge_lines_gdf,
+                        'lidar_tif_dir': lidar_tif_dir,
+                        'HUC': HUC,
+                        'HUC_choice': HUC_choice,
+                        'output_diff_path': output_diff_path,
+                    }
+                )
 
-        #now start the multiprocessing
+        # now start the multiprocessing
         multiprocessing_results = run_with_multiprocessing(
             task_function=make_one_diff,
             tasks_args_list=tasks_args_list,
             file_logger=file_logger,
-            max_workers=number_jobs, 
-            task_id_key="HUC", # must be one of the task arg keys. used for status report
+            max_workers=number_jobs,
+            task_id_key="HUC",  # must be one of the task arg keys. used for status report
             exit_on_failure=False,
         )
 
         print('multiprocessing tasks finished!')
-        #only report if all succeeded or the failed ones
+        # only report if all succeeded or the failed ones
         failed_keys = [k for k, v in multiprocessing_results.items() if not v]
 
         if not failed_keys:
+            file_logger.info("✅ All multiprocessing tasks Succeeded")
             print("✅ All multiprocessing tasks Succeeded")
         else:
+            file_logger.info(f"❌ {len(failed_keys)} failed:")
             print(f"❌ {len(failed_keys)} failed:")
             for k in failed_keys:
+                file_logger.info(f"  - {k}")
                 print(f"  - {k}")
 
         # save with new info (with existence of lidar data or not)

--- a/data/bridges/make_dem_dif_for_bridges.py
+++ b/data/bridges/make_dem_dif_for_bridges.py
@@ -24,6 +24,7 @@ from shapely.geometry import Point
 import utils.shared_functions as sf
 from data.create_vrt_file import create_vrt_file
 from utils.shared_functions import FIM_Helpers as fh
+from src.utils.shared_functions import run_with_multiprocessing, setup_file_logger
 
 
 """
@@ -74,10 +75,10 @@ def rasters_to_point(tif_paths):
     return combined_gdf
 
 
-def make_one_diff(dem_file, OSM_bridge_lines_gdf, lidar_tif_dir, HUC, HUC_choice, output_diff_path):
+def make_one_diff(dem_file, OSM_bridge_lines_gdf, lidar_tif_dir, HUC, HUC_choice, output_diff_path,file_logger, screen_queue):
 
     try:
-        print(f"Start processing {HUC}")
+        screen_queue.put(f"Start processing {HUC}")
         HUC_lidar_tif_osmids = OSM_bridge_lines_gdf[
             (OSM_bridge_lines_gdf['huc%d' % HUC_choice] == HUC)
             & (OSM_bridge_lines_gdf['has_lidar_tif'] == 'Y')
@@ -85,7 +86,7 @@ def make_one_diff(dem_file, OSM_bridge_lines_gdf, lidar_tif_dir, HUC, HUC_choice
         HUC_lidar_tif_paths = [os.path.join(lidar_tif_dir, f"{osmid}.tif") for osmid in HUC_lidar_tif_osmids]
 
         if HUC_lidar_tif_paths:
-            logging.info(
+            file_logger.info(
                 'working on HUC%d %s with %d osm rasters: ' % (HUC_choice, str(HUC), len(HUC_lidar_tif_paths))
             )
             HUC_lidar_points_gdf = rasters_to_point(HUC_lidar_tif_paths)
@@ -136,8 +137,8 @@ def make_one_diff(dem_file, OSM_bridge_lines_gdf, lidar_tif_dir, HUC, HUC_choice
                 dst.write(updated_raster, 1)
 
         else:
-            print('Making a diff raster file only with values of zero for HUC%d:' % HUC_choice + str(HUC))
-            logging.info(
+            screen_queue.put('Making a diff raster file only with values of zero for HUC%d:' % HUC_choice + str(HUC))
+            file_logger.info(
                 'Making a diff raster file only with values of zero for HUC%d:' % HUC_choice + str(HUC)
             )
 
@@ -153,26 +154,24 @@ def make_one_diff(dem_file, OSM_bridge_lines_gdf, lidar_tif_dir, HUC, HUC_choice
             raster_meta.update({'compress': 'lzw'})  # Update metadata to compress
             with rasterio.open(output_diff_path, 'w', **raster_meta) as dst:
                 dst.write(updated_raster, 1)
-        print(f"End of processing {HUC}")
+        screen_queue.put(f"End of processing {HUC}")
+        return True
 
-    except Exception:
-        print('something is wrong for HUC: %s' % str(HUC))
-        logging.critical('something is wrong for HUC: ' + str(HUC))
-        print(traceback.format_exc())
-        logging.critical(traceback.format_exc())
+    except Exception as e:
+        file_logger.error(f"❌ Exception in HUC {HUC}: {str(e)}")
+        file_logger.error(traceback.format_exc()) 
+        return False
+
 
 
 def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number_jobs):
-    # start time and setup logs
     start_time = datetime.now(timezone.utc)
-    dt_string = start_time.strftime("%m/%d/%Y %H:%M:%S")
-    fh.print_start_header('Making HUC elev difference rasters', start_time)
-
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-
-    __setup_logger(output_dir)
-    logging.info(f"Saving results in {output_dir}")
+    
+    file_dt_string = start_time.strftime("%Y_%m_%d-%H_%M_%S")
+    log_file_path = os.path.join(output_dir, f"DEM_diff_rasters-{file_dt_string}.log")
+    file_logger = setup_file_logger(log_file_path)
 
     try:
         print('Reading osm bridge lines...')
@@ -190,96 +189,72 @@ def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number
             os.path.splitext(os.path.basename(path))[0].split('_')[1] for path in available_dif_files
         ]
 
-        with ProcessPoolExecutor(max_workers=number_jobs) as executor:
-            executor_dict = {}
+        tasks_args_list =[]
+        for dem_file in dem_files:
+            # prepare path for output diff file
+            base_name, extension = os.path.splitext(os.path.basename(dem_file))
+            output_diff_file_name = f"{base_name}_diff{extension}"
+            output_diff_path = os.path.join(output_dir, output_diff_file_name)
+            HUC = base_name.split('_')[1]
 
-            for dem_file in dem_files:
-                # prepare path for output diff file
-                base_name, extension = os.path.splitext(os.path.basename(dem_file))
-                output_diff_file_name = f"{base_name}_diff{extension}"
-                output_diff_path = os.path.join(output_dir, output_diff_file_name)
-                HUC = base_name.split('_')[1]
+            HUC_choice = len(HUC)  # this is usually 8 or 6
 
-                HUC_choice = len(HUC)  # this is usually 8 or 6
+            if HUC not in base_names_no_ext:
 
-                if HUC not in base_names_no_ext:
+                tasks_args_list.append({
+                    'dem_file': dem_file,
+                    'OSM_bridge_lines_gdf': OSM_bridge_lines_gdf,
+                    'lidar_tif_dir': lidar_tif_dir,
+                    'HUC': HUC,
+                    'HUC_choice': HUC_choice,
+                    'output_diff_path': output_diff_path,
+                })
 
-                    make_one_diff_args = {
-                        'dem_file': dem_file,
-                        'OSM_bridge_lines_gdf': OSM_bridge_lines_gdf,
-                        'lidar_tif_dir': lidar_tif_dir,
-                        'HUC': HUC,
-                        'HUC_choice': HUC_choice,
-                        'output_diff_path': output_diff_path,
-                    }
+        #now start the multiprocessing
+        multiprocessing_results = run_with_multiprocessing(
+            task_function=make_one_diff,
+            tasks_args_list=tasks_args_list,
+            file_logger=file_logger,
+            max_workers=number_jobs, 
+            task_id_key="HUC", # must be one of the task arg keys. used for status report
+            exit_on_failure=False,
+        )
 
-                    try:
-                        future = executor.submit(make_one_diff, **make_one_diff_args)
-                        executor_dict[future] = dem_file
-                    except Exception as ex:
-                        msg = f"*** Error processing HUC {HUC} : Details: {ex}"
-                        print(msg)
-                        logging.critical(msg)
-                        print(traceback.format_exc())
-                        logging.critical(traceback.format_exc())
-                        dt_string = datetime.now(timezone.utc).strftime("%m/%d/%Y %H:%M:%S")
-                        print(f"*** Program aborted time: {dt_string}")
-                        logging.critical(f"*** Program aborted time: {dt_string}")
-                        executor.shutdown(wait=False)
-                        sys.exit(1)  # TODO: figure out why it won't actually terminate
+        print('multiprocessing tasks finished!')
+        #only report if all succeeded or the failed ones
+        failed_keys = [k for k, v in multiprocessing_results.items() if not v]
 
-            # Send the executor to the progress bar and wait for all tasks to finish
-            # sf.progress_bar_handler(executor_dict, "Making HUC8/6 Diff Raster files")
+        if not failed_keys:
+            print("✅ All multiprocessing tasks Succeeded")
+        else:
+            print(f"❌ {len(failed_keys)} failed:")
+            for k in failed_keys:
+                print(f"  - {k}")
 
         # save with new info (with existence of lidar data or not)
         print('saving the osm bridge lines with info for existence of lidar rasters or not.')
-        logging.info('saving the osm bridge lines with info for existence of lidar rasters or not')
+        file_logger.info('saving the osm bridge lines with info for existence of lidar rasters or not')
         base, ext = os.path.splitext(os.path.basename(OSM_bridge_file))
         OSM_bridge_lines_gdf.to_file(os.path.join(output_dir, f"{base}_modified{ext}"))
 
         # now make a vrt file from all generated diff raster files
         print("==================")
         print('Making a vrt files from all diff raster files.')
-        logging.info('Making a vrt files from all diff raster files')
+        file_logger.info('Making a vrt files from all diff raster files')
         create_vrt_file(output_dir, 'bridge_elev_diff.vrt')
 
         # Record run time
         end_time = datetime.now(timezone.utc)
         tot_run_time = end_time - start_time
-        fh.print_end_header('Making HUC dem diff rasters complete', start_time, end_time)
-        logging.info('TOTAL RUN TIME: ' + str(tot_run_time))
-        # logging.info(fh.print_date_time_duration(start_time, end_time))
+        print('TOTAL RUN TIME: ' + str(tot_run_time))
+        file_logger.info('TOTAL RUN TIME: ' + str(tot_run_time))
 
     except Exception as ex:
-        dt_string = datetime.now(timezone.utc).strftime("%m/%d/%Y %H:%M:%S")
         msg = f"*** An error occured while making dem diffs : Details: {ex}"
-        dt_string = datetime.now(timezone.utc).strftime("%m/%d/%Y %H:%M:%S")
         print(msg)
-
-        print(msg)
-        logging.critical(msg)
+        file_logger.critical(msg)
         print(traceback.format_exc())
-        logging.critical(traceback.format_exc())
-
-
-def __setup_logger(output_folder_path):
-    start_time = datetime.now(timezone.utc)
-    file_dt_string = start_time.strftime("%Y_%m_%d-%H_%M_%S")
-    log_file_name = f"DEM_diff_rasters-{file_dt_string}.log"
-
-    log_file_path = os.path.join(output_folder_path, log_file_name)
-
-    file_handler = logging.FileHandler(log_file_path)
-    file_handler.setLevel(logging.INFO)
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.DEBUG)
-
-    logger = logging.getLogger()
-    logger.addHandler(file_handler)
-    logger.setLevel(logging.DEBUG)
-
-    logging.info(f'Started (UTC): {start_time.strftime("%m/%d/%Y %H:%M:%S")}')
-    logging.info("----------------")
+        file_logger.critical(traceback.format_exc())
 
 
 if __name__ == "__main__":

--- a/data/bridges/make_dem_dif_for_bridges.py
+++ b/data/bridges/make_dem_dif_for_bridges.py
@@ -229,6 +229,7 @@ def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number
             max_workers=number_jobs,
             task_id_key="HUC",  # must be one of the task arg keys. used for status report
             exit_on_failure=False,
+            show_progress=True,
         )
 
         print('multiprocessing tasks finished!')

--- a/data/bridges/make_dem_dif_for_bridges.py
+++ b/data/bridges/make_dem_dif_for_bridges.py
@@ -20,7 +20,7 @@ from rasterio.merge import merge
 from shapely.geometry import Point
 
 from data.create_vrt_file import create_vrt_file
-from src.utils.shared_functions import run_with_multiprocessing, setup_multiprocessing_file_logger
+from utils.shared_functions import run_with_mp, setup_mp_file_logger
 
 
 """
@@ -180,7 +180,7 @@ def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number
 
     file_dt_string = start_time.strftime("%Y_%m_%d-%H_%M_%S")
     log_file_path = os.path.join(output_dir, f"DEM_diff_rasters-{file_dt_string}.log")
-    file_logger = setup_multiprocessing_file_logger(log_file_path)
+    file_logger = setup_mp_file_logger(log_file_path)
 
     try:
         print('Reading osm bridge lines...')
@@ -222,7 +222,7 @@ def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number
                 )
 
         # now start the multiprocessing
-        multiprocessing_results = run_with_multiprocessing(
+        mp_results = run_with_mp(
             task_function=make_one_diff,
             tasks_args_list=tasks_args_list,
             file_logger=file_logger,
@@ -233,7 +233,7 @@ def make_dif_rasters(OSM_bridge_file, dem_dir, lidar_tif_dir, output_dir, number
 
         print('multiprocessing tasks finished!')
         # only report if all succeeded or the failed ones
-        failed_keys = [k for k, v in multiprocessing_results.items() if not v]
+        failed_keys = [k for k, v in mp_results.items() if not v]
 
         if not failed_keys:
             file_logger.info("✅ All multiprocessing tasks Succeeded")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,23 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.x.x.x - 2025-05-14 - [PR#1502](https://github.com/NOAA-OWP/inundation-mapping/pull/1502)
+This PR introduces a multiprocessing utility that can be reused across different workflows and projects.
+
+### Key features:
+- Parallel Task Execution: Uses `ProcessPoolExecutor` to run a set of independent tasks in parallel, with configurable number of workers.
+- Robust Logging:
+  - File-based logging using a centralized `file_logger` for recording of individual task results and errors.
+  - Screen output via a multiprocessing-safe `screen_queue`, printed by a dedicated background thread without interrupting the main progress bar.
+  - Task functions always receive three additional arguments of `file_logger`, `screen_queue`, and `task_id` that allow logging for each individual task.
+- Progress Monitoring: Displays real-time progress using `tqdm`, with success or failure messages for each task.
+
+### Changes
+- src/utils/shared_functions.py ... Introduces two new functions that enable multiprocessing across the codebase
+- data/bridges/make_dem_dif_for_bridges.py ... Provides an example of how to use the new multiprocessing framework instead of the previous code
+
+<br/><br/>
+
 ## v4.6.1.5 - 2025-04-18 - [PR#1490](https://github.com/NOAA-OWP/inundation-mapping/pull/1490)
 
 The segmentation faults we've been experiencing appear to be caused by multiple branches attempting to read the same HUC-level geopackage at the same time. We're not sure why, but the pyogrio/arrow engine seems to be the root cause since changing the engine to fiona for these reads has fixed the issue.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,8 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.x.x.x - 2025-05-14 - [PR#1502](https://github.com/NOAA-OWP/inundation-mapping/pull/1502)
+## v4.6.2.0 - 2025-05-14 - [PR#1502](https://github.com/NOAA-OWP/inundation-mapping/pull/1502)
+
 This PR introduces a multiprocessing utility that can be reused across different workflows and projects.
 
 ### Key features:
@@ -17,6 +18,7 @@ This PR introduces a multiprocessing utility that can be reused across different
 - data/bridges/make_dem_dif_for_bridges.py ... Provides an example of how to use the new multiprocessing framework instead of the previous code
 
 <br/><br/>
+
 
 ## v4.6.1.14 - 2025-05-15 - [PR#1510](https://github.com/NOAA-OWP/inundation-mapping/pull/1510)
 

--- a/src/utils/shared_functions.py
+++ b/src/utils/shared_functions.py
@@ -159,7 +159,6 @@ def run_with_mp(
 
     screen_queue.put("DONE")  # sends the stop SIGNAL to thread
     screen_queue_thread.join()  # official closure of thread
-    file_logger.info(f"Final Results: {results}")
     return results
 
 

--- a/src/utils/shared_functions.py
+++ b/src/utils/shared_functions.py
@@ -50,10 +50,10 @@ def setup_file_logger(log_file_path, logger_name="custom_logger", level=logging.
 
 def run_with_multiprocessing(
     task_function,
-    task_args_list,
-    log_file_path,
+    tasks_args_list,
+    file_logger,
     max_workers=4,
-    task_id_key=None,  #can assign 'HUC'--must be one of the keys in the args list 
+    task_id_key=None,  # must be one of the keys in the args list 
     exit_on_failure=True,
 ):
     '''
@@ -61,27 +61,23 @@ def run_with_multiprocessing(
 
     NOTES:
     This simple setup is using a shared log file and it is ok for now assuming that:
-        - we have limitted amount of logs (3-4 lines per subprocess) in the desired multiprocessing work
+        - we have limitted amount of logs (3-4 lines per subprocess) in multiprocessing work
         - total number of subprocesses is modest (e.g., less than 50), not hundreds or thousands.
         - if we encounter a case that this does not work correctly, then we can improve it by creating one log file per task and combining them afterward.” 
 
     - Use try/except in both the task function and this wrapper:
-        • The task function should handle known/expected errors and always return a structured result.
+        • The task function should handle known/expected errors and always return True or False.
         • This wrapper catches unexpected crashes (e.g., segfaults or crashes in subprocesses).
-        • No more try/except inside helper functions inside task function. Let them fail and task_function excpetion handles them.
+        • No more try/except inside helper functions inside task function. Let them fail and task_function exception handles them.
         • Inside helper functions feel free to log any information. but No need to raise errors. 
         • The only exception is that when we really need to address a special case like API limits and wait and retry.
     - Inside your task function or helpers, log live messages using screen_queue.put(msg).
     - These will appear in the main process via tqdm.write() and won't interrupt the progress bar.
-    - Always pass three additional arguments into task_function and its helpers: logger ,screen_queue and task_id. 
-        - Do not use any print statements in the task function of its helper functions. Instead use screen_queue.put() like screen_logger.put(f"End of processing {HUC}")
+    - Always pass two additional arguments into task_function and its helpers: file_logger ,screen_queue. 
+        - Do not use any print statements after start of multiprocessing in the task function or inside its helper functions. Instead use screen_queue.put().
         - use file_logger.info() to log the message in the log file
-    - task_function must always (either sucess or fail) return a dictionary were status must be either success or failed. { "huc": HUC,  "status": "success" } or { "huc": HUC,  "status": "failed" }.
-
-
     '''
 
-    file_logger = setup_file_logger(log_file_path)
     screen_queue   = Manager().Queue() #creates a process-safe Queue that allows subprocesses to put() messages into it.
 
 
@@ -99,7 +95,7 @@ def run_with_multiprocessing(
     results = {}
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
         future_to_id = {}
-        for i, task_kwargs in enumerate(task_args_list):  #for each dictionary of keyword arguments (kwargs)
+        for i, task_kwargs in enumerate(tasks_args_list):  #for each dictionary of keyword arguments (kwargs)
             task_id = f"Task-{i}"
             if task_id_key:
                 task_id = task_kwargs.get(task_id_key, task_id) #this make a unique id (e.g. HUC number) for the task 
@@ -108,7 +104,6 @@ def run_with_multiprocessing(
             kwargs_updated = task_kwargs.copy()
             kwargs_updated["file_logger"] = file_logger
             kwargs_updated["screen_queue"] = screen_queue  
-            kwargs_updated["task_id"] = task_id
 
             future = executor.submit(task_function, **kwargs_updated) #submits tasks to workers in parallel. IMMEDIATELY after submitting (not after finishing the subprocess job) we get back a Future object, which is like a order number to track your requested food in a restaurant while waiting).
             future_to_id[future] = task_id
@@ -123,19 +118,18 @@ def run_with_multiprocessing(
                     # note that the try except inside tak function always return a 'completed' result in a form of dictionary. so, here we should check that dict to see if it was sucess or failure 
                     result = future.result()
                     results[task_id] = result
-                    if result.get("status") == "success":
-                        tqdm.write(f"[{task_id}] ✅ Result: {result}") #do not use print otherwise a new updated bar is created after each print line
-                        file_logger.info(f"[{task_id}] ✅ Result: {result}")
+                    if result:
+                        tqdm.write(f"✅ success for {task_id}") #do not use print otherwise a new updated bar is created after each print line
+                        file_logger.info(f"✅ success for {task_id}")
                     else:
-                        tqdm.write(f"[{task_id}] ❌ Error reported in task: {result}")
-                        file_logger.info(f"[{task_id}] ❌ Error reported in task: {result}")
+                        tqdm.write(f"❌ Error reported for {task_id}.")
+                        file_logger.info(f"❌ Error reported for {task_id}.")
 
                 except Exception as ex:
-                    error_msg = f"[{task_id}] ❌ Error: {ex}"
+                    error_msg = f"❌ Error for {task_id}: {ex}"
                     traceback_msg = traceback.format_exc()
-
-                    print(error_msg)
-
+                    
+                    tqdm.write(error_msg)
                     file_logger.error(error_msg)
                     file_logger.error(traceback_msg)
 

--- a/src/utils/shared_functions.py
+++ b/src/utils/shared_functions.py
@@ -26,7 +26,7 @@ import utils.shared_variables as sv
 gp.options.io_engine = "pyogrio"
 
 
-def setup_multiprocessing_file_logger(log_file_path, logger_name="custom_logger", level=logging.DEBUG):
+def setup_mp_file_logger(log_file_path, logger_name="custom_logger", level=logging.DEBUG):
     """
     Creates and returns a logger that logs to the specified file.
     """
@@ -49,7 +49,7 @@ def setup_multiprocessing_file_logger(log_file_path, logger_name="custom_logger"
     return logger
 
 
-def run_with_multiprocessing(
+def run_with_mp(
     task_function,
     tasks_args_list,
     file_logger,

--- a/src/utils/shared_functions.py
+++ b/src/utils/shared_functions.py
@@ -56,6 +56,7 @@ def run_with_mp(
     max_workers=4,
     task_id_key=None,  # must be one of the keys in the args list
     exit_on_failure=True,
+    show_progress=True,
 ):
     '''
     Run a set of tasks in parallel using multiprocessing with robust logging and error handling.
@@ -119,43 +120,56 @@ def run_with_mp(
 
         # up to this point, the code is run immediately--submision is done right away. Now we wait for each job to be completed and be processed as below
         # Setup tqdm progress bar
-        with tqdm(total=len(future_to_id), desc="Processing tasks", unit="task") as pbar:
-            for future in as_completed(future_to_id):
-                task_id = future_to_id[future]
-                try:
-                    # note that try/except here only worries about running and catching catastrophic errors. Specifc errors must be addressed inside the task function
-                    # note that the try except inside task function always return (which is result here) True or False
-                    result = future.result()
-                    results[task_id] = result
-                    if result:
+        pbar = tqdm(total=len(future_to_id), desc="Processing tasks", unit="task") if show_progress else None
+        # with tqdm(total=len(future_to_id), desc="Processing tasks", unit="task") as pbar:
+        for future in as_completed(future_to_id):
+            task_id = future_to_id[future]
+            try:
+                # note that try/except here only worries about running and catching catastrophic errors. Specifc errors must be addressed inside the task function
+                # note that the try except inside task function always return (which is result here) True or False
+                result = future.result()
+                results[task_id] = result
+                if result:
+                    if show_progress:
                         tqdm.write(
                             f"✅ success for {task_id}"
                         )  # do not use print otherwise a new updated bar is created after each print line
-                        file_logger.info(f"✅ success for {task_id}")
                     else:
+                        print(f"✅ success for {task_id}")
+                    file_logger.info(f"✅ success for {task_id}")
+                else:
+                    if show_progress:
                         tqdm.write(f"❌ Error reported for {task_id}.")
-                        file_logger.info(f"❌ Error reported for {task_id}.")
+                    else:
+                        print(f"❌ Error reported for {task_id}.")
+                    file_logger.info(f"❌ Error reported for {task_id}.")
 
-                except Exception as ex:
-                    error_msg = f"❌ Error for {task_id}: {ex}"
-                    traceback_msg = traceback.format_exc()
+            except Exception as ex:
+                error_msg = f"❌ Error for {task_id}: {ex}"
+                traceback_msg = traceback.format_exc()
 
+                if show_progress:
                     tqdm.write(error_msg)
-                    file_logger.error(error_msg)
-                    file_logger.error(traceback_msg)
+                else:
+                    print(error_msg)
+                file_logger.error(error_msg)
+                file_logger.error(traceback_msg)
 
-                    results[task_id] = None
+                results[task_id] = None
 
-                    if exit_on_failure:
-                        dt_string = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-                        final_msg = f"Program aborted at {dt_string} due to error in {task_id}"
-                        file_logger.critical(final_msg)
-                        executor.shutdown(
-                            wait=False
-                        )  # tells the ProcessPoolExecutor to stop accepting new tasks. Even cancel the running tasks as soon as possible
-                        sys.exit(1)
+                if exit_on_failure:
+                    dt_string = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+                    final_msg = f"Program aborted at {dt_string} due to error in {task_id}"
+                    file_logger.critical(final_msg)
+                    executor.shutdown(
+                        wait=False
+                    )  # tells the ProcessPoolExecutor to stop accepting new tasks. Even cancel the running tasks as soon as possible
+                    sys.exit(1)
 
+            if pbar:
                 pbar.update(1)  # ✅ Progress update for each completed task
+        if pbar:
+            pbar.close()
 
     screen_queue.put("DONE")  # sends the stop SIGNAL to thread
     screen_queue_thread.join()  # official closure of thread

--- a/src/utils/shared_functions.py
+++ b/src/utils/shared_functions.py
@@ -2,10 +2,15 @@
 
 import glob
 import inspect
+import logging
 import os
 import re
+import sys
+import threading
+import traceback
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
+from multiprocessing import Manager
 from os.path import splitext
 from pathlib import Path
 
@@ -15,16 +20,11 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-import sys
-import logging
-import traceback
-from multiprocessing import Manager
-import threading
-
 import utils.shared_variables as sv
 
 
 gp.options.io_engine = "pyogrio"
+
 
 def setup_file_logger(log_file_path, logger_name="custom_logger", level=logging.DEBUG):
     """
@@ -48,12 +48,13 @@ def setup_file_logger(log_file_path, logger_name="custom_logger", level=logging.
 
     return logger
 
+
 def run_with_multiprocessing(
     task_function,
     tasks_args_list,
     file_logger,
     max_workers=4,
-    task_id_key=None,  # must be one of the keys in the args list 
+    task_id_key=None,  # must be one of the keys in the args list
     exit_on_failure=True,
 ):
     '''
@@ -63,49 +64,57 @@ def run_with_multiprocessing(
     This simple setup is using a shared log file and it is ok for now assuming that:
         - we have limitted amount of logs (3-4 lines per subprocess) in multiprocessing work
         - total number of subprocesses is modest (e.g., less than 50), not hundreds or thousands.
-        - if we encounter a case that this does not work correctly, then we can improve it by creating one log file per task and combining them afterward.” 
+        - if we encounter a case that this does not work correctly, then we can improve it by creating one log file per task and combining them afterward.”
 
     - Use try/except in both the task function and this wrapper:
         • The task function should handle known/expected errors and always return True or False.
         • This wrapper catches unexpected crashes (e.g., segfaults or crashes in subprocesses).
         • No more try/except inside helper functions inside task function. Let them fail and task_function exception handles them.
-        • Inside helper functions feel free to log any information. but No need to raise errors. 
+        • Inside helper functions feel free to log any information. but No need to raise errors.
         • The only exception is that when we really need to address a special case like API limits and wait and retry.
     - Inside your task function or helpers, log live messages using screen_queue.put(msg).
     - These will appear in the main process via tqdm.write() and won't interrupt the progress bar.
-    - Always pass two additional arguments into task_function and its helpers: file_logger ,screen_queue. 
+    - Always pass three additional arguments into task_function and its helpers: file_logger ,screen_queue and task_id.
         - Do not use any print statements after start of multiprocessing in the task function or inside its helper functions. Instead use screen_queue.put().
         - use file_logger.info() to log the message in the log file
     '''
 
-    screen_queue   = Manager().Queue() #creates a process-safe Queue that allows subprocesses to put() messages into it.
-
+    screen_queue = (
+        Manager().Queue()
+    )  # creates a process-safe Queue that allows subprocesses to put() messages into it.
 
     # Background thread to print logs without interrupting tqdm
     def log_worker(queue):
         while True:
             msg = queue.get()
-            if msg == "DONE": #this must match the last message passed to screen_queue
+            if msg == "DONE":  # this must match the last message passed to screen_queue
                 break
             tqdm.write(msg)
 
-    screen_queue_thread  = threading.Thread(target=log_worker, args=(screen_queue ,)) #this (from the main process)) reads screen_queues and prints on screen.
-    screen_queue_thread.start() 
+    screen_queue_thread = threading.Thread(
+        target=log_worker, args=(screen_queue,)
+    )  # this (from the main process)) reads screen_queues and prints on screen.
+    screen_queue_thread.start()
 
     results = {}
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
         future_to_id = {}
-        for i, task_kwargs in enumerate(tasks_args_list):  #for each dictionary of keyword arguments (kwargs)
+        for i, task_kwargs in enumerate(tasks_args_list):  # for each dictionary of keyword arguments (kwargs)
             task_id = f"Task-{i}"
             if task_id_key:
-                task_id = task_kwargs.get(task_id_key, task_id) #this make a unique id (e.g. HUC number) for the task 
+                task_id = task_kwargs.get(
+                    task_id_key, task_id
+                )  # this make a unique id (e.g. HUC number) for the task
 
-            #also pass the loggers and task id
+            # also pass the loggers and task id
             kwargs_updated = task_kwargs.copy()
             kwargs_updated["file_logger"] = file_logger
-            kwargs_updated["screen_queue"] = screen_queue  
+            kwargs_updated["screen_queue"] = screen_queue
+            kwargs_updated["task_id"] = task_id
 
-            future = executor.submit(task_function, **kwargs_updated) #submits tasks to workers in parallel. IMMEDIATELY after submitting (not after finishing the subprocess job) we get back a Future object, which is like a order number to track your requested food in a restaurant while waiting).
+            future = executor.submit(
+                task_function, **kwargs_updated
+            )  # submits tasks to workers in parallel. IMMEDIATELY after submitting (not after finishing the subprocess job) we get back a Future object, which is like a order number to track your requested food in a restaurant while waiting).
             future_to_id[future] = task_id
 
         # up to this point, the code is run immediately--submision is done right away. Now we wait for each job to be completed and be processed as below
@@ -114,12 +123,14 @@ def run_with_multiprocessing(
             for future in as_completed(future_to_id):
                 task_id = future_to_id[future]
                 try:
-                    #note that try/except here only worries about running and catching catastrophic errors. Specifc errors must be addressed inside the task function
-                    # note that the try except inside tak function always return a 'completed' result in a form of dictionary. so, here we should check that dict to see if it was sucess or failure 
+                    # note that try/except here only worries about running and catching catastrophic errors. Specifc errors must be addressed inside the task function
+                    # note that the try except inside task function always return (which is result here) True or False
                     result = future.result()
                     results[task_id] = result
                     if result:
-                        tqdm.write(f"✅ success for {task_id}") #do not use print otherwise a new updated bar is created after each print line
+                        tqdm.write(
+                            f"✅ success for {task_id}"
+                        )  # do not use print otherwise a new updated bar is created after each print line
                         file_logger.info(f"✅ success for {task_id}")
                     else:
                         tqdm.write(f"❌ Error reported for {task_id}.")
@@ -128,7 +139,7 @@ def run_with_multiprocessing(
                 except Exception as ex:
                     error_msg = f"❌ Error for {task_id}: {ex}"
                     traceback_msg = traceback.format_exc()
-                    
+
                     tqdm.write(error_msg)
                     file_logger.error(error_msg)
                     file_logger.error(traceback_msg)
@@ -139,13 +150,15 @@ def run_with_multiprocessing(
                         dt_string = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
                         final_msg = f"Program aborted at {dt_string} due to error in {task_id}"
                         file_logger.critical(final_msg)
-                        executor.shutdown(wait=False) #tells the ProcessPoolExecutor to stop accepting new tasks. Even cancel the running tasks as soon as possible
+                        executor.shutdown(
+                            wait=False
+                        )  # tells the ProcessPoolExecutor to stop accepting new tasks. Even cancel the running tasks as soon as possible
                         sys.exit(1)
 
                 pbar.update(1)  # ✅ Progress update for each completed task
 
-    screen_queue.put("DONE") #sends the stop SIGNAL to thread
-    screen_queue_thread.join() # official closure of thread
+    screen_queue.put("DONE")  # sends the stop SIGNAL to thread
+    screen_queue_thread.join()  # official closure of thread
     file_logger.info(f"Final Results: {results}")
     return results
 

--- a/src/utils/shared_functions.py
+++ b/src/utils/shared_functions.py
@@ -26,7 +26,7 @@ import utils.shared_variables as sv
 gp.options.io_engine = "pyogrio"
 
 
-def setup_file_logger(log_file_path, logger_name="custom_logger", level=logging.DEBUG):
+def setup_multiprocessing_file_logger(log_file_path, logger_name="custom_logger", level=logging.DEBUG):
     """
     Creates and returns a logger that logs to the specified file.
     """

--- a/src/utils/shared_functions.py
+++ b/src/utils/shared_functions.py
@@ -4,7 +4,7 @@ import glob
 import inspect
 import os
 import re
-from concurrent.futures import as_completed
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
 from os.path import splitext
 from pathlib import Path
@@ -15,10 +15,145 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
+import sys
+import logging
+import traceback
+from multiprocessing import Manager
+import threading
+
 import utils.shared_variables as sv
 
 
 gp.options.io_engine = "pyogrio"
+
+def setup_file_logger(log_file_path, logger_name="custom_logger", level=logging.DEBUG):
+    """
+    Creates and returns a logger that logs to the specified file.
+    """
+    os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(level)
+
+    # Prevent duplicate handlers if already exists
+    if not logger.handlers:
+        file_handler = logging.FileHandler(log_file_path)
+        file_handler.setLevel(level)
+
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        file_handler.setFormatter(formatter)
+
+        logger.addHandler(file_handler)
+        logger.propagate = False  # avoid logging to root logger too
+
+    return logger
+
+def run_with_multiprocessing(
+    task_function,
+    task_args_list,
+    log_file_path,
+    max_workers=4,
+    task_id_key=None,  #can assign 'HUC'--must be one of the keys in the args list 
+    exit_on_failure=True,
+):
+    '''
+    Run a set of tasks in parallel using multiprocessing with robust logging and error handling.
+
+    NOTES:
+    This simple setup is using a shared log file and it is ok for now assuming that:
+        - we have limitted amount of logs (3-4 lines per subprocess) in the desired multiprocessing work
+        - total number of subprocesses is modest (e.g., less than 50), not hundreds or thousands.
+        - if we encounter a case that this does not work correctly, then we can improve it by creating one log file per task and combining them afterward.” 
+
+    - Use try/except in both the task function and this wrapper:
+        • The task function should handle known/expected errors and always return a structured result.
+        • This wrapper catches unexpected crashes (e.g., segfaults or crashes in subprocesses).
+        • No more try/except inside helper functions inside task function. Let them fail and task_function excpetion handles them.
+        • Inside helper functions feel free to log any information. but No need to raise errors. 
+        • The only exception is that when we really need to address a special case like API limits and wait and retry.
+    - Inside your task function or helpers, log live messages using screen_queue.put(msg).
+    - These will appear in the main process via tqdm.write() and won't interrupt the progress bar.
+    - Always pass three additional arguments into task_function and its helpers: logger ,screen_queue and task_id. 
+        - Do not use any print statements in the task function of its helper functions. Instead use screen_queue.put() like screen_logger.put(f"End of processing {HUC}")
+        - use file_logger.info() to log the message in the log file
+    - task_function must always (either sucess or fail) return a dictionary were status must be either success or failed. { "huc": HUC,  "status": "success" } or { "huc": HUC,  "status": "failed" }.
+
+
+    '''
+
+    file_logger = setup_file_logger(log_file_path)
+    screen_queue   = Manager().Queue() #creates a process-safe Queue that allows subprocesses to put() messages into it.
+
+
+    # Background thread to print logs without interrupting tqdm
+    def log_worker(queue):
+        while True:
+            msg = queue.get()
+            if msg == "DONE": #this must match the last message passed to screen_queue
+                break
+            tqdm.write(msg)
+
+    screen_queue_thread  = threading.Thread(target=log_worker, args=(screen_queue ,)) #this (from the main process)) reads screen_queues and prints on screen.
+    screen_queue_thread.start() 
+
+    results = {}
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        future_to_id = {}
+        for i, task_kwargs in enumerate(task_args_list):  #for each dictionary of keyword arguments (kwargs)
+            task_id = f"Task-{i}"
+            if task_id_key:
+                task_id = task_kwargs.get(task_id_key, task_id) #this make a unique id (e.g. HUC number) for the task 
+
+            #also pass the loggers and task id
+            kwargs_updated = task_kwargs.copy()
+            kwargs_updated["file_logger"] = file_logger
+            kwargs_updated["screen_queue"] = screen_queue  
+            kwargs_updated["task_id"] = task_id
+
+            future = executor.submit(task_function, **kwargs_updated) #submits tasks to workers in parallel. IMMEDIATELY after submitting (not after finishing the subprocess job) we get back a Future object, which is like a order number to track your requested food in a restaurant while waiting).
+            future_to_id[future] = task_id
+
+        # up to this point, the code is run immediately--submision is done right away. Now we wait for each job to be completed and be processed as below
+        # Setup tqdm progress bar
+        with tqdm(total=len(future_to_id), desc="Processing tasks", unit="task") as pbar:
+            for future in as_completed(future_to_id):
+                task_id = future_to_id[future]
+                try:
+                    #note that try/except here only worries about running and catching catastrophic errors. Specifc errors must be addressed inside the task function
+                    # note that the try except inside tak function always return a 'completed' result in a form of dictionary. so, here we should check that dict to see if it was sucess or failure 
+                    result = future.result()
+                    results[task_id] = result
+                    if result.get("status") == "success":
+                        tqdm.write(f"[{task_id}] ✅ Result: {result}") #do not use print otherwise a new updated bar is created after each print line
+                        file_logger.info(f"[{task_id}] ✅ Result: {result}")
+                    else:
+                        tqdm.write(f"[{task_id}] ❌ Error reported in task: {result}")
+                        file_logger.info(f"[{task_id}] ❌ Error reported in task: {result}")
+
+                except Exception as ex:
+                    error_msg = f"[{task_id}] ❌ Error: {ex}"
+                    traceback_msg = traceback.format_exc()
+
+                    print(error_msg)
+
+                    file_logger.error(error_msg)
+                    file_logger.error(traceback_msg)
+
+                    results[task_id] = None
+
+                    if exit_on_failure:
+                        dt_string = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+                        final_msg = f"Program aborted at {dt_string} due to error in {task_id}"
+                        file_logger.critical(final_msg)
+                        executor.shutdown(wait=False) #tells the ProcessPoolExecutor to stop accepting new tasks. Even cancel the running tasks as soon as possible
+                        sys.exit(1)
+
+                pbar.update(1)  # ✅ Progress update for each completed task
+
+    screen_queue.put("DONE") #sends the stop SIGNAL to thread
+    screen_queue_thread.join() # official closure of thread
+    file_logger.info(f"Final Results: {results}")
+    return results
 
 
 def getDriver(fileName):


### PR DESCRIPTION
This PR introduces a multiprocessing utility that can be reused across different workflows and projects.

### Key features:
- Parallel Task Execution: Uses `ProcessPoolExecutor` to run a set of independent tasks in parallel, with configurable number of workers.
- Robust Logging:
  - File-based logging using a centralized `file_logger` for recording of individual task results and errors.
  - Screen output via a multiprocessing-safe `screen_queue`, printed by a dedicated background thread without interrupting the main progress bar.
  - Task functions always receive three additional arguments of `file_logger`, `screen_queue`, and `task_id` that allow logging for each individual task.
- Progress Monitoring: Displays real-time progress using `tqdm`, with success or failure messages for each task.



### Example Usage Flow

#### 1. Prepare the list of task arguments

Create a list of dictionaries, where each dictionary contains the necessary inputs for a single task.  Also, it is helpful to sort the tasks by their identifier, as this provides a clearer sense of progress when reviewing the logs during the run.
For example, to process each HUC's geometry and associated catchment boundaries:

```python
import os
import numpy as np
import geopandas as gpd

output_dir = "outputs/roads/HUCs_roads_test/"

# Build the tasks argument list
huc_gpd = gpd.read_file("wbd/WBD_National_HUC8_EPSG_5070_HAND_domain.gpkg")
huc_numbers = sorted(np.unique(huc_gpd["HUC8"])) # Sort tasks to help track progress in logs

tasks_args_list = []
for HUC_no in huc_numbers:
    this_huc_info = huc_gpd[huc_gpd["HUC8"] == HUC_no]
    this_huc_geom = this_huc_info.iloc[0]["geometry"]

    tasks_args_list.append({
        "HUC_no": HUC_no,
        "huc_geom": this_huc_geom,
        "catchment_path": f"data/inputs/pre_clip_huc8/20250218/{HUC_no}/nwm_catchments_proj_subset.gpkg",
        "output_dir": output_dir
    })
```


#### 2. Define the main task function (**see the note below**)

This **function** manages the work per task and should handle any sub-functions internally. See the section `Updates Introduced After PRs #1660 and #1647` for more details.  

```python
import traceback

def task_fn(HUC_no, huc_geom, catchment_path, output_dir, file_logger, screen_queue, task_id):
    file_logger.info(f"Started processing {task_id}")
    screen_queue.put(f"Started processing {task_id}")
    try:
        sub_fn1_result = sub_fn1(HUC_no, huc_geom, file_logger, screen_queue, task_id)
        sub_fn2(sub_fn1_result , catchment_path, output_dir, file_logger, screen_queue, task_id)
        # return True  (deprecated)
        return 1, [True]
    except Exception as e:
        file_logger.error(f"❌ Exception in {task_id}: {str(e)}")
        file_logger.error(traceback.format_exc())
        # return False  (deprecated)
        return 0, [False]
```

#### Key Notes for Running Task Function with Multiprocessing:
- Always pass these three logging-related arguments to the task function and sub-functions:
  - `file_logger` for file-based logging (`info`, `warning`, `error`, `critical`)
  - `screen_queue` for screen/status updates
  - `task_id` to easily identify each task
- **Do not use `print()` statements** inside the task function or sub-functions. We can still use `print()` before or after running `run_with_mp()`.
- Ideally, the task function (without the three additional argument ) should be successfully tested on a single task before running it in parallel.



#### 3. Complement your argument list creation and run the multiprocessing code

Your complete call code should look like this:

```python
from src.utils.shared_functions import run_with_mp, setup_mp_file_logger

# Create output directory if it doesn't exist
os.makedirs(output_dir, exist_ok=True)

# Create the logger
log_file_path = os.path.join(output_dir, "sample.log")
# file_logger = setup_mp_file_logger(log_file_path) # Old (deprecated)
# New (requires explicit logger_name)
file_logger = setup_mp_file_logger(log_file_path, logger_name="pull_osm_roads")
print('started the process')
file_logger.info('started the process')

# Prepare tasks_args_list as shown earlier

# Run multiprocessing
mp_results = run_with_mp(
    task_function=task_fn,
    tasks_args_list=tasks_args_list,
    file_logger=file_logger,
    max_workers=4,
    task_id_key="HUC_no",  # Must match a key inside task arguments
    # exit_on_failure=False, (deprecated)
    show_progress=True
)
```

Finally, we can generate a clear summary of the jobs using mp_results, which contains a dictionary of task ID and returned list. The example below shows how to report whether all processes completed successfully and, if not, identify which ones failed. Here the first item of the returned list contains True or False to indicate the status of the sub-task run. 

```python
print('multiprocessing tasks finished!')
# only report if all succeeded or the failed ones... mp_results: {task_id: [True] or [False]}
failed_keys = [tid for tid, payload in mp_results.items() if not payload[0]]

if not failed_keys:
    file_logger.info("✅ All multiprocessing tasks Succeeded")
    print("✅ All multiprocessing tasks Succeeded")
else:
    file_logger.info(f"❌ {len(failed_keys)} failed:")
    print(f"❌ {len(failed_keys)} failed:")
    for tid in failed_keys:
        file_logger.info(f"  - {tid}")
        print(f"  - {tid}")

print("Done!")
file_logger.info("Done!")

```


---
### Updates Introduced After PRs #1660 and #1647.

1. **Task function return contract**

   * Each task **must return two items**: `return_code, payload_list`
   * **`return_code`**:

     * `1` → success (use in the `try` block)
     * `0` → non-fatal failure (use in the `except` block when other tasks may continue)
     * `-1` → critical failure (use in the `except` block when a failure should abort all multiprocessing)
   * **`payload_list`**: a **list** containing output objects. Keep its **length and order consistent** between success and failure; use `None` placeholders for failures.

     * Examples:

       * Boolean payloads → success: `[True]`, failure: `[False]`
       * DataFrame payloads → success: `[df]`, failure: `[None]`
       * Mixed outputs → success: `[df, summary, True]`, failure: `[None, None, False]`

2. **Return value of `run_with_mp`**

   * The function returns a **dictionary**:

     ```python
     {task_id: payload_list, ...}
     ```
   * Post-process this dict after the MP call to collect/aggregate outputs.

3. **`exit_on_failure` removed**

   * The introduction of return code `-1` replaces the need for the `exit_on_failure` argument, which has been removed.

4. **Logger setup now requires `logger_name`**

   * When setting up the file logger via `setup_mp_file_logger`, pass an explicit name, e.g.:

     ```python
     file_logger = setup_mp_file_logger(
         logger_name="pull_osm_roads",
         log_path=log_file_path
     )
     ```

---



### Changes
- src/utils/shared_functions.py ... Introduces two new functions that enable multiprocessing across the codebase
- data/bridges/make_dem_dif_for_bridges.py ... Provides an example of how to use the new multiprocessing framework instead of the previous code

### Testing
Refactored `data/bridges/make_dem_dif_for_bridges.py` to use the new multiprocessing function, yielding similar results as before with improved detailed logging support.


### Deployment Plan (For developer use)

_How does the changes affect the product?_
- [ ] Code only?
- [ ] If applicable, has a deployment plan be created with the deployment person/team?
- [ ] Require new or adjusted data inputs? Does it have start, end and duration code (in UTC)?
- [ ] If new or updated data sets, has the FIM code been updated and tested with the new/adjusted data (subset is fine, but must be a subset of the new data)?
- [ ] Require new pre-clip set?
- [ ] Has new or updated python packages?

### Issuer Checklist (For developer use)

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [ ] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [ ] Links are provided if this PR resolves an issue, or depends on another other PR
- [ ] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [ ] `pre-commit` hooks were run locally
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [ ] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
