### PR TITLE
[1pt] Improve error handling for CatFIM under-inundation caused by elevation disparity

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ Improves the error handling in stage-based CatFIM for instances where the hand_s
 - `tools/catfim/generate_categorical_fim.py`: Added a message that warns when the elevation difference is greater than 5 ft. Added functionality to abort site processing if a negative stage value is encountered. Made the logging more streamlined.
 - `tools/catfim/generate_categorical_fim_mapping.py`:  Added code to exit out of processing when a negative stage value is encountered. Cleaned up vestigial debugging statements.
 - `tools/tools_shared_functions.py`: Improved output logging of `mask_out_lakes()` function.
-
+<br/>
 
 ## v4.8.10.0 - 2025-07-30 - [PR#1561]([https://github.com/NOAA-OWP/inundation-mapping/pull/1554])
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.8.___ - 2025-_____ - [PR#1636]([https://github.com/NOAA-OWP/inundation-mapping/pull/1636])
+## v4.8.10.2 - 2025-08-29 - [PR#1636]([https://github.com/NOAA-OWP/inundation-mapping/pull/1636])
 
 Improves the error handling in stage-based CatFIM for instances where the hand_stage variable is negative and/or there is an elevation disparity that is moderate (5-10 ft) but not high enough to filter out the site completely. These updates catch and flag when there is a negative stage value and prevents further processing of that site.
 
@@ -11,6 +11,8 @@ Improves the error handling in stage-based CatFIM for instances where the hand_s
 - `tools/catfim/generate_categorical_fim.py`: Added a message that warns when the elevation difference is greater than 5 ft. Added functionality to abort site processing if a negative stage value is encountered. Made the logging more streamlined.
 - `tools/catfim/generate_categorical_fim_mapping.py`:  Added code to exit out of processing when a negative stage value is encountered. Cleaned up vestigial debugging statements.
 - `tools/tools_shared_functions.py`: Improved output logging of `mask_out_lakes()` function.
+<br/>
+
 ## v4.8.10.1 - 2025-08-29 - [PR#1622]([https://github.com/NOAA-OWP/inundation-mapping/pull/1622])
 
 Fixes an error that was causing the CatFIM site compare outputs to not load correctly in ArcGIS Pro. The geopackages could be brought into ArcGIS Pro but a data error would occur when trying to open the attribute table because the geometry columns had too much data un them.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,18 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.8.___ - 2025-_____ - [PR#1636]([https://github.com/NOAA-OWP/inundation-mapping/pull/1636])
+
+Improves the error handling in stage-based CatFIM for instances where the hand_stage variable is negative and/or there is an elevation disparity that is moderate (5-10 ft) but not high enough to filter out the site completely. These updates catch and flag when there is a negative stage value and prevents further processing of that site.
+
+### Changes
+- `tools/catfim/README.md`: Updated documentation about CatFIM run commands and added information about CatFIM site compare. 
+- `tools/catfim/ahps_restricted_sites.csv`: Adjusted formatting.
+- `tools/catfim/generate_categorical_fim.py`: Added a message that warns when the elevation difference is greater than 5 ft. Added functionality to abort site processing if a negative stage value is encountered. Made the logging more streamlined.
+- `tools/catfim/generate_categorical_fim_mapping.py`:  Added code to exit out of processing when a negative stage value is encountered. Cleaned up vestigial debugging statements.
+- `tools/tools_shared_functions.py`: Improved output logging of `mask_out_lakes()` function.
+
+
 ## v4.8.10.0 - 2025-07-30 - [PR#1561]([https://github.com/NOAA-OWP/inundation-mapping/pull/1554])
 
 Some minor tweaks that should help the performance of lofi. Also included are a handful of small bugfixes and some cleanup of the CLI defaults.

--- a/tools/catfim/README.md
+++ b/tools/catfim/README.md
@@ -57,7 +57,31 @@ Flow-based example with HUC list:
 - `-mc`, `--past_major_interval_cap`: OPTIONAL: Stage-Based Only. How many feet past major do you want to go for the interval FIMs? of the machine. Defaults to 5.
 - `-step`: 'OPTIONAL: By adding a number here, you may be able to skip levels of processing. The number you submit means it will start at that step. e.g. step of 2 means start at step 2 which for flow based is the creating of tifs and gpkgs. Note: This assumes those previous steps have already been processed and the files are present. Defaults to 0 which means all steps processed.
 - `-me`, `--nwm_metafile`: OPTIONAL: If you have a pre-existing nwm metadata pickle file, you can path to it here.  NOTE: This parameter is for quick debugging only and should not be used in a production mode.
+- `-cv`, `--catfim-version`: OPTIONAL: The version of the code that was used to run the product. This value is included in the output gpkgs and csvs in a field named product_version. If you put in a value here, we will add the phrase CatFIM to the front of it. ie) 2.0 becomes CatFIM, 2.2 becomes CatFIM, etc. Defaults to blank. 
+- `-hv`, `--model-version`: OPTIONAL: The version of the HAND data outputs that was used to run the product. This value is included in the output gpkgs and csvs in a field named model_version. If you put in a value here, we will change dots to underscores only. This should be a HAND version number only and not include the word HAND_ ie) 4.5.11.1 becomes 4_5_11_1, etc. Defaults to blank.
 - `-o`, `--overwrite`: OPTIONAL: Overwrite files.
+
+## Running CatFIM Site Comparison
+### What is CatFIM Site Comparison?
+CatFIM site comparison is an internal tool that allows us to compare multiple different versions of CatFIM outputs. 
+
+
+### Commands
+
+Generating geopackages:
+`python /foss_fim/tools/catfim/catfim_sites_compare.py -p '/data/catfim/hand_4_5_11_1_stage_based/ /data/catfim/fim_4_5_2_11_stage_based/' -o '/test_outputs' -g`
+
+Multiple comparisons:
+`python /foss_fim/tools/catfim/catfim_sites_compare.py -p '/data/catfim/hand_4_5_11_1_stage_based/ /data/catfim/fim_4_5_2_11_stage_based/ /data/catfim/hand_4_5_11_1_flow_based/ /data/catfim/fim_4_5_2_11_flow_based/' -o '/test_outputs'`
+
+
+### Arguments
+
+- `-p`, `--path-list`: Space-delimited list of CatFIM output paths from which to compile sites. Paths MUST have the version number in it (i.e. `4_5_11_1`) because the version number is used to put the versions in sequential order.
+- `-o`, `--output-save-filepath`: Path to where the results files will be saved.
+- `-k`, `--keep-differences-only`: OPTIONAL: Option to keep only changed sites in the comparison files.
+- `-g`, `--generate-geopackages`: OPTIONAL: Option to generate spatial difference maps and a points geopackage for the version comparisons.
+- `-d`, `--debug-mode`: OPTIONAL: Debug mode. Will only iterate through 100 records while generating geopackages.
 
 ## Visualization Tips & Tricks
 

--- a/tools/catfim/ahps_restricted_sites.csv
+++ b/tools/catfim/ahps_restricted_sites.csv
@@ -32,7 +32,6 @@ MCVA3,Historical gauge,both
 NVRN6,Pool elevation thresholds. Disabled at request of MARFC.,stage
 PEPN6,Pool elevation thresholds. Disabled at request of MARFC.,stage
 PRXQ9,Outside U.S.,both
-ONDN6,Inundation issues,stage
 QUTG1,Stage thresholds seem to be based on sea level and not channel thalweg,stage
 RCYF1,Out of Service,both
 RWBW3,Historical gauge,both

--- a/tools/catfim/ahps_restricted_sites.csv
+++ b/tools/catfim/ahps_restricted_sites.csv
@@ -34,6 +34,7 @@ ONDN6,Inundation issues,stage
 PEPN6,Pool elevation thresholds. Disabled at request of MARFC.,stage
 PRXQ9,Outside U.S.,both
 QUTG1,Stage thresholds seem to be based on sea level and not channel thalweg,stage
+QBYQ2,Outside U.S.,both
 RCYF1,Out of Service,both
 RWBW3,Historical gauge,both
 SMSV2,Point not in AHPS,both

--- a/tools/catfim/ahps_restricted_sites.csv
+++ b/tools/catfim/ahps_restricted_sites.csv
@@ -30,6 +30,7 @@ KLNQ9,Outside U.S.,both
 LAMF1,Stage thresholds seem to be based on sea level and not channel thalweg.,stage
 MCVA3,Historical gauge,both
 NVRN6,Pool elevation thresholds. Disabled at request of MARFC.,stage
+ONDN6,Inundation issues,stage
 PEPN6,Pool elevation thresholds. Disabled at request of MARFC.,stage
 PRXQ9,Outside U.S.,both
 QUTG1,Stage thresholds seem to be based on sea level and not channel thalweg,stage

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -591,8 +591,8 @@ def iterate_through_huc_stage_based(
 
             for lid in nws_lids:
 
-                # debugging
-                # if lid.upper() not in ['PNTA3', 'PWBA3']:
+                # # Debugging mode:
+                # if lid.upper() not in ['PACI1']:
                 #    continue
 
                 # TODO: Oct 2024, yes. this is goofy but temporary
@@ -804,8 +804,10 @@ def iterate_through_huc_stage_based(
                 # At this point we have at least one valid stage/category
                 # cyle through on the stages that are valid
                 # This are not interval values
+
+                negative_hand_stage = False # initialize value
+
                 for idx, stage_row in stage_values_df.iterrows():
-                    # MP_LOG.lprint(f"{huc_lid_id}: Magnitude is {category}")
                     # Pull stage value and confirm it's valid, then process
 
                     category = stage_row['stage_name']
@@ -814,6 +816,10 @@ def iterate_through_huc_stage_based(
                     # messages already included in the stage_warning_msg above
                     if stage_value == -1:
                         continue
+
+                    if negative_hand_stage == True:
+                        MP_LOG.lprint(f"{huc_lid_id}: Skipping remaining stages because a negative hand stage was already found")
+                        continue  # no need to keep going if we already have a negative hand stage
 
                     MP_LOG.trace(f"About to create tifs for {huc_lid_id} : {category} : {stage_value}")
 
@@ -843,10 +849,13 @@ def iterate_through_huc_stage_based(
                         child_log_file_prefix,
                     )
 
-                    # If we get a message back, then something went wrong with the site adn we need to
+                    # If we get a message back, then something went wrong with the site and we need to
                     # remove it as a valid site
-
                     all_messages += messages
+
+                    # Mark site as invalid if any stage results in a negative hand stage value
+                    if hand_stage < 0:                    
+                        negative_hand_stage = True
 
                     # Extra metadata for alternative CatFIM technique.
                     # TODO Revisit because branches complicate things
@@ -868,8 +877,17 @@ def iterate_through_huc_stage_based(
                         mapping_lid_directory, lid + '_' + category_key + '_extent.tif'
                     )
                     if os.path.exists(stage_file_name) == False:
-                        # somethign failed and we didn't get a rolled up extent file, so we need to reject the stage
+                        # something failed and we didn't get a rolled up extent file, so we need to reject the stage
                         stage_values_df.at[idx, 'stage_value'] = -1
+
+                # If any stage resulted in a negative hand stage value, mark site as invalid.
+                # because this indicates that there is an elevation disparity that will
+                # likely result in bad mapping.
+                if negative_hand_stage == True:
+                    msg = ': One or more stages resulted in a negative hand stage value'
+                    all_messages.append(lid + msg)
+                    MP_LOG.warning(huc_lid_id + msg)
+                    continue
 
                 # So, we might have an MP inside an MP
                 # let's merge what we have at this point, before we go into another MP

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -753,11 +753,12 @@ def iterate_through_huc_stage_based(
                 elevation_diff = lid_usgs_elev - (lid_altitude * 0.3048)
                 diff_rounded = round(elevation_diff, 2)
 
-                # Log elevation difference warnings (for now, maybe remove later)
-                if elevation_diff > 0:
+                if elevation_diff > 0:  # Log elevation difference warnings (for now, maybe remove later)
                     MP_LOG.lprint(f"{huc_lid_id}: USGS elev is higher than HAND elev by {diff_rounded} ft")
                 elif elevation_diff < 0:
-                    MP_LOG.lprint(f"{huc_lid_id}: USGS elev is lower than HAND elev by {abs(diff_rounded)} ft")
+                    MP_LOG.lprint(
+                        f"{huc_lid_id}: USGS elev is lower than HAND elev by {abs(diff_rounded)} ft"
+                    )
 
                 if abs(elevation_diff) > 10:
                     msg = ':Large discrepancy in elevation estimates from gage and HAND'

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -821,7 +821,7 @@ def iterate_through_huc_stage_based(
 
                     if negative_hand_stage == True:
                         MP_LOG.lprint(
-                            f"{huc_lid_id}: Skipping remaining stages because a negative hand stage was already found"
+                            f"{huc_lid_id}: {category} : {stage_value} Skipping remaining stages because a negative hand stage was already found"
                         )
                         continue  # no need to keep going if we already have a negative hand stage
 

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -433,23 +433,18 @@ def update_sites_mapping_status(output_mapping_dir, catfim_sites_file_path, catf
         for ind, row in sites_gdf.iterrows():
             ahps_id = row['ahps_lid']
             status_val = row['status']
-
+            # If the ahps_id is not in the valid list, then mapped should be "no" and status updated
             if ahps_id not in valid_ahps_ids:
-
                 sites_gdf.at[ind, 'mapped'] = 'no'
                 FLOG.warning(
-                    f"Mapped status was changed to no for {ahps_id} because no inundation GPKGs found."
+                    f"{ahps_id} : Mapped status was changed to no because no inundation GPKGs found."
                 )
-
                 if status_val is None or status_val == "" or status_val == "Good":
                     sites_gdf.at[ind, 'status'] = 'Site resulted with no valid inundated files'
-
                 else:
                     if status_val.startswith("---") == True:
                         status_val = status_val[3:]  # remove the "---" from the status
-
-                    sites_gdf.at[ind, 'status'] = status_val + ', site resulted with no valid inundated files'
-
+                    sites_gdf.at[ind, 'status'] = status_val
                 continue
                 # It is safe to assume a status message for invalid ones already exist
 
@@ -753,7 +748,8 @@ def iterate_through_huc_stage_based(
                 elevation_diff = lid_usgs_elev - (lid_altitude * 0.3048)
                 diff_rounded = round(elevation_diff, 2)
 
-                if elevation_diff > 0:  # Log elevation difference warnings (for now, maybe remove later)
+                # Log elevation difference information - not an error, just for reference (maybe remove later)
+                if elevation_diff > 0:
                     MP_LOG.lprint(f"{huc_lid_id}: USGS elev is higher than HAND elev by {diff_rounded} ft")
                 elif elevation_diff < 0:
                     MP_LOG.lprint(
@@ -823,15 +819,11 @@ def iterate_through_huc_stage_based(
                     category = stage_row['stage_name']
                     stage_value = stage_row['stage_value']
 
-                    # messages already included in the stage_warning_msg above
-                    if stage_value == -1:
+                    if stage_value == -1:  # messages already included in the stage_warning_msg above
                         continue
 
-                    if negative_hand_stage == True:
-                        MP_LOG.lprint(  # eventually we can remove this, but it's helpful for now since it's new
-                            f"{huc_lid_id}: {category} : {stage_value} Skipping remaining stages because a negative hand stage was found"
-                        )
-                        continue  # no need to keep going if we already have a negative hand stage
+                    if negative_hand_stage == True:  # if we already had a negative hand stage, skip remaining stages
+                        continue
 
                     MP_LOG.trace(f"About to create tifs for {huc_lid_id} : {category} : {stage_value}")
 
@@ -896,7 +888,7 @@ def iterate_through_huc_stage_based(
                 # because this indicates that there is an elevation disparity that will
                 # likely result in bad mapping.
                 if negative_hand_stage == True:
-                    msg = ':One or more stages resulted in a negative hand stage value'
+                    msg = ': Discrepancy in elevation estimates from gage and HAND caused negative HAND stage value'
                     all_messages.append(lid + msg)
                     MP_LOG.warning(huc_lid_id + msg)
                     continue
@@ -1991,7 +1983,7 @@ if __name__ == '__main__':
         help='OPTIONAL: The version of the HAND data outputs that was used to run the product.'
         ' This value is included in the output gpkgs and csvs in a field named model_version.'
         ' If you put in a value here, we will change dots to underscores only.'
-        ' This shoudl be a HAND version number only and not include the word HAND_'
+        ' This should be a HAND version number only and not include the word HAND_'
         ' ie) 4.5.11.1 becomes 4_5_11_1, etc. Defaults to blank',
         required=False,
         default="",

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -758,7 +758,9 @@ def iterate_through_huc_stage_based(
                     continue
                 elif abs(elevation_diff) > 5:
                     diff_rounded = round(elevation_diff, 1)
-                    msg = f':Moderate discrepancy ({diff_rounded} ft) in elevation estimates from gage and HAND'
+                    msg = (
+                        f':Moderate discrepancy ({diff_rounded} ft) in elevation estimates from gage and HAND'
+                    )
                     all_messages.append(lid + msg)
                     MP_LOG.warning(huc_lid_id + msg)
                     # We are not continuing, just a warning
@@ -805,7 +807,7 @@ def iterate_through_huc_stage_based(
                 # cyle through on the stages that are valid
                 # This are not interval values
 
-                negative_hand_stage = False # initialize value
+                negative_hand_stage = False  # initialize value
 
                 for idx, stage_row in stage_values_df.iterrows():
                     # Pull stage value and confirm it's valid, then process
@@ -818,7 +820,9 @@ def iterate_through_huc_stage_based(
                         continue
 
                     if negative_hand_stage == True:
-                        MP_LOG.lprint(f"{huc_lid_id}: Skipping remaining stages because a negative hand stage was already found")
+                        MP_LOG.lprint(
+                            f"{huc_lid_id}: Skipping remaining stages because a negative hand stage was already found"
+                        )
                         continue  # no need to keep going if we already have a negative hand stage
 
                     MP_LOG.trace(f"About to create tifs for {huc_lid_id} : {category} : {stage_value}")
@@ -854,7 +858,7 @@ def iterate_through_huc_stage_based(
                     all_messages += messages
 
                     # Mark site as invalid if any stage results in a negative hand stage value
-                    if hand_stage < 0:                    
+                    if hand_stage < 0:
                         negative_hand_stage = True
 
                     # Extra metadata for alternative CatFIM technique.

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -751,13 +751,20 @@ def iterate_through_huc_stage_based(
                 # Check for large discrepancies between the elevation values from WRDS and HAND.
                 #   Otherwise this causes bad mapping.
                 elevation_diff = lid_usgs_elev - (lid_altitude * 0.3048)
+                diff_rounded = round(elevation_diff, 2)
+
+                # Log elevation difference warnings (for now, maybe remove later)
+                if elevation_diff > 0:
+                    MP_LOG.lprint(f"{huc_lid_id}: USGS elev is higher than HAND elev by {diff_rounded} ft")
+                elif elevation_diff < 0:
+                    MP_LOG.lprint(f"{huc_lid_id}: USGS elev is lower than HAND elev by {abs(diff_rounded)} ft")
+
                 if abs(elevation_diff) > 10:
                     msg = ':Large discrepancy in elevation estimates from gage and HAND'
                     all_messages.append(lid + msg)
                     MP_LOG.warning(huc_lid_id + msg)
                     continue
                 elif abs(elevation_diff) > 5:
-                    diff_rounded = round(elevation_diff, 1)
                     msg = (
                         f':Moderate discrepancy ({diff_rounded} ft) in elevation estimates from gage and HAND'
                     )

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -761,8 +761,8 @@ def iterate_through_huc_stage_based(
                     msg = (
                         f':Moderate discrepancy ({diff_rounded} ft) in elevation estimates from gage and HAND'
                     )
-                    all_messages.append(lid + msg)
                     MP_LOG.warning(huc_lid_id + msg)
+                    # all_messages.append(lid + msg) # just print as a warning for now (not appending to message)
                     # We are not continuing, just a warning
 
                 # This function sometimes is called within a MP but sometimes not.
@@ -820,8 +820,8 @@ def iterate_through_huc_stage_based(
                         continue
 
                     if negative_hand_stage == True:
-                        MP_LOG.lprint(
-                            f"{huc_lid_id}: {category} : {stage_value} Skipping remaining stages because a negative hand stage was already found"
+                        MP_LOG.lprint(  # eventually we can remove this, but it's helpful for now since it's new
+                            f"{huc_lid_id}: {category} : {stage_value} Skipping remaining stages because a negative hand stage was found"
                         )
                         continue  # no need to keep going if we already have a negative hand stage
 
@@ -888,7 +888,7 @@ def iterate_through_huc_stage_based(
                 # because this indicates that there is an elevation disparity that will
                 # likely result in bad mapping.
                 if negative_hand_stage == True:
-                    msg = ': One or more stages resulted in a negative hand stage value'
+                    msg = ':One or more stages resulted in a negative hand stage value'
                     all_messages.append(lid + msg)
                     MP_LOG.warning(huc_lid_id + msg)
                     continue
@@ -1061,7 +1061,7 @@ def iterate_through_huc_stage_based(
 
                     if stage_warning_msg == "":  # does not mean the lid is good.
                         all_messages.append(lid + ':Good')
-                    else:  # we will leave the ":---" on it for now if it is does have a warnning message
+                    else:  # we will leave the ":---" on it for now if it is does have a warning message
                         all_messages.append(lid + stage_warning_msg)
                         MP_LOG.warning(huc_lid_id + stage_warning_msg)
                 else:

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -756,6 +756,12 @@ def iterate_through_huc_stage_based(
                     all_messages.append(lid + msg)
                     MP_LOG.warning(huc_lid_id + msg)
                     continue
+                elif abs(elevation_diff) > 5:
+                    diff_rounded = round(elevation_diff, 1)
+                    msg = f':Moderate discrepancy ({diff_rounded} ft) in elevation estimates from gage and HAND'
+                    all_messages.append(lid + msg)
+                    MP_LOG.warning(huc_lid_id + msg)
+                    # We are not continuing, just a warning
 
                 # This function sometimes is called within a MP but sometimes not.
                 # So, we might have an MP inside an MP

--- a/tools/catfim/generate_categorical_fim.py
+++ b/tools/catfim/generate_categorical_fim.py
@@ -822,7 +822,9 @@ def iterate_through_huc_stage_based(
                     if stage_value == -1:  # messages already included in the stage_warning_msg above
                         continue
 
-                    if negative_hand_stage == True:  # if we already had a negative hand stage, skip remaining stages
+                    if (
+                        negative_hand_stage == True
+                    ):  # if we already had a negative hand stage, skip remaining stages
                         continue
 
                     MP_LOG.trace(f"About to create tifs for {huc_lid_id} : {category} : {stage_value}")

--- a/tools/catfim/generate_categorical_fim_mapping.py
+++ b/tools/catfim/generate_categorical_fim_mapping.py
@@ -316,77 +316,57 @@ def produce_inundated_branch_tif(
         file_name = lid + '_' + category_key + '_extent_' + huc + '_' + branch
         output_tif = os.path.join(lid_directory, file_name + '.tif')
 
-        # MP_LOG.lprint("+++++++++++++++++++++++")
-        # MP_LOG.lprint(f"... At the start of producing a tif for {file_name}")
-        # MP_LOG.trace(locals())
-        # MP_LOG.lprint(f"output_tif is {output_tif} (if it is valid)")
-        # MP_LOG.trace("+++++++++++++++++++++++")
-
-        # both of these have a nodata value of 0 (well.. not by the image but by cell values)
+        # Open the REM and Catchments rasters (both have a nodata value of 0)
         rem_src = rasterio.open(rem_path)
         catchments_src = rasterio.open(catchments_path)
         rem_array = rem_src.read(1)
         catchments_array = catchments_src.read(1)
 
-        # TEMP: look at a catchment and rem from the same branch.
-        # Then look at a stage based 4.4.0.0 for this huc and see if we can figure out the
-        # intended results. Are we trying for a image that makes all values below the hand stage
-        # value to be a value (kinda like a 1 and 0 ?)
-
         # Use numpy.where operation to reclassify rem_path on the condition that the pixel values
         #   are <= to hand_stage and the catchments value is in the hydroid_list.
-
         reclass_rem_array = np.where((rem_array <= hand_stage) & (rem_array != rem_src.nodata), 1, 0).astype(
             'int16'
         )
 
-        # MP_LOG.trace(f"min of reclass_rem_array (min is {np.min(reclass_rem_array)} and max is {np.max(reclass_rem_array)}")
-
         # The catchment_array has hydroid that have had the first 4 chars cut off
         # we need to the same for the hydroid's from the hydroid_list
-        # clipped_hydroid_list = [str(x[-4:]) for x in hydroid_list]
         clipped_hydroid_list = []
         for i in hydroid_list:
             clipped_str = str(i)[-4:]
             clipped_hydroid_list.append(int(clipped_str))
 
+        # Create a mask of the catchments_array where the values are in the clipped_hydroid_list
         hydroid_mask = np.isin(catchments_array, clipped_hydroid_list)
 
-        # MP_LOG.trace(f"max of hydroid_mask {np.max(hydroid_mask)}")
-
+        # Create a target array where the catchments_array is not nodata and the hydroid_mask is True
         target_catchments_array = np.where(
             ((hydroid_mask == True) & (catchments_array != catchments_src.nodata)), 1, 0
         ).astype('int16')
 
-        # MP_LOG.trace(f"min of target_catchments_array (min is {np.min(target_catchments_array)} and max is {np.max(target_catchments_array)}")
-
+        # Mask the reclass_rem_array with the target_catchments_array
         masked_reclass_rem_array = np.where(
             ((reclass_rem_array >= 1) & (target_catchments_array >= 1)), 1, 0
         ).astype('int16')
 
-        # MP_LOG.trace(f"min of masked_reclass_rem_array (min is {np.min(masked_reclass_rem_array)} and max is {np.max(masked_reclass_rem_array)}")
+        ## Debugging:
 
-        # change it all to either 1 or 0 (one being inundated)
+        # Change it all to either 1 or 0 (one being inundated)
         # masked_reclass_rem_array[np.where(masked_reclass_rem_array <= 0)] = 0
         # masked_reclass_rem_array[np.where(masked_reclass_rem_array > 0)] = 1
 
         # Save resulting array to new tif with appropriate name. ie) brdc1_record_extent_18060005.tif
         # to our mapping/huc/lid site
-        # No cells were inundated which is common. Lots of branches don't inundate as they are out of the extent area
-        is_all_zero = np.all(masked_reclass_rem_array == 0)
 
+        # MP_LOG.trace(f"min of reclass_rem_array (min is {np.min(reclass_rem_array)} and max is {np.max(reclass_rem_array)}")
+        # MP_LOG.trace(f"max of hydroid_mask {np.max(hydroid_mask)}")
+        # MP_LOG.trace(f"min of target_catchments_array (min is {np.min(target_catchments_array)} and max is {np.max(target_catchments_array)}")
+        # MP_LOG.trace(f"min of masked_reclass_rem_array (min is {np.min(masked_reclass_rem_array)} and max is {np.max(masked_reclass_rem_array)}")
         # MP_LOG.lprint(f"{huc}: masked_reclass_rem_array, is_all_zero is {is_all_zero} for {rem_path}")
 
-        # if not is_all_zero:
-        # if is_all_zero == False: # this logic didn't let ANY files get saved
-        #    'is False' means that the object does not exist and not that it really equals the value of False
+        # Check if no cells were inundated (branches don't inundate as they are out of the extent area)
+        is_all_zero = np.all(masked_reclass_rem_array == 0)
+
         if is_all_zero == False:
-            # output_tif = os.path.join(
-            #     lid_directory, lid + '_' + category_key + '_extent_' + huc + '_' + branch + '.tif'
-            # )
-            # File may or may not exist
-            # if os.path.exists(output_tif):
-            # MP_LOG.lprint(f" +++ Branch output_tif is {output_tif}")
             with rasterio.Env():
                 profile = rem_src.profile
                 profile.update(dtype=rasterio.uint8)
@@ -396,14 +376,7 @@ def produce_inundated_branch_tif(
                 # masked_reclass_rem_array[masked_reclass_rem_array == profile["nodata"]] = 0
 
                 with rasterio.open(output_tif, 'w', **profile) as dst:
-                    # dst.nodata = 0
                     dst.write(masked_reclass_rem_array, 1)
-        
-        elif is_all_zero == True:
-            # Print the 
-        
-        # else:  # commented out as there are so many of these
-        #     MP_LOG.trace(f"{file_name} : inundation was all zero cells")
 
     except Exception:
         MP_LOG.error(f"{huc} : {lid} Error producing inundation maps with stage")

--- a/tools/catfim/generate_categorical_fim_mapping.py
+++ b/tools/catfim/generate_categorical_fim_mapping.py
@@ -77,8 +77,8 @@ def produce_stage_based_lid_tifs(
 
     # If hand_stage is negative, write message and exit out
     if hand_stage < 0:
-        msg = f":negative hand stage ({hand_stage} mm), no inundation"
-        messages.append(lid + msg)
+        msg = f": Negative hand stage ({hand_stage} mm), no inundation"
+        # messages.append(lid + msg)
         MP_LOG.warning(huc_lid_cat_id + msg)
         return messages, hand_stage, datum_adj_wse, datum_adj_wse_m
 

--- a/tools/catfim/generate_categorical_fim_mapping.py
+++ b/tools/catfim/generate_categorical_fim_mapping.py
@@ -77,7 +77,7 @@ def produce_stage_based_lid_tifs(
 
     # If hand_stage is negative, write message and exit out
     if hand_stage < 0:
-        msg = f": Negative hand stage ({hand_stage} mm), no inundation"
+        msg = f": Negative hand stage ({hand_stage} mm) detected, no inundation possible"
         # messages.append(lid + msg)
         MP_LOG.warning(huc_lid_cat_id + msg)
         return messages, hand_stage, datum_adj_wse, datum_adj_wse_m
@@ -254,7 +254,7 @@ def produce_stage_based_lid_tifs(
 
         # Mask out the lakes from the inundation array
         summed_masked_array, mask_status = mask_out_lakes(summed_array, huc, zero_branch_src, fim_dir)
-        MP_LOG.lprint(mask_status)
+        MP_LOG.trace(f"{huc_lid_cat_id}: {mask_status}")
 
         del zero_branch_array, summed_array  # Clean up
 

--- a/tools/catfim/generate_categorical_fim_mapping.py
+++ b/tools/catfim/generate_categorical_fim_mapping.py
@@ -75,6 +75,13 @@ def produce_stage_based_lid_tifs(
     hand_stage_m = datum_adj_wse_m - lid_usgs_elev
     hand_stage = round(hand_stage_m * 1000)  # convert to mm to match HAND
 
+    # If hand_stage is negative, write message and exit out
+    if hand_stage < 0:
+        msg = f":negative hand stage ({hand_stage} mm), no inundation"
+        messages.append(lid + msg)
+        MP_LOG.warning(huc_lid_cat_id + msg)
+        return messages, hand_stage, datum_adj_wse, datum_adj_wse_m
+
     # If no segments, write message and exit out
     if not segments or len(segments) == 0:
         msg = ':missing nwm segments'
@@ -391,6 +398,10 @@ def produce_inundated_branch_tif(
                 with rasterio.open(output_tif, 'w', **profile) as dst:
                     # dst.nodata = 0
                     dst.write(masked_reclass_rem_array, 1)
+        
+        elif is_all_zero == True:
+            # Print the 
+        
         # else:  # commented out as there are so many of these
         #     MP_LOG.trace(f"{file_name} : inundation was all zero cells")
 

--- a/tools/tools_shared_functions.py
+++ b/tools/tools_shared_functions.py
@@ -159,7 +159,9 @@ def mask_out_lakes(input_array, huc, raster_src, fim_run_dir):
 
     if not os.path.exists(preclip_lakes_path):
         # If the lakes shapefile does not exist, return the input array without masking
-        mask_status = f'No lakes shapefile found at {preclip_lakes_path}, returning original array without lake masking'
+        mask_status = (
+            f'No lakes shapefile found at {preclip_lakes_path}, returning original array without lake masking'
+        )
         return input_array, mask_status
     else:
         # Read in the lakes shapefile

--- a/tools/tools_shared_functions.py
+++ b/tools/tools_shared_functions.py
@@ -159,7 +159,7 @@ def mask_out_lakes(input_array, huc, raster_src, fim_run_dir):
 
     if not os.path.exists(preclip_lakes_path):
         # If the lakes shapefile does not exist, return the input array without masking
-        mask_status = f'HUC {huc}: No lakes shapefile found, returning original array'
+        mask_status = f'No lakes shapefile found at {preclip_lakes_path}, returning original array without lake masking'
         return input_array, mask_status
     else:
         # Read in the lakes shapefile
@@ -175,7 +175,7 @@ def mask_out_lakes(input_array, huc, raster_src, fim_run_dir):
 
         # Set values within the lake geometry to zero, masking them out of the FIM
         masked_array = input_array * lake_mask
-        mask_status = f'HUC {huc}: Lakes shapefile available, masked out lake'
+        mask_status = 'Lakes shapefile available, masked out lake'
         return masked_array, mask_status
 
 


### PR DESCRIPTION
Resolves issue #1635. 

This pull request improves the error handling in stage-based CatFIM for instances where the hand_stage variable is negative and/or there is an elevation disparity that is moderate (5-10 ft) but not high enough to filter out the site completely.

Action and Minor flood stages for site PACI1 were not inundating because the hand_stage variable was negative. This was because the adjusted water surface elevation (datum_adj_wse_m) for Action and Minor stages was lower than the LID elevation value (lid_usgs_elev), which was causing them to not map (and also causing Moderate and Record stages to be under-inundated). 

These updates catch and flag when there is a negative stage value and prevents further processing of that site. The logic behind this is that a site where there is enough of an elevation disparity to cause a negative stage value should not be trusted at the higher (non-negative) stages either. 
 
### Changes
- `tools/catfim/README.md`: Updated documentation about CatFIM run commands and added information about CatFIM site compare. 
- `tools/catfim/ahps_restricted_sites.csv`: Adjusted formatting.
- `tools/catfim/generate_categorical_fim.py`: Added a message that warns when the elevation difference is greater than 5 ft. Added functionality to abort site processing if a negative stage value is encountered. Made the logging more streamlined.
- `tools/catfim/generate_categorical_fim_mapping.py`:  Added code to exit out of processing when a negative stage value is encountered. Cleaned up vestigial debugging statements.
- `tools/tools_shared_functions.py`: Improved output logging of `mask_out_lakes()` function.

---------------------------------------------------------------
### Testing
Generally, you do not copy this part into the ChangeLog. These are some quick notes on what you did test and/or notes for the reviewer to help with their review testing.

---------------------------------------------------------------
### Deployment Plan (For FIM developers use)
- **Does the change impact inputs, docker or python packages?**
    - [ ] Yes
    - [x] No  (f no.. skip the rest of the Deployment Plan section)
    
-  **If you are not a FIM dev team member:  Please let us know what you need and we can help with it.**

-  **If you are a FIM Dev team member:** 
    -  Please work with the DevOps team and do not just go ahead and do it without some co-ordination.
    -  Copy where you can, assign where you can not, and it is your responsibility to ensure it is done. Please ensure it is completed before the PR is merged. 
    
    - Has new or updated python packages, PipFile, Pipefile.lock or Dockerfile changes?  DevOps can help or take care of it if you want. Just need to know if it is required.
       - [ ] Yes
       - [ ] No
    - Require new or adjusted data inputs? Does it have a way to version (folder or file dates)?
       - [ ] No
       - [ ] Yes
           -  Require new pre-clip set or any other data reloads, such as DEMS, osm, etc. ie.. pre-requisite re-data upstream of your input  changes.
                - [ ] Yes
                - [ ] No
           -  Has the inputs been copied/exist in all five enviros:
                 - [ ] FIM EFS  
                 - [ ] FIM S3
                 - [ ] ESIP
                 - [ ] Dev1
                 - [ ] UCS2
            
- Please use caution in removing older version unless it is at least two versions ago.  Confirm with DevOps if cleanup might be involved.

- If new or updated data sets, has the FIM code, including running fim_pipeline.sh, been updated and tested with the new/adjusted data? You can dev test against subsets if you like.
    - [ ] Yes

### Notes to DevOps Team or others:
Please add any notes that are helpful for us to make sure it is all done correctly. Do not put actual server names or full true paths, just shortcut paths like 'efs..../inputs/,  or 'dev1....inputs', etc.



---------------------------------------------------------------
### Issuer Checklist (For developer use)

You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code.

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [ ] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] `pre-commit` hooks were run locally
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [x] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

---------------------------------------------------------------
### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
