### PR TITLE
[1pt] PR: Remove buffer clipping from streams below HUC

### DIFF
--- a/data/wbd/clip_vectors_to_wbd.py
+++ b/data/wbd/clip_vectors_to_wbd.py
@@ -391,7 +391,7 @@ def subset_vector_layers(huc, wbd_filename, wbd_buffer_filename, huc_directory, 
         if os.path.exists(input_LANDSEA):
             logging.info(f"Clipping NWM Streams for {huc} to land areas")
             landsea = gpd.read_file(input_LANDSEA, mask=wbd_buffer, engine="fiona")
-            nwm_streams = nwm_streams[~nwm_streams.intersects(landsea.unary_union)]
+            nwm_streams = nwm_streams.overlay(landsea, how='difference')
         else:
             logging.info(f"No landsea file provided, using all NWM streams for {huc}")
 

--- a/data/wbd/clip_vectors_to_wbd.py
+++ b/data/wbd/clip_vectors_to_wbd.py
@@ -170,6 +170,9 @@ def subset_vector_layers(huc, wbd_filename, wbd_buffer_filename, huc_directory, 
     wbd = gpd.read_file(os.path.join(huc_directory, wbd_filename))
     wbd_buffer = gpd.read_file(os.path.join(huc_directory, wbd_buffer_filename))
 
+    if 'shape_Length' in wbd.columns:
+        wbd = wbd.drop(columns=['shape_Length'])
+
     # for copying, use shutil.copy2 to preserve the orignal files timestamps
     if copying_flags['copy_levee_protected_areas']:
         src = os.path.join(copy_from_dir, huc, output_filenames['levee_protected_areas'])
@@ -386,8 +389,34 @@ def subset_vector_layers(huc, wbd_filename, wbd_buffer_filename, huc_directory, 
 
         nwm_streams = extend_outlet_streams(nwm_streams, wbd_buffer, wbd)
 
-        nwm_streams_outlets = nwm_streams[~nwm_streams['to'].isin(nwm_streams['ID'])]
-        nwm_streams_nonoutlets = nwm_streams[nwm_streams['to'].isin(nwm_streams['ID'])]
+        # nonoutlets = nwm_streams['to'].isin(nwm_streams['ID'])
+        # nwm_streams_outlets = nwm_streams[~nonoutlets]
+        # nwm_streams_nonoutlets = nwm_streams[nonoutlets]
+
+        # Select only the streams that are outlet
+        streams_crossing_wbd = gpd.sjoin(nwm_streams, wbd, predicate='crosses')
+        streams_in_wbd = gpd.sjoin(nwm_streams, wbd, predicate='intersects')
+
+        if streams_crossing_wbd.empty:
+            logging.warning("No streams intersect the WBD. Cannot extend outlet streams.")
+            return nwm_streams
+
+        # Filter streams that are outlets
+        outlets = streams_crossing_wbd[~streams_crossing_wbd['to'].isin(streams_in_wbd['ID'])]
+
+        # Find all stream IDs downstream of the outlets
+        outlet_ids = set()
+        for outlet_id in set(outlets['ID']):
+            outlet_ids.add(outlet_id)
+            downstream_segments = nwm_streams[
+                nwm_streams['ID'] == nwm_streams.loc[nwm_streams['ID'] == outlet_id, 'to'].values[0]
+            ]
+            while not downstream_segments.empty:
+                outlet_ids.add(downstream_segments['ID'].values[0])
+                downstream_segments = nwm_streams[nwm_streams['ID'].isin(downstream_segments['to'])]
+        # Filter the original streams to keep only those that are downstream of the outlets
+        nwm_streams_outlets = nwm_streams[nwm_streams['ID'].isin(outlet_ids)]
+        nwm_streams_nonoutlets = nwm_streams[~nwm_streams['ID'].isin(outlet_ids)]
 
         if len(nwm_streams) > 0:
             # Address issue where NWM streams exit the HUC boundary and then re-enter, creating a MultiLineString

--- a/data/wbd/clip_vectors_to_wbd.py
+++ b/data/wbd/clip_vectors_to_wbd.py
@@ -143,6 +143,7 @@ def subset_vector_layers(huc, wbd_filename, wbd_buffer_filename, huc_directory, 
 
     dem_cellsize = float(os.getenv('res'))
 
+    # Define the landsea water body mask using either Great Lakes or Ocean polygon input #
     if huc[:2] == '19':
         nwm_lakes = os.getenv('input_nwm_lakes_Alaska')
         nwm_catchments = os.getenv('input_nwm_catchments_Alaska')
@@ -154,6 +155,7 @@ def subset_vector_layers(huc, wbd_filename, wbd_buffer_filename, huc_directory, 
         osm_bridges = os.getenv('osm_bridges_alaska')
         osm_roads = os.getenv('osm_roads_alaska')
         huc_CRS = os.getenv('ALASKA_CRS')
+        input_LANDSEA = os.getenv('input_landsea_Alaska')
     else:
         nwm_lakes = os.getenv('input_nwm_lakes')
         nwm_catchments = os.getenv('input_nwm_catchments')
@@ -165,6 +167,11 @@ def subset_vector_layers(huc, wbd_filename, wbd_buffer_filename, huc_directory, 
         osm_bridges = os.getenv('osm_bridges')
         osm_roads = os.getenv('osm_roads')
         huc_CRS = os.getenv('DEFAULT_FIM_PROJECTION_CRS')
+
+        if huc[:2] == "04":
+            input_LANDSEA = os.getenv('input_GL_boundaries')
+        else:
+            input_LANDSEA = os.getenv('input_landsea')
 
     # read wbd and wbd_buffered that are needed for clipping
     wbd = gpd.read_file(os.path.join(huc_directory, wbd_filename))
@@ -381,6 +388,18 @@ def subset_vector_layers(huc, wbd_filename, wbd_buffer_filename, huc_directory, 
         logging.info(f"Clipping NWM Streams for {huc}")
         nwm_streams = gpd.read_file(nwm_streams, mask=wbd_buffer, engine="fiona")
 
+        if os.path.exists(input_LANDSEA):
+            logging.info(f"Clipping NWM Streams for {huc} to land areas")
+            landsea = gpd.read_file(input_LANDSEA, mask=wbd_buffer, engine="fiona")
+            nwm_streams = nwm_streams[~nwm_streams.intersects(landsea.unary_union)]
+        else:
+            logging.info(f"No landsea file provided, using all NWM streams for {huc}")
+
+        if nwm_streams.empty:
+            print("No NWM stream segments within HUC " + str(huc) + " boundaries.")
+            logging.info("No NWM stream segments within HUC " + str(huc) + " boundaries.")
+            sys.exit(0)
+
         # NWM can have duplicate records, but appear to always be identical duplicates
         nwm_streams.drop_duplicates(subset="ID", keep="first", inplace=True)
 
@@ -447,7 +466,7 @@ if __name__ == '__main__':
     '''
     sample usage:
 
-    python subset_vectors.py \
+    python clip_vectors_to_wbd.py \
     --huc 21020001 \
     --wbd_filename wbd.gpkg \
     --wbd_buffer_filename wbd_buffered.gpkg \
@@ -461,8 +480,8 @@ if __name__ == '__main__':
             "copy_levee_protected_areas": false,
             "copy_osm_bridges": false,
                 "copy_osm_roads": false}'
-
     '''
+
     parser = argparse.ArgumentParser(description='Subset vector layers')
 
     parser.add_argument('--huc', type=str, required=True, help='HUC number (e.g., "03180004")')

--- a/data/wbd/clip_vectors_to_wbd.py
+++ b/data/wbd/clip_vectors_to_wbd.py
@@ -389,10 +389,6 @@ def subset_vector_layers(huc, wbd_filename, wbd_buffer_filename, huc_directory, 
 
         nwm_streams = extend_outlet_streams(nwm_streams, wbd_buffer, wbd)
 
-        # nonoutlets = nwm_streams['to'].isin(nwm_streams['ID'])
-        # nwm_streams_outlets = nwm_streams[~nonoutlets]
-        # nwm_streams_nonoutlets = nwm_streams[nonoutlets]
-
         # Select only the streams that are outlet
         streams_crossing_wbd = gpd.sjoin(nwm_streams, wbd, predicate='crosses')
         streams_in_wbd = gpd.sjoin(nwm_streams, wbd, predicate='intersects')

--- a/data/wbd/generate_pre_clip_fim_huc8.py
+++ b/data/wbd/generate_pre_clip_fim_huc8.py
@@ -366,7 +366,7 @@ def huc_level_clip_vectors_to_wbd(huc, outputs_dir, copy_from_dir, copying_flags
             input_WBD_filename = input_WBD_gdb
             dem_domain = input_DEM_domain
 
-        # Define the landsea water body mask using either Great Lakes or Ocean polygon input #
+        # Define the landsea waterbody mask using either Great Lakes or Ocean polygon input #
         if huc2Identifier == "04":
             input_LANDSEA = f"{input_GL_boundaries}"
         elif huc2Identifier == "19":

--- a/data/wbd/generate_pre_clip_fim_huc8.py
+++ b/data/wbd/generate_pre_clip_fim_huc8.py
@@ -227,7 +227,7 @@ def pre_clip_hucs_from_wbd(outputs_dir, huc_list, number_of_jobs, overwrite, cop
             logging.info(f" - {layer}")
     else:
         logging.info(
-            "You have requested for all layers to be copied. No need to use this tol for a simple copying!"
+            "You have requested for all layers to be copied. No need to use this tool for a simple copying!"
         )
         sys.exit(0)
 
@@ -284,7 +284,7 @@ def pre_clip_hucs_from_wbd(outputs_dir, huc_list, number_of_jobs, overwrite, cop
 
     if len(failed_HUCs_list) > 0:
         logging.info("\n+++++++++++++++++++")
-        logging.info("HUCs that failed to proccess are: ")
+        logging.info("HUCs that failed to process are: ")
         huc_error_msg = "  -- "
         for huc in failed_HUCs_list:
             huc_error_msg += f"{huc}, "
@@ -293,7 +293,7 @@ def pre_clip_hucs_from_wbd(outputs_dir, huc_list, number_of_jobs, overwrite, cop
         print(
             "\n\nOften you can just create a new huc list with the fails, re-run to a"
             " temp directory and recheck if errors still exists. Sometimes multi-prod can create"
-            " contention errors.\nFor each HUC that is sucessful, you can just copy it back"
+            " contention errors.\nFor each HUC that is successful, you can just copy it back"
             " into the original full pre-clip folder.\n"
         )
 
@@ -348,7 +348,6 @@ def huc_level_clip_vectors_to_wbd(huc, outputs_dir, copy_from_dir, copying_flags
     logging.info(f"Start Processing {huc}")
 
     try:
-
         huc_directory = os.path.join(outputs_dir, huc)
 
         # SET VARIABLES AND FILE INPUTS #

--- a/data/wbd/generate_pre_clip_fim_huc8.py
+++ b/data/wbd/generate_pre_clip_fim_huc8.py
@@ -544,9 +544,15 @@ if __name__ == '__main__':
         Always we need to add --copy_from_dir followed by path to the previous preclips results
         In addition, we can add one or multiple of above 8 arguments:
 
-        python foss_fim/data/wbd/generate_pre_clip_fim_huc8.py -u /data/inputs/huc_lists/included_huc8_withAlaska.lst -n outputs/preclips/test6_2/ -o
-        --copy_from_dir data/inputs/pre_clip_huc8/20250218/
-        --copy_nwm_catchments --copy_levee_lines_burned --copy_levee_lines --copy_nwm_streams_headwater
+        python foss_fim/data/wbd/generate_pre_clip_fim_huc8.py \
+            -u /data/inputs/huc_lists/included_huc8_withAlaska.lst \
+            -n outputs/preclips/test6_2/ \
+            -o \
+            --copy_from_dir data/inputs/pre_clip_huc8/20250218/ \
+            --copy_nwm_catchments \
+            --copy_levee_lines_burned \
+            --copy_levee_lines \
+            --copy_nwm_streams_headwater
     '''
 
     parser = argparse.ArgumentParser(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## v4.x.x.x - 2025-07-10 - [PR#1591](https://github.com/NOAA-OWP/inundation-mapping/pull/1591)
+
+Clipping of NWM streams below the HUC can cause issues if a stream exits and re-enters the DEM. The buffering causes the outlet to not extend to the edge of the DEM even if the ultimate outlet does. This results in "reverse flow" during the pit-filling operation which causes flat areas in the filled DEM and the loss of catchments as the DEM-derived reaches deviate from the NWM streams. Removing the clipping of the outlet streams anywhere below the HUC corrects the DEM so that the pit-filling produces the correct result.
+
+### Changes
+
+- `data/wbd/clip_vectors_to_wbd.py`: Removes clipping from streams below HUC
+
+<br/><br/>
+
 ## v4.8.6.2 - 2025-06-24 - [PR#1556](https://github.com/NOAA-OWP/inundation-mapping/pull/1556)
 
 Decided to make a separate PR to incorporate multiple PR and changes including:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+
+## v4.8.8.1 - 2025-07-30 - [PR#1591](https://github.com/NOAA-OWP/inundation-mapping/pull/1591)
+
+Clipping of NWM streams below the HUC can cause issues if a stream exits and re-enters the DEM. The buffering causes the outlet to not extend to the edge of the DEM even if the ultimate outlet does. This results in "reverse flow" during the pit-filling operation which causes flat areas in the filled DEM and the loss of catchments as the DEM-derived reaches deviate from the NWM streams. Removing the clipping of the outlet streams anywhere below the HUC corrects the DEM so that the pit-filling produces the correct result.
+
+### Changes
+
+- `data/wbd/clip_vectors_to_wbd.py`: Removes clipping from streams below HUC
+<br/>
+
 ## v4.8.8.0 - 2025-07-30 - [PR#1543](https://github.com/NOAA-OWP/inundation-mapping/pull/1543)
 
 This PR addresses the issue #1385 and includes the following enhancements:
@@ -50,15 +60,6 @@ Addresses bug related to the `location_id` data type that is read in from the `a
 <br/><br/>
 
 
-## v4.x.x.x - 2025-07-10 - [PR#1591](https://github.com/NOAA-OWP/inundation-mapping/pull/1591)
-
-Clipping of NWM streams below the HUC can cause issues if a stream exits and re-enters the DEM. The buffering causes the outlet to not extend to the edge of the DEM even if the ultimate outlet does. This results in "reverse flow" during the pit-filling operation which causes flat areas in the filled DEM and the loss of catchments as the DEM-derived reaches deviate from the NWM streams. Removing the clipping of the outlet streams anywhere below the HUC corrects the DEM so that the pit-filling produces the correct result.
-
-### Changes
-
-- `data/wbd/clip_vectors_to_wbd.py`: Removes clipping from streams below HUC
-
-<br/><br/>
 ## v4.8.7.1 - 2025-07-18 - [PR#1539]([https://github.com/NOAA-OWP/inundation-mapping/pull/1539])
 
 Updates the CatFIM site comparison tool to make the outputs better suited to be loaded into HydroVis. Add % change calculations to site change outputs. 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,14 +4,17 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## v4.8.x.x - 2025-07-15 - [PR#1595](https://github.com/NOAA-OWP/inundation-mapping/pull/1595)
 
-Removes NWM streams that intersect the ocean/lake mask.
+Clips NWM streams at the land/sea mask.
 
 ### Changes
 
 - `data/wbd/`
-    - `clip_vectors_to_wbd.py`: Removes NWM streams that intersect the ocean/lake mask.
-    - `generate_pre_clip_fim_huc8.py`: Corrects a spelling error.
-- `src/bash_variables.env`: Updates `pre_clip_huc_dir` with new folder date.
+    - `clip_vectors_to_wbd.py`: Clips NWM streams at the land/sea mask
+    - `generate_pre_clip_fim_huc8.py`: Corrects a spelling error
+- `src/`
+    - `agreedem.py`: Check if `smogrid` is nodata and exits if so
+    - `bash_variables.env`: Updates `pre_clip_huc_dir` with new folder date
+    - `run_by_branch.sh`: Formatting
 
 <br/><br/>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,22 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.8.6.3 - 2025-07-14 - [PR#1574](https://github.com/NOAA-OWP/inundation-mapping/pull/1574)
 
-Resolves #1551.
+## v4.8.x.x - 2025-07-15 - [PR#1595](https://github.com/NOAA-OWP/inundation-mapping/pull/1595)
+
+Removes NWM streams that intersect the ocean/lake mask.
+
+### Changes
+
+- `data/wbd/`
+    - `clip_vectors_to_wbd.py`: Removes NWM streams that intersect the ocean/lake mask.
+    - `generate_pre_clip_fim_huc8.py`: Corrects a spelling error.
+- `src/bash_variables.env`: Updates `pre_clip_huc_dir` with new folder date.
+
+<br/><br/>
+
+
+## v4.8.6.3 - 2025-07-14 - [PR#1574](https://github.com/NOAA-OWP/inundation-mapping/pull/1574)
 
 This pull requests updates the ngvd_to_navd_ft() function which uses the Vdatum API to convert elevation from NGVD29 to NAVD88 in feet.
 

--- a/src/agreedem.py
+++ b/src/agreedem.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 import argparse
 import os
+import sys
 
 import numpy as np
 import rasterio
 import whitebox
+
+from utils.fim_enums import FIM_exit_codes
 
 
 def agreedem(
@@ -71,6 +74,7 @@ def agreedem(
         vectallo_grid = os.path.join(workspace, 'agree_smogrid_allo.tif')
 
         # Windowed reading/calculating/writing
+        smogrid_valid = False  # Flag to check if smogrid has any data.
         with rasterio.Env():
             with rasterio.open(smo_output, 'w', **smo_profile) as raster:
                 for ji, window in elev.block_windows(1):
@@ -95,6 +99,13 @@ def agreedem(
 
                     # Write out raster
                     raster.write(smogrid_window.astype('float32'), indexes=1, window=window)
+
+                    if len(smogrid_window[smogrid_window != 0]) > 0:
+                        smogrid_valid = True
+
+        # If smogrid has no data, raise an error.
+        if not smogrid_valid:
+            sys.exit(FIM_exit_codes.NO_FLOWLINES_EXIST.value)  # will send a 61 back
 
         # ------------------------------------------------------------------
         # 3. From Hellweger documentation: Compute the vector distance grids

--- a/src/bash_variables.env
+++ b/src/bash_variables.env
@@ -7,7 +7,7 @@ export ALASKA_CRS=EPSG:3338
 
 # NOTE: $inputsDir is defined in Dockerfile
 
-export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250708_Matt/
+export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250515/
 
 export                              input_DEM=${inputsDir}/dems/3dep_dems/10m_5070/20250616/hand_seamless_3dep_dems.vrt
 export                       input_DEM_domain=${inputsDir}/dems/3dep_dems/10m_5070/20250616/DEM_Domain.gpkg

--- a/src/bash_variables.env
+++ b/src/bash_variables.env
@@ -7,7 +7,7 @@ export ALASKA_CRS=EPSG:3338
 
 # NOTE: $inputsDir is defined in Dockerfile
 
-export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250515/
+export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250714_Matt/
 
 export                              input_DEM=${inputsDir}/dems/3dep_dems/10m_5070/20250616/hand_seamless_3dep_dems.vrt
 export                       input_DEM_domain=${inputsDir}/dems/3dep_dems/10m_5070/20250616/DEM_Domain.gpkg

--- a/src/bash_variables.env
+++ b/src/bash_variables.env
@@ -7,7 +7,7 @@ export ALASKA_CRS=EPSG:3338
 
 # NOTE: $inputsDir is defined in Dockerfile
 
-export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250515/
+export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250708_Matt/
 
 export                              input_DEM=${inputsDir}/dems/3dep_dems/10m_5070/20250616/hand_seamless_3dep_dems.vrt
 export                       input_DEM_domain=${inputsDir}/dems/3dep_dems/10m_5070/20250616/DEM_Domain.gpkg

--- a/src/bash_variables.env
+++ b/src/bash_variables.env
@@ -7,7 +7,7 @@ export ALASKA_CRS=EPSG:3338
 
 # NOTE: $inputsDir is defined in Dockerfile
 
-export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250711/
+export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250715/
 
 export                              input_DEM=${inputsDir}/dems/3dep_dems/10m_5070/20250616/hand_seamless_3dep_dems.vrt
 export                       input_DEM_domain=${inputsDir}/dems/3dep_dems/10m_5070/20250616/DEM_Domain.gpkg

--- a/src/bash_variables.env
+++ b/src/bash_variables.env
@@ -7,7 +7,7 @@ export ALASKA_CRS=EPSG:3338
 
 # NOTE: $inputsDir is defined in Dockerfile
 
-export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250515/
+export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250711/
 
 export                              input_DEM=${inputsDir}/dems/3dep_dems/10m_5070/20250616/hand_seamless_3dep_dems.vrt
 export                       input_DEM_domain=${inputsDir}/dems/3dep_dems/10m_5070/20250616/DEM_Domain.gpkg

--- a/src/bash_variables.env
+++ b/src/bash_variables.env
@@ -7,7 +7,7 @@ export ALASKA_CRS=EPSG:3338
 
 # NOTE: $inputsDir is defined in Dockerfile
 
-export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250714_Matt/
+export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250715/
 
 export                              input_DEM=${inputsDir}/dems/3dep_dems/10m_5070/20250616/hand_seamless_3dep_dems.vrt
 export                       input_DEM_domain=${inputsDir}/dems/3dep_dems/10m_5070/20250616/DEM_Domain.gpkg

--- a/src/bash_variables.env
+++ b/src/bash_variables.env
@@ -7,7 +7,7 @@ export ALASKA_CRS=EPSG:3338
 
 # NOTE: $inputsDir is defined in Dockerfile
 
-export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250715/
+export                        pre_clip_huc_dir=${inputsDir}/pre_clip_huc8/20250717/
 
 export                              input_DEM=${inputsDir}/dems/3dep_dems/10m_5070/20250616/hand_seamless_3dep_dems.vrt
 export                       input_DEM_domain=${inputsDir}/dems/3dep_dems/10m_5070/20250616/DEM_Domain.gpkg

--- a/src/run_by_branch.sh
+++ b/src/run_by_branch.sh
@@ -94,6 +94,7 @@ python3 $srcDir/agreedem.py -r $tempCurrentBranchDataDir/flows_grid_boolean_$cur
     -b $agree_DEM_buffer \
     -sm 10 \
     -sh 1000
+    
 ## ADJUST FLOODPLAINS ##
 echo -e $startDiv"Adjust floodplains $hucNumber $current_branch_id"
 echo -e $tempHucDataDir/branch_polygons.gpkg

--- a/src/stream_branches.py
+++ b/src/stream_branches.py
@@ -1178,7 +1178,7 @@ class StreamNetwork(gpd.GeoDataFrame):
         # Find the HUC outlet(s) -- downstream segments that intersect WBD boundary
         sjoin = gpd.sjoin(self_in_wbd, wbd, predicate='crosses')  # this finds both inflows and outflows
 
-        outflows = sjoin[sjoin['to'].isin(self_in_wbd['ID'])]
+        outflows = sjoin[~sjoin['to'].isin(self_in_wbd['ID'])]
 
         # if outflows.empty:
         #     # Alternate method -- when there are no segments downstream of any outlets

--- a/src/stream_branches.py
+++ b/src/stream_branches.py
@@ -1181,8 +1181,12 @@ class StreamNetwork(gpd.GeoDataFrame):
         outflows = sjoin[sjoin['to'].isin(self_not_in_wbd['ID'])]
 
         if outflows.empty:
-            self.write(out_vector_files, index=False)
-            return self
+            # Alternate method -- when there are no segments downstream of any outlets
+            outflows = sjoin[~sjoin['to'].isin(self_in_wbd['ID'])]
+
+            if outflows.empty:
+                self.write(out_vector_files, index=False)
+                return self
 
         # ensure the new stream order has the order from it's highest child
         max_stream_order = (

--- a/src/stream_branches.py
+++ b/src/stream_branches.py
@@ -1172,21 +1172,21 @@ class StreamNetwork(gpd.GeoDataFrame):
         self_in_wbd = gpd.sjoin(self, wbd)
         self_in_wbd = self_in_wbd.drop('index_right', axis=1)
 
-        # Find downstream segments outside of WBD
-        self_not_in_wbd = self_ref[~self_ref['ID'].isin(self_in_wbd['ID'])]
+        # # Find downstream segments outside of WBD
+        # self_not_in_wbd = self_ref[~self_ref['ID'].isin(self_in_wbd['ID'])]
 
         # Find the HUC outlet(s) -- downstream segments that intersect WBD boundary
         sjoin = gpd.sjoin(self_in_wbd, wbd, predicate='crosses')  # this finds both inflows and outflows
 
-        outflows = sjoin[sjoin['to'].isin(self_not_in_wbd['ID'])]
+        outflows = sjoin[sjoin['to'].isin(self_in_wbd['ID'])]
+
+        # if outflows.empty:
+        #     # Alternate method -- when there are no segments downstream of any outlets
+        #     outflows = sjoin[~sjoin['to'].isin(self_in_wbd['ID'])]
 
         if outflows.empty:
-            # Alternate method -- when there are no segments downstream of any outlets
-            outflows = sjoin[~sjoin['to'].isin(self_in_wbd['ID'])]
-
-            if outflows.empty:
-                self.write(out_vector_files, index=False)
-                return self
+            self.write(out_vector_files, index=False)
+            return self
 
         # ensure the new stream order has the order from it's highest child
         max_stream_order = (
@@ -1235,30 +1235,28 @@ class StreamNetwork(gpd.GeoDataFrame):
                     merged_line = list(merged_line.geoms)[0]
                     self.loc[lpid, "geometry"] = merged_line
 
-        self = StreamNetwork(
-            self,
-            branch_id_attribute=branch_id_attribute,
-            attribute_excluded=attribute_excluded,
-            values_excluded=values_excluded,
-        )
+        # self = StreamNetwork(
+        #     self,
+        #     branch_id_attribute=branch_id_attribute,
+        #     attribute_excluded=attribute_excluded,
+        #     values_excluded=values_excluded,
+        # )
 
-        # merges each multi-line string to a singular linestring
-        for lpid, row in tqdm(
-            self.iterrows(), total=len(self), disable=(not verbose), desc="Merging mult-part geoms"
-        ):
-            if isinstance(row.geometry, MultiLineString):
-                merged_line = linemerge(row.geometry)
+        # # merges each multi-line string to a singular linestring
+        # for lpid, row in tqdm(
+        #     self.iterrows(), total=len(self), disable=(not verbose), desc="Merging mult-part geoms"
+        # ):
+        #     if isinstance(row.geometry, MultiLineString):
+        #         merged_line = linemerge(row.geometry)
 
-                # self.loc[lpid,'geometry'] = merged_line
-                try:
-                    self.loc[lpid, "geometry"] = merged_line
-                except ValueError:
-                    merged_line = list(merged_line.geoms)[0]
-                    self.loc[lpid, "geometry"] = merged_line
+        #         # self.loc[lpid,'geometry'] = merged_line
+        #         try:
+        #             self.loc[lpid, "geometry"] = merged_line
+        #         except ValueError:
+        #             merged_line = list(merged_line.geoms)[0]
+        #             self.loc[lpid, "geometry"] = merged_line
 
-        if out_vector_files is not None and not self_not_in_wbd.empty:
-            self.write(out_vector_files, index=False)
-        else:
+        if isinstance(self, gpd.GeoDataFrame):
             # self[branch_id_attribute] = bids
             self = StreamNetwork(
                 self,
@@ -1267,13 +1265,10 @@ class StreamNetwork(gpd.GeoDataFrame):
                 values_excluded=values_excluded,
             )
 
-            if out_vector_files is not None:
-                if verbose:
-                    print("Writing dissolved branches ...")
+        if verbose:
+            print("Writing dissolved branches ...")
 
-                self.write(out_vector_files, index=False)
-
-            self.write(out_vector_files, index=False)
+        self.write(out_vector_files, index=False)
 
         return self
 


### PR DESCRIPTION
Clipping of NWM streams below the HUC can cause issues if a stream exits and re-enters the DEM. The buffering causes the outlet to not extend to the edge of the DEM even if the ultimate outlet does. This results in "reverse flow" during the pit-filling operation which causes flat areas in the filled DEM and the loss of catchments as the DEM-derived reaches deviate from the NWM streams. Removing the clipping of the outlet streams anywhere below the HUC corrects the DEM so that the pit-filling produces the correct result. Resolves #1589.

### Changes

- `data/wbd/`
    - `clip_vectors_to_wbd.py`: Removes clipping from streams below HUC
    - `generate_pre_clip_fim_huc8.py`: Fixes spelling errors
- `src/`
    - `bash_variables.env`: Updates `pre_clip_huc_dir` with new folder date
    - `stream_branches.py`: Updated logic and cleaned up code (deleted commented code blocks)

### Testing
Resolves the issue in HUC 05030106. Previously, the NWM stream that exited and re-entered the DEM below the HUC outlet was clipped, and that clipped stream line was burned into the DEM (left). Now, the stream line is not clipped before it's burned (right).
<img width="1142" height="615" alt="image" src="https://github.com/user-attachments/assets/e01dcf1a-c98d-4dca-b316-d52c9f6e7bd8" />

The resulting GMS catchments are once again complete.
<img width="905" height="656" alt="image" src="https://github.com/user-attachments/assets/0c751c5d-7358-4021-8409-fac3de68ed95" />


### Deployment Plan (For developer use)

_How does the changes affect the product?_
- [ ] Code only?
- [ ] If applicable, has a deployment plan be created with the deployment person/team?
- [x] Require new or adjusted data inputs? Does it have start, end and duration code (in UTC)?
- [x] If new or updated data sets, has the FIM code been updated and tested with the new/adjusted data (subset is fine, but must be a subset of the new data)?
- [x] Require new pre-clip set?
- [ ] Has new or updated python packages?

### Issuer Checklist (For developer use)

_You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code._

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] `pre-commit` hooks were run locally
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [x] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
