### PR TITLE
[1pt] Improve legibility of status message for stage-based CatFIM sites removed due to USGS acceptance criteria 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4._____ - 2025-_____ - [PR#1503](https://github.com/NOAA-OWP/inundation-mapping/issues/1503)
+## v4.6.1.12 - 2025-05-16 - [PR#1503](https://github.com/NOAA-OWP/inundation-mapping/issues/1503)
 
 Updates the stage-based CatFIM USGS site filtration code so removed sites have clear status message listing what acceptance criteria they didn't meet.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.6.1.12 - 2025-05-16 - [PR#1503](https://github.com/NOAA-OWP/inundation-mapping/issues/1503)
+## v4.6.1.12 - 2025-05-16 - [PR#1512](https://github.com/NOAA-OWP/inundation-mapping/issues/1512)
 
 Updates the stage-based CatFIM USGS site filtration code so removed sites have clear status message listing what acceptance criteria they didn't meet.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4._____ - 2025-_____ - [PR#1503](https://github.com/NOAA-OWP/inundation-mapping/issues/1503)
+
+Updates the stage-based CatFIM USGS site filtration code so removed sites have clear status message listing what acceptance criteria they didn't meet.
+
+### Changes
+- `inundation-mapping/tools/catfim/generate_categorical_fim.py`: Updated `__create_acceptable_usgs_elev_df()` function to produce a descriptive `usgs_exclusion_status` column instead of just filtering out the sites that don't meet the acceptance criteria. Updated the `__adj_dem_evalation_val()` function to use the `usgs_exclusion_status` column to filter out sites that should be excluded and provide a more descriptive message for the excluded sites, where available.
+
+<br/><br/>
+
+
 ## v4.6.1.11 - 2025-05-01 - [PR#1494](https://github.com/NOAA-OWP/inundation-mapping/pull/1494)
 
 Downloads the FEMA NFHL data for HUC8.

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -667,9 +667,7 @@ def iterate_through_huc_stage_based(
                 # Get the dem_adj_elevation value from usgs_elev_table.csv.
                 # Prioritize the value that is not from branch 0.
                 lid_usgs_elev, dem_eval_messages = __adj_dem_evalation_val(
-                    acceptable_usgs_elev_df,
-                    lid,
-                    huc_lid_id
+                    acceptable_usgs_elev_df, lid, huc_lid_id
                 )
                 all_messages = all_messages + dem_eval_messages
                 if len(dem_eval_messages) > 0:
@@ -1392,9 +1390,25 @@ def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
     try:
 
         # Create columns for whether the USGS data meets each criterion
-        msg1 = np.where(usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list), '', 'Unacceptable USGS data altitude method: ' + usgs_elev_df['usgs_data_alt_method_code'].astype(str)  + ', ')
-        msg2 = np.where(usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list), '', 'Unacceptable USGS site type: ' + usgs_elev_df['usgs_data_site_type'].astype(str) + ', ')
-        msg3 = np.where(usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh, '', 'Unacceptable USGS altitude accuracy threshold: ' + usgs_elev_df['usgs_data_alt_accuracy_code'].astype(str) + ', ')
+        msg1 = np.where(
+            usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list),
+            '',
+            'Unacceptable USGS data altitude method: '
+            + usgs_elev_df['usgs_data_alt_method_code'].astype(str)
+            + ', ',
+        )
+        msg2 = np.where(
+            usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list),
+            '',
+            'Unacceptable USGS site type: ' + usgs_elev_df['usgs_data_site_type'].astype(str) + ', ',
+        )
+        msg3 = np.where(
+            usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh,
+            '',
+            'Unacceptable USGS altitude accuracy threshold: '
+            + usgs_elev_df['usgs_data_alt_accuracy_code'].astype(str)
+            + ', ',
+        )
 
         status_df = pd.DataFrame({'msg1': msg1, 'msg2': msg2, 'msg3': msg3})
 
@@ -1402,8 +1416,10 @@ def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
         usgs_elev_df['usgs_exclusion_status'] = status_df['msg1'] + status_df['msg2'] + status_df['msg3']
 
         # If it doesn't have anything for the exclusion criteria, set the usgs_exclusion_status to acceptable
-        # CatFIM will only be processed for sites with a usgs_exclusion_status of 'acceptable' 
-        usgs_elev_df['usgs_exclusion_status'] = usgs_elev_df['usgs_exclusion_status'].replace('', 'acceptable')
+        # CatFIM will only be processed for sites with a usgs_exclusion_status of 'acceptable'
+        usgs_elev_df['usgs_exclusion_status'] = usgs_elev_df['usgs_exclusion_status'].replace(
+            '', 'acceptable'
+        )
 
         # Copy df to de-fragment and rename
         acceptable_usgs_elev_df = usgs_elev_df.copy()
@@ -1427,9 +1443,9 @@ def __adj_dem_evalation_val(acceptable_usgs_elev_df, lid, huc_lid_id):
 
     lid_usgs_elev = 0
     all_messages = []
-    try:      
+    try:
         # Check for USGS elevation data that matches the LID
-        matching_rows = acceptable_usgs_elev_df.loc[acceptable_usgs_elev_df['nws_lid'] == lid.upper()] 
+        matching_rows = acceptable_usgs_elev_df.loc[acceptable_usgs_elev_df['nws_lid'] == lid.upper()]
 
         # Check if the site is not in the usgs table in our data
         if len(matching_rows) == 0:
@@ -1443,7 +1459,8 @@ def __adj_dem_evalation_val(acceptable_usgs_elev_df, lid, huc_lid_id):
         if len(matching_rows) == 2:
             # Get the site that does not have a levpa_id of zero and matches the LID
             lid_info = acceptable_usgs_elev_df.loc[
-                (acceptable_usgs_elev_df['nws_lid'] == lid.upper()) & (acceptable_usgs_elev_df['levpa_id'] != 0)
+                (acceptable_usgs_elev_df['nws_lid'] == lid.upper())
+                & (acceptable_usgs_elev_df['levpa_id'] != 0)
             ]
 
         else:

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -1388,24 +1388,28 @@ def __adjust_datum_ft(flows, metadata, lid, huc_lid_id):
 def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
     acceptable_usgs_elev_df = None
     try:
+        acceptable_msg = ''
+        unacceptable_alt_meth_msg = 'Unacceptable USGS data altitude method: '
+        unacceptable_site_type_msg = 'Unacceptable USGS site type: '
+        unacceptable_alt_acc_msg = 'Unacceptable USGS altitude accuracy threshold: '
 
         # Create columns for whether the USGS data meets each criterion
         msg1 = np.where(
             usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list),
-            '',
-            'Unacceptable USGS data altitude method: '
+            acceptable_msg, 
+            unacceptable_alt_meth_msg
             + usgs_elev_df['usgs_data_alt_method_code'].astype(str)
             + ', ',
         )
         msg2 = np.where(
             usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list),
-            '',
-            'Unacceptable USGS site type: ' + usgs_elev_df['usgs_data_site_type'].astype(str) + ', ',
+            acceptable_msg,
+            unacceptable_site_type_msg + usgs_elev_df['usgs_data_site_type'].astype(str) + ', ',
         )
         msg3 = np.where(
             usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh,
-            '',
-            'Unacceptable USGS altitude accuracy threshold: '
+            acceptable_msg,
+            unacceptable_alt_acc_msg
             + usgs_elev_df['usgs_data_alt_accuracy_code'].astype(str)
             + ', ',
         )

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -1392,14 +1392,17 @@ def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
     try:
 
         # Create columns for whether the USGS data meets each criterion
-        msg1 = np.where(usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list), '', 'unacceptable USGS data altitude method: ' + usgs_elev_df['usgs_data_alt_method_code'].astype(str)  + ', ')
-        msg2 = np.where(usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list), '', 'unacceptable USGS site type: ' + usgs_elev_df['usgs_data_site_type'].astype(str) + ', ')
-        msg3 = np.where(usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh, '', 'unacceptable USGS altitude accuracy threshold: ' + usgs_elev_df['usgs_data_alt_accuracy_code'].astype(str) + ', ')
+        msg1 = np.where(usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list), '', 'Unacceptable USGS data altitude method: ' + usgs_elev_df['usgs_data_alt_method_code'].astype(str)  + ', ')
+        msg2 = np.where(usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list), '', 'Unacceptable USGS site type: ' + usgs_elev_df['usgs_data_site_type'].astype(str) + ', ')
+        msg3 = np.where(usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh, '', 'Unacceptable USGS altitude accuracy threshold: ' + usgs_elev_df['usgs_data_alt_accuracy_code'].astype(str) + ', ')
 
         status_df = pd.DataFrame({'msg1': msg1, 'msg2': msg2, 'msg3': msg3})
 
         # Create detailed USGS exclusion status
         usgs_elev_df['usgs_exclusion_status'] = status_df['msg1'] + status_df['msg2'] + status_df['msg3']
+
+        # Remove the last comma using rstrip
+        usgs_elev_df['usgs_exclusion_status'] = usgs_elev_df['usgs_exclusion_status'].str.rstrip(',')
 
         # If it doesn't have anything for the exclusion criteria, set the usgs_exclusion_status to acceptable 
         usgs_elev_df['usgs_exclusion_status'] = usgs_elev_df['usgs_exclusion_status'].replace('', 'acceptable')
@@ -1455,7 +1458,7 @@ def __adj_dem_evalation_val(acceptable_usgs_elev_df, lid, huc_lid_id):
 
         # If there is an exclusion status other than 'acceptable,' return the status 
         if usgs_exclusion_status != 'acceptable':
-            msg = ':' + usgs_exclusion_status
+            msg = ':Gage excluded due to the following criteria -- ' + usgs_exclusion_status
             all_messages.append(lid + msg)
             MP_LOG.warning(huc_lid_id + msg)
             return lid_usgs_elev, all_messages

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -1401,10 +1401,8 @@ def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
         # Create detailed USGS exclusion status
         usgs_elev_df['usgs_exclusion_status'] = status_df['msg1'] + status_df['msg2'] + status_df['msg3']
 
-        # Remove the last comma using rstrip
-        usgs_elev_df['usgs_exclusion_status'] = usgs_elev_df['usgs_exclusion_status'].str.rstrip(',')
-
-        # If it doesn't have anything for the exclusion criteria, set the usgs_exclusion_status to acceptable 
+        # If it doesn't have anything for the exclusion criteria, set the usgs_exclusion_status to acceptable
+        # CatFIM will only be processed for sites with a usgs_exclusion_status of 'acceptable' 
         usgs_elev_df['usgs_exclusion_status'] = usgs_elev_df['usgs_exclusion_status'].replace('', 'acceptable')
 
         # Copy df to de-fragment and rename
@@ -1436,7 +1434,7 @@ def __adj_dem_evalation_val(acceptable_usgs_elev_df, lid, huc_lid_id):
         # Check if the site is not in the usgs table in our data
         if len(matching_rows) == 0:
             # msg = ':Gage not in HAND usgs gage records' # prev error message (deprecated May 2025)
-            msg = ':Gage not in HAND usgs gage records, likely due to exclusion criteria' # TODO: Temporary intermediate solution, more descriptive error message to come
+            msg = ':Gage not in HAND usgs gage records, likely due to exclusion criteria'
             all_messages.append(lid + msg)
             MP_LOG.warning(huc_lid_id + msg)
             return lid_usgs_elev, all_messages
@@ -1456,9 +1454,10 @@ def __adj_dem_evalation_val(acceptable_usgs_elev_df, lid, huc_lid_id):
         lid_usgs_elev = lid_info['dem_adj_elevation'].values[0]
         usgs_exclusion_status = lid_info['usgs_exclusion_status'].values[0]
 
-        # If there is an exclusion status other than 'acceptable,' return the status 
+        # If there is an exclusion status other than 'acceptable,' return the status
+        # Uses [:-1] to exclude the last comma in the string
         if usgs_exclusion_status != 'acceptable':
-            msg = ':Gage excluded due to the following criteria -- ' + usgs_exclusion_status
+            msg = ':Gage excluded due to the following criteria -- ' + usgs_exclusion_status[:-1]
             all_messages.append(lid + msg)
             MP_LOG.warning(huc_lid_id + msg)
             return lid_usgs_elev, all_messages

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -657,8 +657,9 @@ def iterate_through_huc_stage_based(
 
                 # Look for acceptable elevs
                 acceptable_usgs_elev_df = __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id)
+
                 if acceptable_usgs_elev_df is None or len(acceptable_usgs_elev_df) == 0:
-                    msg = ":Unable to find gage data"
+                    msg = ":Unable to find gage data"  # TODO: USGS Gage Method: Update this error message to be more descriptive
                     all_messages.append(lid + msg)
                     MP_LOG.warning(huc_lid_id + msg)
                     continue
@@ -666,7 +667,9 @@ def iterate_through_huc_stage_based(
                 # Get the dem_adj_elevation value from usgs_elev_table.csv.
                 # Prioritize the value that is not from branch 0.
                 lid_usgs_elev, dem_eval_messages = __adj_dem_evalation_val(
-                    acceptable_usgs_elev_df, lid, huc_lid_id
+                    acceptable_usgs_elev_df, 
+                    lid, 
+                    huc_lid_id
                 )
                 all_messages = all_messages + dem_eval_messages
                 if len(dem_eval_messages) > 0:
@@ -686,18 +689,8 @@ def iterate_through_huc_stage_based(
                     MP_LOG.warning(huc_lid_id + msg)
                     continue
 
-                # Filter out sites that don't have "good" data
+                # Filter out sites that don't have "good" data ## TODO: USGS Gage Method: It doens't seem like the below error messages are performing as expected....
                 try:
-                    ## Removed this part to relax coordinate accuracy requirements
-                    # if not metadata['usgs_data']['coord_accuracy_code'] in acceptable_coord_acc_code_list:
-                    #     MP_LOG.warning(
-                    #         f"\t{huc_lid_id}: {metadata['usgs_data']['coord_accuracy_code']} "
-                    #         "Not in acceptable coord acc codes"
-                    #     )
-                    #     continue
-                    # if not metadata['usgs_data']['coord_method_code'] in acceptable_coord_method_code_list:
-                    #     MP_LOG.warning(f"\t{huc_lid_id}: Not in acceptable coord method codes")
-                    #     continue
                     if not metadata['usgs_data']['alt_method_code'] in acceptable_alt_meth_code_list:
                         MP_LOG.warning(f"{huc_lid_id}: Not in acceptable alt method codes")
                         continue
@@ -1397,20 +1390,22 @@ def __adjust_datum_ft(flows, metadata, lid, huc_lid_id):
 def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
     acceptable_usgs_elev_df = None
     try:
-        # Drop columns that offend acceptance criteria
-        usgs_elev_df['acceptable_codes'] = (
-            usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list)
-            & usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list)
-        )
 
-        usgs_elev_df = usgs_elev_df.astype({'usgs_data_alt_accuracy_code': float})
-        usgs_elev_df['acceptable_alt_error'] = np.where(
-            usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh, True, False
-        )
+        # Create columns for whether the USGS data meets each criterion
+        msg1 = np.where(usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list), '', 'unacceptable USGS data altitude method: ' + usgs_elev_df['usgs_data_alt_method_code'].astype(str)  + ', ')
+        msg2 = np.where(usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list), '', 'unacceptable USGS site type: ' + usgs_elev_df['usgs_data_site_type'].astype(str) + ', ')
+        msg3 = np.where(usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh, '', 'unacceptable USGS altitude accuracy threshold: ' + usgs_elev_df['usgs_data_alt_accuracy_code'].astype(str) + ', ')
 
-        acceptable_usgs_elev_df = usgs_elev_df[
-            (usgs_elev_df['acceptable_codes'] == True) & (usgs_elev_df['acceptable_alt_error'] == True)
-        ]
+        status_df = pd.DataFrame({'msg1': msg1, 'msg2': msg2, 'msg3': msg3})
+
+        # Create detailed USGS exclusion status
+        usgs_elev_df['usgs_exclusion_status'] = status_df['msg1'] + status_df['msg2'] + status_df['msg3']
+
+        # If it doesn't have anything for the exclusion criteria, set the usgs_exclusion_status to acceptable 
+        usgs_elev_df['usgs_exclusion_status'] = usgs_elev_df['usgs_exclusion_status'].replace('', 'acceptable')
+
+        # Copy df to de-fragment and rename
+        acceptable_usgs_elev_df = usgs_elev_df.copy()
 
     except Exception:
         # Not sure any of the sites actually have those USGS-related
@@ -1431,30 +1426,41 @@ def __adj_dem_evalation_val(acceptable_usgs_elev_df, lid, huc_lid_id):
 
     lid_usgs_elev = 0
     all_messages = []
-    try:
-        matching_rows = acceptable_usgs_elev_df.loc[
-            acceptable_usgs_elev_df['nws_lid'] == lid.upper(), 'dem_adj_elevation'
-        ]
+    try:      
+        # Check for USGS elevation data that matches the LID
+        matching_rows = acceptable_usgs_elev_df.loc[acceptable_usgs_elev_df['nws_lid'] == lid.upper()] 
 
+        # Check if the site is not in the usgs table in our data
         if len(matching_rows) == 0:
-            msg = ':Gage not in HAND usgs gage records'
+            # msg = ':Gage not in HAND usgs gage records' # prev error message (deprecated May 2025)
+            msg = ':Gage not in HAND usgs gage records, likely due to exclusion criteria' # TODO: Temporary intermediate solution, more descriptive error message to come
             all_messages.append(lid + msg)
             MP_LOG.warning(huc_lid_id + msg)
             return lid_usgs_elev, all_messages
 
-        # It means there are two level paths, use the one that is not 0
-        # There will never be more than two
+        # It means there are two level paths, use the one that is not 0 (there will never be more than two)
         if len(matching_rows) == 2:
-            lid_usgs_elev = acceptable_usgs_elev_df.loc[
-                (acceptable_usgs_elev_df['nws_lid'] == lid.upper())
-                & (acceptable_usgs_elev_df['levpa_id'] != 0),
-                'dem_adj_elevation',
-            ].values[0]
-        else:
-            lid_usgs_elev = acceptable_usgs_elev_df.loc[
-                acceptable_usgs_elev_df['nws_lid'] == lid.upper(), 'dem_adj_elevation'
-            ].values[0]
+            # Get the site that does not have a levpa_id of zero and matches the LID
+            lid_info = acceptable_usgs_elev_df.loc[
+                (acceptable_usgs_elev_df['nws_lid'] == lid.upper()) & (acceptable_usgs_elev_df['levpa_id'] != 0)
+            ]
 
+        else:
+            # Get the site that matches the LID
+            lid_info = acceptable_usgs_elev_df.loc[acceptable_usgs_elev_df['nws_lid'] == lid.upper()]
+
+        # Get elevation and exclusion status
+        lid_usgs_elev = lid_info['dem_adj_elevation'].values[0]
+        usgs_exclusion_status = lid_info['usgs_exclusion_status'].values[0]
+
+        # If there is an exclusion status other than 'acceptable,' return the status 
+        if usgs_exclusion_status != 'acceptable':
+            msg = ':' + usgs_exclusion_status
+            all_messages.append(lid + msg)
+            MP_LOG.warning(huc_lid_id + msg)
+            return lid_usgs_elev, all_messages
+
+        # Check whether DEM adjusted elevation is 0 or not set
         if lid_usgs_elev == 0:
             msg = ':DEM adjusted elevation is 0 or not set'
             all_messages.append(lid + msg)
@@ -1639,7 +1645,6 @@ def generate_stage_based_categorical_fim(
 
     # Preprocess the out_gdf GeoDataFrame. Reproject and reformat fields.
 
-    # TODO: Accomodate AK projection?   Yes.. and Alaska and CONUS should all end up as the same projection output
     # epsg:5070, we really want 3857 out for all outputs
     sites_gdf = sites_gdf.to_crs(VIZ_PROJECTION)
     sites_gdf.rename(

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -1399,8 +1399,6 @@ def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
     try:
         # Drop columns that offend acceptance criteria
         usgs_elev_df['acceptable_codes'] = (
-            # usgs_elev_df['usgs_data_coord_accuracy_code'].isin(acceptable_coord_acc_code_list)
-            # & usgs_elev_df['usgs_data_coord_method_code'].isin(acceptable_coord_method_code_list)
             usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list)
             & usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list)
         )
@@ -1413,12 +1411,6 @@ def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
         acceptable_usgs_elev_df = usgs_elev_df[
             (usgs_elev_df['acceptable_codes'] == True) & (usgs_elev_df['acceptable_alt_error'] == True)
         ]
-
-        # # TEMP DEBUG Record row difference and write it to a CSV or something
-        # label = 'Old code' ## TEMP DEBUG
-        # num_potential_rows = usgs_elev_df.shape[0]
-        # num_acceptable_rows = acceptable_usgs_elev_df.shape[0]
-        # out_message = f'{label}: kept {num_acceptable_rows} rows out of {num_potential_rows} available rows.'
 
     except Exception:
         # Not sure any of the sites actually have those USGS-related

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -1396,10 +1396,8 @@ def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
         # Create columns for whether the USGS data meets each criterion
         msg1 = np.where(
             usgs_elev_df['usgs_data_alt_method_code'].isin(acceptable_alt_meth_code_list),
-            acceptable_msg, 
-            unacceptable_alt_meth_msg
-            + usgs_elev_df['usgs_data_alt_method_code'].astype(str)
-            + ', ',
+            acceptable_msg,
+            unacceptable_alt_meth_msg + usgs_elev_df['usgs_data_alt_method_code'].astype(str) + ', ',
         )
         msg2 = np.where(
             usgs_elev_df['usgs_data_site_type'].isin(acceptable_site_type_list),
@@ -1409,9 +1407,7 @@ def __create_acceptable_usgs_elev_df(usgs_elev_df, huc_lid_id):
         msg3 = np.where(
             usgs_elev_df['usgs_data_alt_accuracy_code'] <= acceptable_alt_acc_thresh,
             acceptable_msg,
-            unacceptable_alt_acc_msg
-            + usgs_elev_df['usgs_data_alt_accuracy_code'].astype(str)
-            + ', ',
+            unacceptable_alt_acc_msg + usgs_elev_df['usgs_data_alt_accuracy_code'].astype(str) + ', ',
         )
 
         status_df = pd.DataFrame({'msg1': msg1, 'msg2': msg2, 'msg3': msg3})

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -1455,9 +1455,9 @@ def __adj_dem_evalation_val(acceptable_usgs_elev_df, lid, huc_lid_id):
         usgs_exclusion_status = lid_info['usgs_exclusion_status'].values[0]
 
         # If there is an exclusion status other than 'acceptable,' return the status
-        # Uses [:-1] to exclude the last comma in the string
+        # Uses [:-2] to exclude the last comma and space in the string
         if usgs_exclusion_status != 'acceptable':
-            msg = ':Gage excluded due to the following criteria -- ' + usgs_exclusion_status[:-1]
+            msg = ':Gage excluded due to the following criteria -- ' + usgs_exclusion_status[:-2]
             all_messages.append(lid + msg)
             MP_LOG.warning(huc_lid_id + msg)
             return lid_usgs_elev, all_messages

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -667,8 +667,8 @@ def iterate_through_huc_stage_based(
                 # Get the dem_adj_elevation value from usgs_elev_table.csv.
                 # Prioritize the value that is not from branch 0.
                 lid_usgs_elev, dem_eval_messages = __adj_dem_evalation_val(
-                    acceptable_usgs_elev_df, 
-                    lid, 
+                    acceptable_usgs_elev_df,
+                    lid,
                     huc_lid_id
                 )
                 all_messages = all_messages + dem_eval_messages


### PR DESCRIPTION
Resolves [Issue 1503](https://github.com/NOAA-OWP/inundation-mapping/issues/1503)

Currently, all stage-based CatFIM sites that are removed from the processing due to not meeting the USGS gage acceptance criteria receive the following status message: “Gage not in HAND usgs gage records.” This status message has resulted in confusion from the field and made it difficult to pinpoint exactly why a gage is being excluded (and therefore if there's any way to fix the issue).

This PR updates the stage-based CatFIM USGS site filtration code so removed sites have clear status message listing what acceptance criteria they didn't meet.

### Example

An example of the functionality is in site cnea3. Previously, the status message was: `Gage not in HAND usgs gage records.`
Now it is: `Gage excluded due to the following criteria -- Unacceptable USGS data altitude method: M, Unacceptable USGS altitude accuracy threshold: 20.0`

For sites that are filtered out of the USGS rating curve data before CatFIM processing, their status message was previously:  `Gage not in HAND usgs gage records.`
After this update, they will read: `Gage not in HAND usgs gage records, likely due to exclusion criteria`

Once the acceptance criteria filtration is moved out of `rating_curve_get_usgs_curves.py` (as described in [Issue 1507](https://github.com/NOAA-OWP/inundation-mapping/issues/1507) ), all sites will have the updated descriptive status message.

### Changes
- `inundation-mapping/tools/catfim/generate_categorical_fim.py`: Updated `__create_acceptable_usgs_elev_df()` function to produce a descriptive `usgs_exclusion_status` column instead of just filtering out the sites that don't meet the acceptance criteria. Updated the `__adj_dem_evalation_val()` function to use the `usgs_exclusion_status` column to filter out sites that should be excluded and provide a more descriptive message for the excluded sites, where available. 

### Testing
This change has been tested on stage-based CatFIM for the following HUCs: 01060003 01080205 15050302 17020010 07080201. Each of these HUCs has one or more occurrence of the  “Gage not in HAND usgs gage records" error message and in the new filtering there were many that were able to be updated with more legible statuses.


### Deployment Plan (For developer use)

_How does the changes affect the product?_
- [ ] Code only?
- [ ] If applicable, has a deployment plan be created with the deployment person/team?
- [ ] Require new or adjusted data inputs? Does it have start, end and duration code (in UTC)?
- [ ] If new or updated data sets, has the FIM code been updated and tested with the new/adjusted data (subset is fine, but must be a subset of the new data)?
- [ ] Require new pre-clip set?
- [ ] Has new or updated python packages?

### Issuer Checklist (For developer use)

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [ ] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [ ] `pre-commit` hooks were run locally
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [ ] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
