### PR TITLE
[3pt] PR: Lofi performance tweaks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,30 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.x.x.x - 2025-06-17 - [PR#1554]([https://github.com/NOAA-OWP/inundation-mapping/pull/1554])
+
+Some minor tweaks that should help performance of lofi.
+
+Performance enhancements:
+* Vectorized `generate_streamflow_percentiles`
+* Removed unnecessary copies
+* Reduced unnecessary iterations over collections
+
+Bug fixes:
+* Properly compare floats
+* Remove threading when writing dataset
+* Exit non-zero when exception is raised
+* Cleanup defaults in cli
+
+User facing:
+* Create compressed and tiled GeoTiff rasters
+
+### Changes
+- `tools/lofi/`
+   `probabilistic_inundation.py`: as described
+
+<br/><br/>
+
 ## v4.8.1.0 - 2025-06-10 - [PR#1552]([https://github.com/NOAA-OWP/inundation-mapping/pull/1552])
 
 This PR only focuses on adding the global optimized manning N as an input file to the bash_variables.env.

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -665,18 +665,14 @@ def inundate_probabilistic(
         ds.close()
 
     if output_vector is True:
+        def _make_geometry(shapes):
+            for p, v in shapes:
+                yield shape(p), v
+
         with rasterio.open(out_rast, 'r') as rst:
             shapes = rasterio.features.shapes(rst.read(1), mask=None, transform=rst.transform)
-
-            polygons = []
-            for geom, value in shapes:
-                polygon = shape(geom)
-                polygons.append((polygon, value))
-
-            data = []
-            for polygon, value in polygons:
-                data.append({'geometry': polygon, 'value': value})
-            gdf = gpd.GeoDataFrame(data, crs=raster_crs)
+            gdf = gpd.GeoDataFrame(_make_geometry(shapes), columns=['geometry', 'value'], crs=raster_crs)
+            gdf = gdf.set_geometry('geometry')
             gdf.to_file(os.path.join(base_output_path, output_file_name))
 
     for file in percentile_files:

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -264,7 +264,7 @@ def get_subdivided_src(
     df_src['channel_n'] = channel_manning
     df_src['overbank_n'] = overbank_manning
 
-    df_src['subdiv_applied'] = np.where(df_src['Stage_bankfull'].isnull(), False, True)  # creat
+    df_src['subdiv_applied'] = ~df_src['Stage_bankfull'].isnull()  # creat
 
     # Subdivide Manning Eq --------------------------------------------------------------------------------
 

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -614,14 +614,15 @@ def inundate_probabilistic(
     out_rast = os.path.join(base_output_path, output_file_name.replace(".gpkg", ".tif"))
     with rasterio.open(out_rast, "w+", **profile) as write_rst:
         for window in windows:
-            arrays = []
+            data_buf = None
             for d, p in zip(datasets, percentiles.keys()):
                 data = d.read(1, window=window)
-                data[data > 0] = np.int8(p)
-                arrays.append(data)
-
-            merged = np.max(arrays, axis=0)
-            write_rst.write(merged, window=window, indexes=1)
+                if data_buf is None:
+                    data[data > 0] = int(p)
+                    data_buf = data
+                else:
+                    np.max(data_buf, int(p), where=data > 0, out=data_buf)
+            write_rst.write(data_buf, window=window, indexes=1)
 
     # Close datasets
     for ds in datasets:

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -534,7 +534,7 @@ def inundate_probabilistic(
     )
 
     # Make directories if they do not exist
-    output_file_name = mosaic_prob_output_name.split('/')[-1]
+    output_file_name = os.path.basename(mosaic_prob_output_name)
     base_output_path = os.path.join(fim_outputs_dir, str(huc))
     src_output_path = os.path.join(base_output_path, 'srcs')
     htable_output_path = os.path.join(base_output_path, 'srcs')

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -609,10 +609,10 @@ def inundate_probabilistic(
     windows = [windows for _, windows in datasets[0].block_windows()]
     profile = datasets[0].profile
     raster_crs = datasets[0].crs
-    profile.update(dtype=np.int8)
+    profile.update(dtype=np.int8, tiled=True, compress=profile.get('compress', 'DEFLATE'))
 
     out_rast = os.path.join(base_output_path, output_file_name.replace(".gpkg", ".tif"))
-    with rasterio.open(out_rast, "w+", **profile, compress='DEFLATE', tiled=True) as write_rst:
+    with rasterio.open(out_rast, "w+", **profile) as write_rst:
         for window in windows:
             arrays = []
             for d, p in zip(datasets, percentiles.keys()):

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -168,19 +168,10 @@ def generate_streamflow_percentiles(
     scaled_likelihoods = np.squeeze(likelihoods / np.sum(likelihoods)) * np.linspace(1, 0.9, 6) * 10000
 
     # Create data to fit truncated exponential distribution
-    values = []
-
-    for value, scale in zip(np.squeeze(ensemble_forecast.values), scaled_likelihoods):
-        if np.isnan(value):
-            value = 0
-
-        if np.isnan(scale):
-            scale = 1
-
-        values.append(np.repeat(value, int(scale)))
-
-    streamflow_expon_values = np.hstack(values).ravel()
-
+    ef_values = np.where(np.isnan(ensemble_forecast.values), 0, ensemble_forecast.values)
+    sl_values = np.where(np.isnan(scaled_likelihoods), 1, scaled_likelihoods).astype(int)
+    streamflow_expon_values = np.repeat(ef_values.ravel(), sl_values.ravel())
+    
     # Check to see if all values are the same, if so grab the first, otherwise get their point percent functions
     if not np.allclose(streamflow_expon_values, streamflow_expon_values[0]):
         # Generate 10000 random values from distribution

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -601,7 +601,7 @@ def inundate_probabilistic(
 
     # percentiles
     percentile_files = [
-        f'{base_output_path}/extent_{file}_v10_day{day}_hour{hour}.tif' for file in list(percentiles.keys())
+        f'{base_output_path}/extent_{file}_v10_day{day}_hour{hour}.tif' for file in percentiles.keys()
     ]
 
     # For every percentile inundation map convert values to percentile

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -622,7 +622,7 @@ def inundate_probabilistic(
     profile.update(dtype=np.int8)
 
     out_rast = os.path.join(base_output_path, output_file_name.replace(".gpkg", ".tif"))
-    with rasterio.open(out_rast, "w+", **profile) as write_rst:
+    with rasterio.open(out_rast, "w+", **profile, compress='DEFLATE', tiled=True) as write_rst:
         for window in windows:
             arrays = []
             for d, p in zip(datasets, percentiles.keys()):

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -148,7 +148,7 @@ def generate_streamflow_percentiles(
     ef_values = np.where(np.isnan(ensemble_forecast.values), 0, ensemble_forecast.values)
     sl_values = np.where(np.isnan(scaled_likelihoods), 1, scaled_likelihoods).astype(int)
     streamflow_expon_values = np.repeat(ef_values.ravel(), sl_values.ravel())
-    
+
     # Check to see if all values are the same, if so grab the first, otherwise get their point percent functions
     if not np.allclose(streamflow_expon_values, streamflow_expon_values[0]):
         # Generate 10000 random values from distribution
@@ -162,7 +162,7 @@ def generate_streamflow_percentiles(
             '50': max(0, trunc_expon.ppf(0.5)),
             '25': max(0, trunc_expon.ppf(0.75)),
             '10': max(0, trunc_expon.ppf(0.9)),
-            'feature_id': feature
+            'feature_id': feature,
         }
 
     else:
@@ -665,6 +665,7 @@ def inundate_probabilistic(
         ds.close()
 
     if output_vector is True:
+
         def _make_geometry(shapes):
             for p, v in shapes:
                 yield shape(p), v

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -846,7 +846,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "-pd",
         "--posterior_dist",
-        help="OPTIONAL: HUCs to process probabilistic inundation",
+        help="OPTIONAL: Path to posterior distribution configuration file",
         required=False,
     )
 

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -277,7 +277,7 @@ def get_subdivided_src(
     )  # drop these cols (in case subdiv was previously performed)
     df_src['WetArea_chan (m2)'] = df_src['Volume_chan (m3)'] / df_src['LENGTHKM'] / 1000
     df_src['HydraulicRadius_chan (m)'] = df_src['WetArea_chan (m2)'] / df_src['WettedPerimeter_chan (m)']
-    df_src['HydraulicRadius_chan (m)'].fillna(0, inplace=True)
+    df_src['HydraulicRadius_chan (m)'] = df_src['HydraulicRadius_chan (m)'].fillna(0)
     df_src['Discharge_chan (m3s-1)'] = (
         df_src['WetArea_chan (m2)']
         * pow(df_src['HydraulicRadius_chan (m)'], 2.0 / 3)
@@ -285,7 +285,7 @@ def get_subdivided_src(
         / df_src['channel_n']
     )
     df_src['Velocity_chan (m/s)'] = df_src['Discharge_chan (m3s-1)'] / df_src['WetArea_chan (m2)']
-    df_src['Velocity_chan (m/s)'].fillna(0, inplace=True)
+    df_src['Velocity_chan (m/s)'] = df_src['Velocity_chan (m/s)'].fillna(0)
 
     # Calculate discharge (overbank) using Manning's equation
     df_src = df_src.drop(
@@ -301,7 +301,7 @@ def get_subdivided_src(
     df_src['WetArea_obank (m2)'] = df_src['Volume_obank (m3)'] / df_src['LENGTHKM'] / 1000
     df_src['HydraulicRadius_obank (m)'] = df_src['WetArea_obank (m2)'] / df_src['WettedPerimeter_obank (m)']
     df_src = df_src.replace([np.inf, -np.inf], np.nan)  # need to replace inf instances (divide by 0)
-    df_src['HydraulicRadius_obank (m)'].fillna(0, inplace=True)
+    df_src['HydraulicRadius_obank (m)'] = df_src['HydraulicRadius_obank (m)'].fillna(0)
     df_src['Discharge_obank (m3s-1)'] = (
         df_src['WetArea_obank (m2)']
         * pow(df_src['HydraulicRadius_obank (m)'], 2.0 / 3)
@@ -309,7 +309,7 @@ def get_subdivided_src(
         / df_src['overbank_n']
     )
     df_src['Velocity_obank (m/s)'] = df_src['Discharge_obank (m3s-1)'] / df_src['WetArea_obank (m2)']
-    df_src['Velocity_obank (m/s)'].fillna(0, inplace=True)
+    df_src['Velocity_obank (m/s)'] = df_src['Velocity_obank (m/s)'].fillna(0)
 
     # Calcuate the total of the subdivided discharge (channel + overbank)
     df_src = df_src.drop(
@@ -444,7 +444,7 @@ def inundate_probabilistic(
 
     parameters_df = pd.read_csv(parameters)
     params_weibull = parameters_df.loc[parameters_df['distribution_name'] == 'weibull_min']
-    params_weibull.set_index('feature_id', inplace=True)
+    params_weibull = params_weibull.set_index('feature_id')
 
     # Fim outputs directory
     fim_outputs_dir = outputs_dir

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -854,7 +854,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         "--overwrite",
-        default=False,
+        action='store_true',
         help="OPTIONAL: Whether to overwrite existing output",
         required=False,
     )

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -882,7 +882,7 @@ if __name__ == '__main__':
         required=False,
     )
 
-    parser.add_argument("l", "--log_file", type=str, help="OPTIONAL: Filepath for log file", required=False)
+    parser.add_argument("-l", "--log_file", type=str, help="OPTIONAL: Filepath for log file", required=False)
 
     parser.add_argument(
         "-a",

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -463,7 +463,7 @@ def inundate_probabilistic(
     features = ensembles.coords['feature_id']
 
     # For each feature in the provided ensembles
-    with ThreadPoolExecutor(max_workers=1) as executor:
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
 
         # Get max streamflow for every feature up to forecast time
         if aggregate_forecasts == "max_to_forecast":

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -634,7 +634,7 @@ def inundate_probabilistic(
 
         wrst.write(merged, window=window, indexes=1)
 
-    executor = ThreadPoolExecutor(max_workers=1)
+    executor = ThreadPoolExecutor(max_workers=num_threads)
 
     def __data_generator(datasets, percentiles, windows, wrst):
         for window in windows:

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from glob import glob
+from glob import iglob
 from typing import Dict, Optional, Tuple, Union
 
 import geopandas as gpd
@@ -554,6 +554,10 @@ def inundate_probabilistic(
     os.makedirs(htable_output_path, exist_ok=True)
     os.makedirs(flow_path, exist_ok=True)
 
+     # Find the original hydrotable
+    all_branches = iglob(os.path.join(hydrofabric_dir, huc, "branches", "*"))
+    all_branches = list(map(os.path.basename, all_branches))
+
     # Apply inundation map to each percentile
     for percentile, val in percentiles.items():
         channel_n = channel_dist.ppf(1 - int(percentile) / 100)
@@ -568,10 +572,6 @@ def inundate_probabilistic(
         # Skip if the file exists
         if os.path.exists(final_inundation_path) and not overwrite:
             continue
-
-        # Open the original hydrotable
-        all_branches = glob(os.path.join(hydrofabric_dir, huc, "branches", "*"))
-        all_branches = [x.split('/')[-1] for x in all_branches]
 
         htable_output_file = "htable_{0}.feather"
         for branch in all_branches:

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -878,9 +878,8 @@ if __name__ == '__main__':
     parser.add_argument(
         "-q",
         "--quiet",
-        default=True,
+        action='store_true',
         help="OPTIONAL: Whether to be verbose or not",
-        required=False
     )
 
     parser.add_argument(

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -886,17 +886,17 @@ if __name__ == '__main__':
     parser.add_argument(
         "-j",
         "--num_jobs",
+        default=1,
         type=int,
         help="REQUIRED: Number of jobs to process HUCs",
-        required=True
     )
 
     parser.add_argument(
         "-t",
         "--num_threads",
+        default=1,
         type=int,
         help="REQUIRED: Number of threads to process HUCs",
-        required=True
     )
 
     parser.add_argument(

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -51,7 +51,6 @@ def get_fim_probability_distributions(
     """
 
     if posterior_dist is None:
-
         # Default weibull likelihood for channel manning roughness
         channel_dist = weibull_min(c=1.5, scale=0.0367, loc=0.032)
 
@@ -62,7 +61,6 @@ def get_fim_probability_distributions(
         slope_dist = weibull_min(c=4, scale=0.95 / 10, loc=-0.0867)
 
     else:
-
         raise NotImplementedError("Currently not implemented")
 
     return channel_dist, obank_dist, slope_dist
@@ -464,17 +462,14 @@ def inundate_probabilistic(
 
     # For each feature in the provided ensembles
     with ThreadPoolExecutor(max_workers=num_threads) as executor:
-
         # Get max streamflow for every feature up to forecast time
         if aggregate_forecasts == "max_to_forecast":
-
             sel_forecast = ensembles.sel({'time': slice(reference_time, forecast_time)}).max('time')[
                 'streamflow'
             ]
 
         # Timeslice representing the max streamflow for any feature id in time up to forecast time
         elif aggregate_forecasts == "timeslice_max_of_any_feature_id":
-
             sel_forecast = ensembles['streamflow'].isel(
                 {
                     'time': ensembles['streamflow']
@@ -486,7 +481,6 @@ def inundate_probabilistic(
 
         # Timeslice representing the max sum of streamflow for all feature ids in time up to forecast time
         elif aggregate_forecasts == "timeslice_max_sum":
-
             sel_forecast = ensembles['streamflow'].isel(
                 {
                     'time': ensembles['streamflow']
@@ -498,13 +492,11 @@ def inundate_probabilistic(
 
         # Timeslice at forecast time
         else:
-
             sel_forecast = ensembles.sel({'time': forecast_time})['streamflow']
 
         # Generate streamflow likelihoods for each feature
         executor_dict = {}
         for feat in features:
-
             feat = feat if isinstance(feat, int) else int(feat)
             ensemble_forecast = sel_forecast.sel({'feature_id': feat})
 
@@ -554,7 +546,7 @@ def inundate_probabilistic(
     os.makedirs(htable_output_path, exist_ok=True)
     os.makedirs(flow_path, exist_ok=True)
 
-     # Find the original hydrotable
+    # Find the original hydrotable
     all_branches = iglob(os.path.join(hydrofabric_dir, huc, "branches", "*"))
     all_branches = list(map(os.path.basename, all_branches))
 
@@ -781,7 +773,6 @@ def inundate_hucs(
 
 
 if __name__ == '__main__':
-
     """
     Example Usage:
 
@@ -800,18 +791,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Run probabilistic inundation on selected HUCs")
 
     parser.add_argument(
-        "-e",
-        "--ensembles",
-        help="REQUIRED: Location of ensembles NetCDF file",
-        required=True
+        "-e", "--ensembles", help="REQUIRED: Location of ensembles NetCDF file", required=True
     )
 
-    parser.add_argument(
-        "-p",
-        "--parameters",
-        help='REQUIRED: Location of parameters CSV file',
-        required=True
-    )
+    parser.add_argument("-p", "--parameters", help='REQUIRED: Location of parameters CSV file', required=True)
 
     parser.add_argument(
         "-hd",
@@ -821,18 +804,11 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        "-od",
-        "--outputs_dir",
-        help="REQUIRED: Directory with fim outputs and hydrofabric",
-        required=True
+        "-od", "--outputs_dir", help="REQUIRED: Directory with fim outputs and hydrofabric", required=True
     )
 
     parser.add_argument(
-        "-hc",
-        "--hucs",
-        nargs="*",
-        help="REQUIRED: HUCs to process probabilistic inundation",
-        required=True
+        "-hc", "--hucs", nargs="*", help="REQUIRED: HUCs to process probabilistic inundation", required=True
     )
 
     parser.add_argument(
@@ -888,27 +864,14 @@ if __name__ == '__main__':
         required=False,
     )
 
+    parser.add_argument("-q", "--quiet", action='store_true', help="OPTIONAL: Whether to be verbose or not")
+
     parser.add_argument(
-        "-q",
-        "--quiet",
-        action='store_true',
-        help="OPTIONAL: Whether to be verbose or not",
+        "-j", "--num_jobs", default=1, type=int, help="REQUIRED: Number of jobs to process HUCs"
     )
 
     parser.add_argument(
-        "-j",
-        "--num_jobs",
-        default=1,
-        type=int,
-        help="REQUIRED: Number of jobs to process HUCs",
-    )
-
-    parser.add_argument(
-        "-t",
-        "--num_threads",
-        default=1,
-        type=int,
-        help="REQUIRED: Number of threads to process HUCs",
+        "-t", "--num_threads", default=1, type=int, help="REQUIRED: Number of threads to process HUCs"
     )
 
     parser.add_argument(
@@ -919,20 +882,16 @@ if __name__ == '__main__':
         required=False,
     )
 
-    parser.add_argument(
-        "l",
-        "--log_file",
-        type=str,
-        help="OPTIONAL: Filepath for log file",
-        required=False
-    )
+    parser.add_argument("l", "--log_file", type=str, help="OPTIONAL: Filepath for log file", required=False)
 
     parser.add_argument(
         "-a",
         "--aggregate_forecasts",
         type=str,
-        help=('OPTIONAL: Method to aggregate forecasts.  Options are max_to_forecast, '
-        'timeslice_max_of_any_feature_id, timeslice_max_sum'),
+        help=(
+            'OPTIONAL: Method to aggregate forecasts.  Options are max_to_forecast, '
+            'timeslice_max_of_any_feature_id, timeslice_max_sum'
+        ),
     )
 
     args = vars(parser.parse_args())

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -162,7 +162,7 @@ def generate_streamflow_percentiles(
             '10': float(ensemble_forecast.sel({'member': '1'})),
         }
 
-    likelihoods = np.array([1 - r.cdf(x) for x in ensemble_forecast.values])
+    likelihoods = 1 - r.cdf(ensemble_forecast.values)
 
     # Scale the likelihoods to equal 1 and then generate a dataset given their likelihood
     scaled_likelihoods = np.squeeze(likelihoods / np.sum(likelihoods)) * np.linspace(1, 0.9, 6) * 10000

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -102,47 +102,29 @@ def generate_streamflow_percentiles(
         "weibull_min": weibull_min,
     }
 
+    dkeys = ['90', '75', '50', '25', '10']
+
     # Check for deterministic products (currently NBM, Short Range, and Data Assimilated)
     if 'nbm' in ensemble_forecast.coords['member']:
-        return {
-            'feature_id': int(feature),
-            '90': float(ensemble_forecast.sel({'member': 'nbm'})),
-            '75': float(ensemble_forecast.sel({'member': 'nbm'})),
-            '50': float(ensemble_forecast.sel({'member': 'nbm'})),
-            '25': float(ensemble_forecast.sel({'member': 'nbm'})),
-            '10': float(ensemble_forecast.sel({'member': 'nbm'})),
-        }
+        rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': 'nbm'})))
+        rv['feature_id'] = int(feature)
+        return rv
 
     if 'da' in ensemble_forecast.coords['member']:
-        return {
-            'feature_id': int(feature),
-            '90': float(ensemble_forecast.sel({'member': 'da'})),
-            '75': float(ensemble_forecast.sel({'member': 'da'})),
-            '50': float(ensemble_forecast.sel({'member': 'da'})),
-            '25': float(ensemble_forecast.sel({'member': 'da'})),
-            '10': float(ensemble_forecast.sel({'member': 'da'})),
-        }
+        rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': 'da'})))
+        rv['feature_id'] = int(feature)
+        return rv
 
     if 'short' in ensemble_forecast.coords['member']:
-        return {
-            'feature_id': int(feature),
-            '90': float(ensemble_forecast.sel({'member': 'short'})),
-            '75': float(ensemble_forecast.sel({'member': 'short'})),
-            '50': float(ensemble_forecast.sel({'member': 'short'})),
-            '25': float(ensemble_forecast.sel({'member': 'short'})),
-            '10': float(ensemble_forecast.sel({'member': 'short'})),
-        }
+        rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': 'short'})))
+        rv['feature_id'] = int(feature)
+        return rv
 
     # If there is no feature in the NWM parameters file
     if int(feature) not in params_weibull.index:
-        return {
-            'feature_id': int(feature),
-            '90': float(ensemble_forecast.sel({'member': '1'})),
-            '75': float(ensemble_forecast.sel({'member': '1'})),
-            '50': float(ensemble_forecast.sel({'member': '1'})),
-            '25': float(ensemble_forecast.sel({'member': '1'})),
-            '10': float(ensemble_forecast.sel({'member': '1'})),
-        }
+        rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': '1'})))
+        rv['feature_id'] = int(feature)
+        return rv
     else:
         parameters = params_weibull.loc[int(feature)]
 
@@ -153,14 +135,9 @@ def generate_streamflow_percentiles(
         r = dist_dict[parameters['distribution_name']](**params)
 
     except Exception:
-        return {
-            'feature_id': int(feature),
-            '90': float(ensemble_forecast.sel({'member': '1'})),
-            '75': float(ensemble_forecast.sel({'member': '1'})),
-            '50': float(ensemble_forecast.sel({'member': '1'})),
-            '25': float(ensemble_forecast.sel({'member': '1'})),
-            '10': float(ensemble_forecast.sel({'member': '1'})),
-        }
+        rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': '1'})))
+        rv['feature_id'] = int(feature)
+        return rv
 
     likelihoods = 1 - r.cdf(ensemble_forecast.values)
 
@@ -180,23 +157,18 @@ def generate_streamflow_percentiles(
         )
 
         return {
+            '90': max(0, trunc_expon.ppf(0.1)),
+            '75': max(0, trunc_expon.ppf(0.25)),
+            '50': max(0, trunc_expon.ppf(0.5)),
+            '25': max(0, trunc_expon.ppf(0.75)),
+            '10': max(0, trunc_expon.ppf(0.9)),
             'feature_id': int(feature),
-            '90': np.max([0, trunc_expon.ppf(0.1)]),
-            '75': np.max([0, trunc_expon.ppf(0.25)]),
-            '50': np.max([0, trunc_expon.ppf(0.5)]),
-            '25': np.max([0, trunc_expon.ppf(0.75)]),
-            '10': np.max([0, trunc_expon.ppf(0.9)]),
         }
 
     else:
-        return {
-            'feature_id': int(feature),
-            '90': np.max([0, streamflow_expon_values[0]]),
-            '75': np.max([0, streamflow_expon_values[0]]),
-            '50': np.max([0, streamflow_expon_values[0]]),
-            '25': np.max([0, streamflow_expon_values[0]]),
-            '10': np.max([0, streamflow_expon_values[0]]),
-        }
+        rv = dict.fromkeys(dkeys, max(0, streamflow_expon_values[0]))
+        rv['feature_id'] = int(feature)
+        return rv
 
 
 def get_subdivided_src(

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -937,11 +937,4 @@ if __name__ == '__main__':
     )
 
     args = vars(parser.parse_args())
-
-    try:
-        # Catch all exceptions through the script if it came
-        # from command line.
-        inundate_hucs(**args)
-
-    except Exception:
-        print("The following error has occured:\n", traceback.format_exc())
+    inundate_hucs(**args)

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -801,10 +801,18 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Run probabilistic inundation on selected HUCs")
 
     parser.add_argument(
-        "-e", "--ensembles", help="REQUIRED: Location of ensembles NetCDF file", required=True
+        "-e",
+        "--ensembles",
+        help="REQUIRED: Location of ensembles NetCDF file",
+        required=True
     )
 
-    parser.add_argument("-p", "--parameters", help='REQUIRED: Location of parameters CSV file', required=True)
+    parser.add_argument(
+        "-p",
+        "--parameters",
+        help='REQUIRED: Location of parameters CSV file',
+        required=True
+    )
 
     parser.add_argument(
         "-hd",
@@ -814,11 +822,18 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        "-od", "--outputs_dir", help="REQUIRED: Directory with fim outputs and hydrofabric", required=True
+        "-od",
+        "--outputs_dir",
+        help="REQUIRED: Directory with fim outputs and hydrofabric",
+        required=True
     )
 
     parser.add_argument(
-        "-hc", "--hucs", nargs="*", help="REQUIRED: HUCs to process probabilistic inundation", required=True
+        "-hc",
+        "--hucs",
+        nargs="*",
+        help="REQUIRED: HUCs to process probabilistic inundation",
+        required=True
     )
 
     parser.add_argument(

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -182,7 +182,7 @@ def generate_streamflow_percentiles(
     streamflow_expon_values = np.hstack(values).ravel()
 
     # Check to see if all values are the same, if so grab the first, otherwise get their point percent functions
-    if not np.all(streamflow_expon_values == streamflow_expon_values[0]):
+    if not np.allclose(streamflow_expon_values, streamflow_expon_values[0]):
         # Generate 10000 random values from distribution
         trunc_expon = truncexpon(
             *truncexpon.fit(streamflow_expon_values, loc=np.min(streamflow_expon_values))

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -831,7 +831,6 @@ if __name__ == '__main__':
     parser.add_argument(
         "-pd",
         "--posterior_dist",
-        nargs="*",
         help="OPTIONAL: HUCs to process probabilistic inundation",
         required=False,
     )

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -537,13 +537,12 @@ def inundate_probabilistic(
     output_file_name = os.path.basename(mosaic_prob_output_name)
     base_output_path = os.path.join(fim_outputs_dir, str(huc))
     src_output_path = os.path.join(base_output_path, 'srcs')
-    htable_output_path = os.path.join(base_output_path, 'srcs')
+    htable_output_path = src_output_path
     flow_path = os.path.join(base_output_path, 'flows')
 
     # Create directories if they do not exist
     os.makedirs(base_output_path, exist_ok=True)
     os.makedirs(src_output_path, exist_ok=True)
-    os.makedirs(htable_output_path, exist_ok=True)
     os.makedirs(flow_path, exist_ok=True)
 
     # Find the original hydrotable

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -876,22 +876,34 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        "-q", "--quiet", default=True, help="OPTIONAL: Whether to be verbose or not", required=False
+        "-q",
+        "--quiet",
+        default=True,
+        help="OPTIONAL: Whether to be verbose or not",
+        required=False
     )
 
     parser.add_argument(
-        "-j", "--num_jobs", type=int, help="REQUIRED: Number of jobs to process HUCs", required=True
+        "-j",
+        "--num_jobs",
+        type=int,
+        help="REQUIRED: Number of jobs to process HUCs",
+        required=True
     )
 
     parser.add_argument(
-        "-t", "--num_threads", type=int, help="REQUIRED: Number of threads to process HUCs", required=True
+        "-t",
+        "--num_threads",
+        type=int,
+        help="REQUIRED: Number of threads to process HUCs",
+        required=True
     )
 
     parser.add_argument(
         "-w",
         "--windowed",
         action='store_true',
-        help="REQUIRED: Number of threads to process HUCs",
+        help="OPTIONAL: Number of threads to process HUCs",
         required=False,
     )
 

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -107,26 +107,26 @@ def generate_streamflow_percentiles(
     # Check for deterministic products (currently NBM, Short Range, and Data Assimilated)
     if 'nbm' in ensemble_forecast.coords['member']:
         rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': 'nbm'})))
-        rv['feature_id'] = int(feature)
+        rv['feature_id'] = feature
         return rv
 
     if 'da' in ensemble_forecast.coords['member']:
         rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': 'da'})))
-        rv['feature_id'] = int(feature)
+        rv['feature_id'] = feature
         return rv
 
     if 'short' in ensemble_forecast.coords['member']:
         rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': 'short'})))
-        rv['feature_id'] = int(feature)
+        rv['feature_id'] = feature
         return rv
 
     # If there is no feature in the NWM parameters file
-    if int(feature) not in params_weibull.index:
+    if feature not in params_weibull.index:
         rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': '1'})))
-        rv['feature_id'] = int(feature)
+        rv['feature_id'] = feature
         return rv
     else:
-        parameters = params_weibull.loc[int(feature)]
+        parameters = params_weibull.loc[feature]
 
     # Create probability distribution
     params = ast.literal_eval(parameters['parameters'])
@@ -136,7 +136,7 @@ def generate_streamflow_percentiles(
 
     except Exception:
         rv = dict.fromkeys(dkeys, float(ensemble_forecast.sel({'member': '1'})))
-        rv['feature_id'] = int(feature)
+        rv['feature_id'] = feature
         return rv
 
     likelihoods = 1 - r.cdf(ensemble_forecast.values)
@@ -162,12 +162,12 @@ def generate_streamflow_percentiles(
             '50': max(0, trunc_expon.ppf(0.5)),
             '25': max(0, trunc_expon.ppf(0.75)),
             '10': max(0, trunc_expon.ppf(0.9)),
-            'feature_id': int(feature),
+            'feature_id': feature
         }
 
     else:
         rv = dict.fromkeys(dkeys, max(0, streamflow_expon_values[0]))
-        rv['feature_id'] = int(feature)
+        rv['feature_id'] = feature
         return rv
 
 

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -541,25 +541,24 @@ def inundate_probabilistic(
         posterior_dist=posterior_dist, huc=huc
     )
 
+    # Make directories if they do not exist
+    output_file_name = mosaic_prob_output_name.split('/')[-1]
+    base_output_path = os.path.join(fim_outputs_dir, str(huc))
+    src_output_path = os.path.join(base_output_path, 'srcs')
+    htable_output_path = os.path.join(base_output_path, 'srcs')
+    flow_path = os.path.join(base_output_path, 'flows')
+
+    # Create directories if they do not exist
+    os.makedirs(base_output_path, exist_ok=True)
+    os.makedirs(src_output_path, exist_ok=True)
+    os.makedirs(htable_output_path, exist_ok=True)
+    os.makedirs(flow_path, exist_ok=True)
+
     # Apply inundation map to each percentile
     for percentile, val in percentiles.items():
-
         channel_n = channel_dist.ppf(1 - int(percentile) / 100)
         overbank_n = obank_dist.ppf(1 - int(percentile) / 100)
         slope_adj = slope_dist.ppf(int(percentile) / 100)
-
-        # Make directories if they do not exist
-        output_file_name = mosaic_prob_output_name.split('/')[-1]
-        base_output_path = os.path.join(fim_outputs_dir, str(huc))
-        src_output_path = os.path.join(base_output_path, 'srcs')
-        htable_output_path = os.path.join(base_output_path, 'srcs')
-        flow_path = os.path.join(base_output_path, 'flows')
-
-        # Create directories if they do not exist
-        os.makedirs(base_output_path, exist_ok=True)
-        os.makedirs(src_output_path, exist_ok=True)
-        os.makedirs(htable_output_path, exist_ok=True)
-        os.makedirs(flow_path, exist_ok=True)
 
         # Establish directory to save the final mosaiced inundation
         final_inundation_path = os.path.join(

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -865,7 +865,6 @@ if __name__ == '__main__':
         "--output_raster",
         help="OPTIONAL: Whether to keep final raster output",
         action='store_true',
-        default=True,
         required=False,
     )
 

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -903,7 +903,7 @@ if __name__ == '__main__':
         "-w",
         "--windowed",
         action='store_true',
-        help="OPTIONAL: Number of threads to process HUCs",
+        help="OPTIONAL: Whether to run inundation in windowed mode for memory conservation ",
         required=False,
     )
 

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -504,7 +504,7 @@ def inundate_probabilistic(
                 future = executor.submit(
                     generate_streamflow_percentiles,
                     feature=feat,
-                    ensemble_forecast=ensemble_forecast.copy(),
+                    ensemble_forecast=ensemble_forecast,
                     params_weibull=params_weibull,
                 )
                 executor_dict[future] = feat

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -920,14 +920,20 @@ if __name__ == '__main__':
         required=False,
     )
 
-    parser.add_argument("-l", "--log_file", type=str, help="OPTIONAL: Filepath for log file", required=False)
+    parser.add_argument(
+        "l",
+        "--log_file",
+        type=str,
+        help="OPTIONAL: Filepath for log file",
+        required=False
+    )
 
     parser.add_argument(
         "-a",
         "--aggregate_forecasts",
         type=str,
-        help='OPTIONAL: Method to aggregate forecasts.  Options are max_to_forecast, '
-        'timeslice_max_of_any_feature_id, timeslice_max_sum',
+        help=('OPTIONAL: Method to aggregate forecasts.  Options are max_to_forecast, '
+        'timeslice_max_of_any_feature_id, timeslice_max_sum'),
     )
 
     args = vars(parser.parse_args())

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -621,44 +621,17 @@ def inundate_probabilistic(
     raster_crs = datasets[0].crs
     profile.update(dtype=np.int8)
 
-    def merge_percentiles(
-        ds: list, percentiles: list, window: rasterio.windows.Window, wrst=rasterio.io.DatasetWriter
-    ):
-        arrays = []
-        for d, p in zip(ds, percentiles):
-            data = d.read(1, window=window)
-            data[np.where(data > 0)] = np.int8(p)
-            arrays.append(data)
-
-        merged = np.max(arrays, axis=0)
-
-        wrst.write(merged, window=window, indexes=1)
-
-    executor = ThreadPoolExecutor(max_workers=num_threads)
-
-    def __data_generator(datasets, percentiles, windows, wrst):
-        for window in windows:
-            yield datasets, percentiles, window, wrst
-
-    def _vprint(message, verbose):
-        if verbose:
-            print(message)
-
     out_rast = os.path.join(base_output_path, output_file_name.replace(".gpkg", ".tif"))
     with rasterio.open(out_rast, "w+", **profile) as write_rst:
-        dgen = __data_generator(datasets, list(percentiles.keys()), windows, write_rst)
-        results = {executor.submit(merge_percentiles, *wg): 1 for wg in dgen}
+        for window in windows:
+            arrays = []
+            for d, p in zip(datasets, percentiles.keys()):
+                data = d.read(1, window=window)
+                data[data > 0] = np.int8(p)
+                arrays.append(data)
 
-        for future in as_completed(results):
-            try:
-                future.result()
-            except Exception as exc:
-                _vprint("Exception {} for {}".format(exc, results[future]), not quiet)
-            else:
-                if results[future] is not None:
-                    _vprint("... {} complete".format(results[future]), not quiet)
-                else:
-                    _vprint("... complete", not quiet)
+            merged = np.max(arrays, axis=0)
+            write_rst.write(merged, window=window, indexes=1)
 
     # Close datasets
     for ds in datasets:

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -853,7 +853,6 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        "-",
         "--overwrite",
         default=False,
         help="OPTIONAL: Whether to overwrite existing output",


### PR DESCRIPTION
Some minor tweaks that should help performance of lofi.

Performance enhancements:
* Vectorized `generate_streamflow_percentiles`
* Removed unnecessary copies
* Reduced unnecessary iterations over collections

Bug fixes:
* Properly compare floats
* Remove threading when writing dataset
* Exit non-zero when exception is raised
* Cleanup defaults in cli

User facing:
* Create compressed and tiled GeoTiff rasters

ping @GregoryPetrochenkov-NOAA 