### PR TITLE
PR [1pt]: Fix Christmas Bug

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.9.x.x - 2025-12-16 - [PR#1716]([https://github.com/NOAA-OWP/inundation-mapping/pull/1716])
+## v4.9.5.0 - 2026-01-08 - [PR#1716]([https://github.com/NOAA-OWP/inundation-mapping/pull/1716])
 
 This PR fixes issue #1700 .
 This PR resolves inconsistencies in Discharge (m3s-1) values in the `src_full_crossswalked` table observed when rerunning calibration scripts (`tools/rerun_calibration.py`)
@@ -13,6 +13,9 @@ After running FIM pipeline with all calibration steps off, each calibration scri
 - **The Impact:** This rounding altered the "default slope" value. When subsequent processes (like rerunning calibration or resetting hydrotable) reloaded this data, they used the rounded slope rather than the actual initial slope. This small delta propagated through the calculations, resulting in different final discharge outputs.
 ### Changes
 - `src/longitudinal_flow_adjustment.py`: Ensure that slope values maintain precision when saving back to `src_full_crossswalked`.
+- `src/process_branch.sh`: Minor fix as it missed catching errors 65 due to syntax error.
+<br/>
+
 ## v4.9.4.1 - 2026-01-08 [PR#1723](https://github.com/NOAA-OWP/inundation-mapping/pull/1723)
 
 Fixes branch error code logging and updates formatting and a spelling error.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,20 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.9.x.x - 2025-12-16 - [PR#1716]([https://github.com/NOAA-OWP/inundation-mapping/pull/1716])
+
+This PR fixes issue #1700 .
+This PR resolves inconsistencies in Discharge (m3s-1) values in the `src_full_crossswalked` table observed when rerunning calibration scripts (`tools/rerun_calibration.py`)
+Initially, after running FIM pipeline and then rerunning the calibration, the slope values appear identical, but the Discharge (m3s-1) differs.
+
+- Root cause:
+After running FIM pipeline with all calibration steps off, each calibration script was then run separately. We identified that the `src/longitudinal_flow_adjustment.py` script was saving the `src_full_crossswalked` CSV by rounding all columns to 5 decimal places (line 323).
+
+- **The Impact:** This rounding altered the "default slope" value. When subsequent processes (like rerunning calibration or resetting hydrotable) reloaded this data, they used the rounded slope rather than the actual initial slope. This small delta propagated through the calculations, resulting in different final discharge outputs.
+### Changes
+- `src/longitudinal_flow_adjustment.py`: Ensure that slope values maintain precision when saving back to `src_full_crossswalked`.
+<br/>
+
 ## v4.9.2.1 - 2025-12-05 [PR#1663](https://github.com/NOAA-OWP/inundation-mapping/pull/1663)
 
 This update adds data predownload functionality to CatFIM so it can create categorical FIM maps for sites that don't have thresholds available in the WRDS API. There is also a new default behavior for CatFIM: instead of hitting the WRDS API for each run, the CatFIM code defaults to using pre-downloaded input thresholds and metadata. However, there is still the option to download the thresholds and metadata during the CatFIM run (which was previously the default).

--- a/src/longitudinal_flow_adjustment.py
+++ b/src/longitudinal_flow_adjustment.py
@@ -321,7 +321,7 @@ def filter_longitudinal_discharge_jitters(huc_dir, huc):
             mask = (src_df_merged['LakeID'] > 0) & (src_df_merged['Discharge (m3s-1)_lake'].notnull())
             src_df.loc[mask, 'Discharge (m3s-1)'] = src_df_merged.loc[mask, 'Discharge (m3s-1)_lake']
             # Preserve slope columns exactly as-is
-            slope_cols = ['SLOP', 'default_SLOPE']
+            slope_cols = ['SLOPE', 'default_SLOPE']
             slope_backup = src_df[slope_cols].copy()
             # Round all columns
             src_df = src_df.round(5)

--- a/src/longitudinal_flow_adjustment.py
+++ b/src/longitudinal_flow_adjustment.py
@@ -320,7 +320,13 @@ def filter_longitudinal_discharge_jitters(huc_dir, huc):
             # Update src_df where LakeID > 0 and Stage matches
             mask = (src_df_merged['LakeID'] > 0) & (src_df_merged['Discharge (m3s-1)_lake'].notnull())
             src_df.loc[mask, 'Discharge (m3s-1)'] = src_df_merged.loc[mask, 'Discharge (m3s-1)_lake']
+            # Preserve slope columns exactly as-is
+            slope_cols = ['SLOP', 'default_SLOPE']
+            slope_backup = src_df[slope_cols].copy()
+            # Round all columns
             src_df = src_df.round(5)
+            # Restore slope precision
+            src_df[slope_cols] = slope_backup
 
             # Set Hydraulic properties of original stages with discharge = 0 back to 0
             src_df.loc[Q0_mask, 'Discharge (m3s-1)'] = 0

--- a/src/process_branch.sh
+++ b/src/process_branch.sh
@@ -43,7 +43,7 @@ do
         err_exists=1
         echo "***** Branch has no crosswalks *****"
         rm -rf $tempHucDataDir/branches/$branchId/
-    elif [ $code -eq 65]; then
+    elif [ $code -eq 65 ]; then
         echo
         err_exists=1
         echo "***** Too many HydroIDs or a HydroID with more than 8 digits in gw catchments to convert to Int16 *****"


### PR DESCRIPTION
This PR fixes issue #1700 .
This PR resolves inconsistencies in Discharge (m3s-1) values in the `src_full_crossswalked` table observed when rerunning calibration scripts (`tools/rerun_calibration.py`)
Initially, after running FIM pipeline and then rerunning the calibration, the slope values appear identical, but the Discharge (m3s-1) differs.

- Root cause:
After running FIM pipeline with all calibration steps off, each calibration script was then run separately. We identified that the `src/longitudinal_flow_adjustment.py` script was saving the `src_full_crossswalked` CSV by rounding all columns to 5 decimal places (line 323).

- **The Impact:** This rounding altered the "default slope" value. When subsequent processes (like rerunning calibration or resetting hydrotable) reloaded this data, they used the rounded slope rather than the actual initial slope. This small delta propagated through the calculations, resulting in different final discharge outputs.

### Changes
- `src/longitudinal_flow_adjustment.py`: Ensure that slope values maintain precision when saving back to `src_full_crossswalked`.


---------------------------------------------------------------
### Testing
**Test scenarios:**

- Scenario A:

1. Run fim_pipeline with all calibration routines active.

2. Rerun calibration (`tools/rerun_calibration.py`).

→ Result: same discharge values as initial run.

- Scenario B:

1. Run fim_pipeline.

2. Rerun calibration with ai_toggle=0.

3. Run fim_pipeline with ai_toggle=0.
→ Result: same discharge values for runs 2 and 3.
---------------------------------------------------------------
### Deployment Plan (For FIM developers use)
- **Does the change impact inputs, docker or python packages?**
    - [ ] Yes
    - [x] No  (f no.. skip the rest of the Deployment Plan section)
    
-  **If you are not a FIM dev team member:  Please let us know what you need and we can help with it.**

-  **If you are a FIM Dev team member:** 
    -  Please work with the DevOps team and do not just go ahead and do it without some co-ordination.
    -  Copy where you can, assign where you can not, and it is your responsibility to ensure it is done. Please ensure it is completed before the PR is merged. 
    
    - Has new or updated python packages, PipFile, Pipefile.lock or Dockerfile changes?  DevOps can help or take care of it if you want. Just need to know if it is required.
       - [ ] Yes
       - [ ] No
    - Require new or adjusted data inputs? Does it have a way to version (folder or file dates)?
       - [ ] No
       - [ ] Yes
           -  Require new pre-clip set or any other data reloads, such as DEMS, osm, etc. ie.. pre-requisite re-data upstream of your input changes.
                - [ ] Yes
                - [ ] No
           -  Has the inputs been copied/exist in all four enviros:
                 - [ ] FIM EFS  
                 - [ ] FIM S3
                 - [ ] ESIP
                 - [ ] Dev1
            
- Please use caution in removing older version unless it is at least two versions ago.  Confirm with DevOps if cleanup might be involved.

- If new or updated data sets, has the FIM code, including running fim_pipeline.sh, been updated and tested with the new/adjusted data? You can dev test against subsets if you like.
    - [ ] Yes

### Notes to DevOps Team or others:
Please add any notes that are helpful for us to make sure it is all done correctly. Do not put actual server names or full true paths, just shortcut paths like 'efs..../inputs/,  or 'dev1....inputs', etc.



---------------------------------------------------------------
### Issuer Checklist (For developer use)

You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code.

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] `pre-commit` hooks were run locally
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [x] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead

---------------------------------------------------------------
### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
