### PR TITLE
[1pt]PR: Hotfix to handle hydrofab slope variable names

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,13 +1,14 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.7.4.x - 2025-05-22 - [PR#1481](https://github.com/NOAA-OWP/inundation-mapping/pull/1533)
+## v4.7.4.6 - 2025-05-22 - [PR#1533](https://github.com/NOAA-OWP/inundation-mapping/pull/1533)
 
 Hotfix to address issue caused by a different Slope attribute name in the NWM flowpath data (`nwm_subset_streams_levelPaths.gpkg`). The Alaska hydrofabric uses `So` attribute name whereas the CONUS hydrofabric uses `Slope` for the channel slope attribute name. Also included an additional fix to address a separate issue with missing channel and overbank roughness values in the input roughness file (AK featureids are not included in the current file).
 
 ### Changes
 `src/add_crosswalk.py`: New logic to check for different channel slope attribute names
 `src/subdiv_chan_obank_src.py`: New logic to address feature_ids that we do not specify channel and overbank roughness values in the input file (`vmann_input_file`). Currently we do not have optimized roughness values for AK hucs, so the code now sets missing channel_n values = 0.06 and missing overbank_n values = 0.12.
+
 
 <br/><br/>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.7.4.x - 2025-05-22 - [PR#1481](https://github.com/NOAA-OWP/inundation-mapping/pull/1533)
+
+Hotfix to address issue caused by a different Slope attribute name in the NWM flowpath data (`nwm_subset_streams_levelPaths.gpkg`). The Alaska hydrofabric uses `So` attribute name whereas the CONUS hydrofabric uses `Slope` for the channel slope attribute name. Also included an additional fix to address a separate issue with missing channel and overbank roughness values in the input roughness file (AK featureids are not included in the current file).
+
+### Changes
+`src/add_crosswalk.py`: New logic to check for different channel slope attribute names
+`src/subdiv_chan_obank_src.py`: New logic to address feature_ids that we do not specify channel and overbank roughness values in the input file (`vmann_input_file`). Currently we do not have optimized roughness values for AK hucs, so the code now sets missing channel_n values = 0.06 and missing overbank_n values = 0.12.
+
+<br/><br/>
+
 ## v4.7.4.0 - 2025-05-16 - [PR#1481](https://github.com/NOAA-OWP/inundation-mapping/pull/1481)
 
 Adjusts the elevations in branch floodplains by subtracting an additional amount from the DEM based on distance from the levelpath stream line so streams are more likely to flow directly towards the levelpath in order to address the catchment boundary issue.

--- a/src/add_crosswalk.py
+++ b/src/add_crosswalk.py
@@ -5,6 +5,7 @@ import json
 import sys
 
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 from numpy import unique
 from rasterstats import zonal_stats
@@ -49,9 +50,21 @@ def add_crosswalk(
 
     input_catchments = input_catchments.dissolve(by='HydroID').reset_index()
 
-    input_nwmflows = input_nwmflows.rename(columns={'ID': 'feature_id', 'Slope': 'SLOPE_HFAB'})
+    # Rename ID column
+    input_nwmflows = input_nwmflows.rename(columns={'ID': 'feature_id'})
     if input_nwmflows.feature_id.dtype != 'int':
         input_nwmflows.feature_id = input_nwmflows.feature_id.astype(int)
+
+    # Handle variable slope column name (AK uses So, CONUS uses Slope)
+    if 'Slope' in input_nwmflows.columns:
+        input_nwmflows = input_nwmflows.rename(columns={'Slope': 'SLOPE_HFAB'})
+    elif 'So' in input_nwmflows.columns:
+        input_nwmflows = input_nwmflows.rename(columns={'So': 'SLOPE_HFAB'})
+    else:
+        input_nwmflows['SLOPE_HFAB'] = np.nan
+        print(
+            f"WARNING: could not find a 'Slope' or 'So' attribute in the NWM hydrofabric at {input_nwmflows_fileName} – setting SLOPE_HFAB to n/a"
+        )
 
     # Merge IRIS-SWORD slope data with NWM flows
     input_nwmflows = input_nwmflows.merge(

--- a/src/identify_src_bankfull.py
+++ b/src/identify_src_bankfull.py
@@ -334,7 +334,7 @@ def run_prep(fim_dir, bankfull_flow_filepath, number_of_jobs, verbose, src_plot_
                 ## Check if BARC modified src_full_crosswalked_BARC.csv exists otherwise use
                 #   orginial src_full_crosswalked.csv
                 if isfile(src_orig_full_filename):
-                    huc_pass_list.append(str(huc) + " --> src_full_crosswalked.csv")
+                    huc_pass_list.append(str(huc) + ' --> src_full_crosswalked_' + branch_id + '.csv')
                     procs_list.append(
                         [src_orig_full_filename, df_bflows, huc, branch_id, src_plot_option, huc_output_dir]
                     )

--- a/src/subdiv_chan_obank_src.py
+++ b/src/subdiv_chan_obank_src.py
@@ -111,15 +111,23 @@ def variable_mannings_calc(args):
             check_null = df_src['channel_n'].isnull().sum() + df_src['overbank_n'].isnull().sum()
             if check_null > 0:
                 log_text += (
-                    str(huc)
+                    "WARNING:"
+                    + +str(huc)
                     + '  branch id: '
                     + str(branch_id)
                     + ' --> '
-                    + 'Null feature_ids found in crosswalk btw roughness dataframe and src dataframe'
+                    + 'Null feature_ids found in crosswalk btw roughness dataframe and src dataframe (these will be set to default n values)'
                     + ' --> missing entries= '
                     + str(check_null / 84)
                     + '\n'
                 )
+
+            ## Set default channel and overbank n values
+            default_channel_n = 0.06
+            default_overbank_n = 0.12
+            ## Fill in the missing values with the default n values
+            df_src['channel_n'] = df_src['channel_n'].fillna(default_channel_n)
+            df_src['overbank_n'] = df_src['overbank_n'].fillna(default_overbank_n)
 
             ## Check if there are any missing data in the 'Stage_bankfull' column
             ##   (these are locations where subdiv will not be applied)

--- a/src/subdiv_chan_obank_src.py
+++ b/src/subdiv_chan_obank_src.py
@@ -112,7 +112,7 @@ def variable_mannings_calc(args):
             if check_null > 0:
                 log_text += (
                     "WARNING:"
-                    + +str(huc)
+                    + str(huc)
                     + '  branch id: '
                     + str(branch_id)
                     + ' --> '


### PR DESCRIPTION
Hotfix to address issue caused by a different Slope attribute name in the NWM flowpath data (`nwm_subset_streams_levelPaths.gpkg`). The Alaska hydrofabric uses `So` attribute name whereas the CONUS hydrofabric uses `Slope` for the channel slope attribute name. Also included an additional fix to address a separate issue with missing channel and overbank roughness values in the input roughness file (AK featureids are not included in the current file). Resolves #1525 

### Changes
- `src/add_crosswalk.py`: New logic to check for different channel slope attribute names
- `src/subdiv_chan_obank_src.py`: New logic to address feature_ids that we do not specify channel and overbank roughness values in the input file (`vmann_input_file`). Currently we do not have optimized roughness values for AK hucs, so the code now sets missing channel_n values = 0.06 and missing overbank_n values = 0.12.

### Testing
Successfully ran fim_pipeline.sh for 3 test hucs (11110202, 19020301, 05030202) and confirmed the previous error was addressed.


### Deployment Plan (For developer use)

_How does the changes affect the product?_
- [x] Code only?
- [ ] If applicable, has a deployment plan be created with the deployment person/team?
- [ ] Require new or adjusted data inputs? Does it have start, end and duration code (in UTC)?
- [ ] If new or updated data sets, has the FIM code been updated and tested with the new/adjusted data (subset is fine, but must be a subset of the new data)?
- [ ] Require new pre-clip set?
- [ ] Has new or updated python packages?

### Issuer Checklist (For developer use)

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] `pre-commit` hooks were run locally
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [x] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
