### PR TITLE
[2pt] PR: Address pandas futurewarnings and other warning outputs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.9.x.x - 2026-04-23 - [PR#1783](https://github.com/NOAA-OWP/inundation-mapping/pull/1783)
+
+tbd
+
+### Changes
+
+- `tbd`
+
+<br/>
+
 ## v4.9.11.0 - 2026-04-10 - [PR#1783](https://github.com/NOAA-OWP/inundation-mapping/pull/1783)
 
 Resolves an issue causing stream outlet lines extending outside of the buffered WBD to be snapped back to the buffered WBD.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.9.x.x - 2026-04-23 - [PR#1815](https://github.com/NOAA-OWP/inundation-mapping/pull/1815)
+## v4.9.12.1 - 2026-05-01 - [PR#1815](https://github.com/NOAA-OWP/inundation-mapping/pull/1815)
 
 These changes resolve the numerous pandas 3.0 FutureWarnings as well as other miscellaneous "warning" messages that we track in our logging systems. Resolves #1799
 
@@ -25,7 +25,7 @@ The scripts below were updated to address warnings. There were no changes to the
 `src/src_roughness_optimization.py`
 `src/thalweg_notches_adjustment.py`
 
-<br/>
+
 ## v4.9.12.0 - 2026-05-01 - [PR#1777]([https://github.com/NOAA-OWP/inundation-mapping/pull/1777])
 
 This PR closes the issue #1739 and includes the following enhancements to address buildings Fimpacts:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,13 +1,29 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.9.x.x - 2026-04-23 - [PR#1783](https://github.com/NOAA-OWP/inundation-mapping/pull/1783)
+## v4.9.x.x - 2026-04-23 - [PR#1815](https://github.com/NOAA-OWP/inundation-mapping/pull/1815)
 
-tbd
+These changes resolve the numerous pandas 3.0 FutureWarnings as well as other miscellaneous "warning" messages that we track in our logging systems. Resolves #1799
 
 ### Changes
-
-- `tbd`
+The scripts below were updated to address warnings. There were no changes to the resulting outputs.
+`src/add_crosswalk.py`
+`src/aggregate_branches_to_huc.py`
+`src/bathymetric_adjustment.py`
+`src/build_stream_traversal.py`
+`src/delineate_hydros_and_produce_HAND.sh`
+`src/heal_bridges_osm.py`
+`src/identify_src_bankfull.py`
+`src/longitudinal_flow_adjustment.py`
+`src/mask_dem.py`
+`src/mitigate_branch_outlet_backpool.py`
+`src/nonmonotonic_src_adjustment.py`
+`src/reset_htable_src.py`
+`src/run_by_branch.sh`
+`src/run_huc.sh`
+`src/src_adjust_usgs_rating_trace.py`
+`src/src_roughness_optimization.py`
+`src/thalweg_notches_adjustment.py`
 
 <br/>
 ## v4.9.11.1 - 2026-04-17 - [PR#1809](https://github.com/NOAA-OWP/inundation-mapping/pull/1809)

--- a/src/add_crosswalk.py
+++ b/src/add_crosswalk.py
@@ -175,11 +175,7 @@ def add_crosswalk(
     # replace small segment geometry with neighboring stream
     for stream_index in output_flows.index:
         row = output_flows.loc[stream_index]
-        if (
-            row["areasqkm"] < min_catchment_area
-            and row["LengthKm"] < min_stream_length
-            and row["LakeID"] < 0
-        ):
+        if row["areasqkm"] < min_catchment_area and row["LengthKm"] < min_stream_length and row["LakeID"] < 0:
             short_id = row['HydroID']
             to_node = row['To_Node']
             from_node = row['From_Node']
@@ -282,9 +278,7 @@ def add_crosswalk(
                 str_order = output_order.item()
             else:
                 str_order = output_order.max()
-            sml_segs_rows.append(
-                {'short_id': short_id, 'update_id': update_id, 'str_order': str_order}
-            )
+            sml_segs_rows.append({'short_id': short_id, 'update_id': update_id, 'str_order': str_order})
 
     sml_segs = pd.DataFrame(sml_segs_rows, columns=['short_id', 'update_id', 'str_order'])
 
@@ -316,7 +310,7 @@ def add_crosswalk(
     # Apply masks to filter out invalid slope values
     # Initialize SLOPE with RISE_RUN values
     input_src_base['SLOPE'] = input_src_base['SLOPE_RISE_RUN'].astype(float)
-    
+
     # Override with IRIS_SWORD slope where mask is valid
     input_src_base.loc[sword_mask, 'SLOPE'] = input_src_base.loc[sword_mask, 'SLOPE_IRIS_SWORD'].astype(float)
 

--- a/src/add_crosswalk.py
+++ b/src/add_crosswalk.py
@@ -170,18 +170,19 @@ def add_crosswalk(
 
     # Adjust short model reach rating curves
     print('Adjusting model reach rating curves')
-    sml_segs = pd.DataFrame()
+    sml_segs_rows = []
 
     # replace small segment geometry with neighboring stream
     for stream_index in output_flows.index:
+        row = output_flows.loc[stream_index]
         if (
-            output_flows["areasqkm"][stream_index] < min_catchment_area
-            and output_flows["LengthKm"][stream_index] < min_stream_length
-            and output_flows["LakeID"][stream_index] < 0
+            row["areasqkm"] < min_catchment_area
+            and row["LengthKm"] < min_stream_length
+            and row["LakeID"] < 0
         ):
-            short_id = output_flows['HydroID'][stream_index]
-            to_node = output_flows['To_Node'][stream_index]
-            from_node = output_flows['From_Node'][stream_index]
+            short_id = row['HydroID']
+            to_node = row['To_Node']
+            from_node = row['From_Node']
 
             # multiple upstream segments
             if len(output_flows.loc[output_flows['NextDownID'] == short_id]['HydroID']) > 1:
@@ -281,15 +282,11 @@ def add_crosswalk(
                 str_order = output_order.item()
             else:
                 str_order = output_order.max()
-            sml_segs = pd.concat(
-                [
-                    sml_segs,
-                    pd.DataFrame(
-                        {'short_id': [short_id], 'update_id': [update_id], 'str_order': [str_order]}
-                    ),
-                ],
-                ignore_index=True,
+            sml_segs_rows.append(
+                {'short_id': short_id, 'update_id': update_id, 'str_order': str_order}
             )
+
+    sml_segs = pd.DataFrame(sml_segs_rows, columns=['short_id', 'update_id', 'str_order'])
 
     print(
         f"Number of short reaches [areasqkm < {min_catchment_area} and LengthKm < {min_stream_length}] = "
@@ -337,7 +334,7 @@ def add_crosswalk(
     input_src_base['HydraulicRadius (m)'] = (
         input_src_base['WetArea (m2)'] / input_src_base['WettedPerimeter (m)']
     )
-    input_src_base['HydraulicRadius (m)'].fillna(0, inplace=True)
+    input_src_base['HydraulicRadius (m)'] = input_src_base['HydraulicRadius (m)'].fillna(0)
     input_src_base['Discharge (m3s-1)'] = (
         input_src_base['WetArea (m2)']
         * pow(input_src_base['HydraulicRadius (m)'], 2.0 / 3)
@@ -390,17 +387,17 @@ def add_crosswalk(
             output_src = output_src.drop(columns=['Discharge (m3s-1)_df2'])
         else:
             for index, segment in sml_segs.iterrows():
-                short_id = segment[0]
-                update_id = segment[1]
+                short_id = segment['short_id']
+                update_id = segment['update_id']
                 new_values = output_src.loc[output_src['HydroID'] == update_id][
                     ['Stage', 'Discharge (m3s-1)']
                 ]
 
                 for src_index, src_stage in new_values.iterrows():
                     output_src.loc[
-                        (output_src['HydroID'] == short_id) & (output_src['Stage'] == src_stage[0]),
+                        (output_src['HydroID'] == short_id) & (output_src['Stage'] == src_stage['Stage']),
                         ['Discharge (m3s-1)'],
-                    ] = src_stage[1]
+                    ] = src_stage['Discharge (m3s-1)']
 
     del sml_segs
 

--- a/src/add_crosswalk.py
+++ b/src/add_crosswalk.py
@@ -314,11 +314,11 @@ def add_crosswalk(
     # hfab_mask = (input_src_base['SLOPE_HFAB'] >= SLOPE_MIN) & (input_src_base['SLOPE_HFAB'] <= SLOPE_MAX)
 
     # Apply masks to filter out invalid slope values
-    sword_slope = input_src_base['SLOPE_IRIS_SWORD'].where(sword_mask).astype(float)
-    # hfab_slope = input_src_base['SLOPE_HFAB'].where(hfab_mask)
-
-    # Assign SLOPE values with priority: IRIS_SWORD then RISE_RUN
-    input_src_base['SLOPE'] = sword_slope.combine_first(input_src_base['SLOPE_RISE_RUN']).astype(float)
+    # Initialize SLOPE with RISE_RUN values
+    input_src_base['SLOPE'] = input_src_base['SLOPE_RISE_RUN'].astype(float)
+    
+    # Override with IRIS_SWORD slope where mask is valid
+    input_src_base.loc[sword_mask, 'SLOPE'] = input_src_base.loc[sword_mask, 'SLOPE_IRIS_SWORD'].astype(float)
 
     # --- Normalize and stabilize precision of extremely small slopes ---
     #   1. Rounded to 3 digits in scientific notation

--- a/src/aggregate_branches_to_huc.py
+++ b/src/aggregate_branches_to_huc.py
@@ -42,7 +42,7 @@ class HucDirectory(object):
             'HUC8': str,
             'snap_distance': float,
         }
-        self.agg_usgs_elev_table = pd.DataFrame(columns=list(self.usgs_dtypes.keys()))
+        self.agg_usgs_elev_table = []
 
         self.hydrotable_dtypes = {
             'HydroID': int,
@@ -84,7 +84,7 @@ class HucDirectory(object):
             'subdiv_discharge_cms': float,
             'discharge_cms': float,
         }
-        self.agg_hydrotable = pd.DataFrame(columns=list(self.hydrotable_dtypes.keys()))
+        self.agg_hydrotable = []
 
         self.src_crosswalked_dtypes = {
             'branch_id': int,
@@ -132,7 +132,7 @@ class HucDirectory(object):
             'Velocity_obank (m/s)': float,
             'Discharge (m3s-1)_subdiv': float,
         }
-        self.agg_src_cross = pd.DataFrame(columns=list(self.src_crosswalked_dtypes.keys()))
+        self.agg_src_cross = []
 
         self.ras_dtypes = {
             'location_id': str,
@@ -147,7 +147,7 @@ class HucDirectory(object):
             'HUC8': str,
             'snap_distance': float,
         }
-        self.agg_ras_elev_table = pd.DataFrame(columns=list(self.ras_dtypes.keys()))
+        self.agg_ras_elev_table = []
 
         self.bridge_dtypes = {
             'osmid': int,
@@ -162,7 +162,7 @@ class HucDirectory(object):
             'mainstem': int,
             'geometry': object,
         }
-        self.agg_bridge_pnts = gpd.GeoDataFrame(columns=list(self.bridge_dtypes.keys()))
+        self.agg_bridge_pnts = []
 
         self.road_dtypes = {
             'osmid': str,
@@ -180,7 +180,7 @@ class HucDirectory(object):
             'threshold_discharge_cfs': float,
         }
 
-        self.agg_road_fimpact = pd.DataFrame(columns=list(self.road_dtypes.keys()))
+        self.agg_road_fimpact = []
 
     def iter_branches(self):
         if self.limit_branches:
@@ -197,7 +197,7 @@ class HucDirectory(object):
             return
 
         usgs_elev_table = pd.read_csv(usgs_elev_filename, dtype=self.usgs_dtypes)
-        self.agg_usgs_elev_table = pd.concat([self.agg_usgs_elev_table, usgs_elev_table])
+        self.agg_usgs_elev_table.append(usgs_elev_table)
 
     def aggregate_hydrotables(self, branch_path, branch_id):
         hydrotable_filename = join(branch_path, f'hydroTable_{branch_id}.csv')
@@ -207,7 +207,7 @@ class HucDirectory(object):
         hydrotable = pd.read_csv(hydrotable_filename, dtype=self.hydrotable_dtypes)
         hydrotable['branch_id'] = branch_id
         hydrotable[['calb_applied']] = hydrotable[['calb_applied']].fillna(value=False)
-        self.agg_hydrotable = pd.concat([self.agg_hydrotable, hydrotable])
+        self.agg_hydrotable.append(hydrotable)
 
     def aggregate_src_full_crosswalk(self, branch_path, branch_id):
         src_cross_filename = join(branch_path, f'src_full_crosswalked_{branch_id}.csv')
@@ -216,7 +216,7 @@ class HucDirectory(object):
 
         src_cross = pd.read_csv(src_cross_filename, dtype=self.src_crosswalked_dtypes)
         src_cross['branch_id'] = branch_id
-        self.agg_src_cross = pd.concat([self.agg_src_cross, src_cross])
+        self.agg_src_cross.append(src_cross)
 
     def aggregate_ras_elev_table(self, branch_path):
         ras_elev_filename = join(branch_path, 'ras_elev_table.csv')
@@ -224,7 +224,7 @@ class HucDirectory(object):
             return
 
         ras_elev_table = pd.read_csv(ras_elev_filename, dtype=self.ras_dtypes)
-        self.agg_ras_elev_table = pd.concat([self.agg_ras_elev_table, ras_elev_table])
+        self.agg_ras_elev_table.append(ras_elev_table)
 
     def aggregate_bridge_pnts(self, branch_path, branch_id):
         bridge_filename = join(branch_path, f'osm_bridge_centroids_{branch_id}.gpkg')
@@ -240,7 +240,7 @@ class HucDirectory(object):
         hydrotable = pd.read_csv(hydrotable_filename, dtype=self.hydrotable_dtypes)
         # Get the flows for each stage
         bridge_pnts = flows_from_hydrotable(bridge_pnts, hydrotable)
-        self.agg_bridge_pnts = pd.concat([self.agg_bridge_pnts, bridge_pnts])
+        self.agg_bridge_pnts.append(bridge_pnts)
 
     def aggregate_road_fimpacts(self, branch_path, branch_id):
         fimpact_filename = join(branch_path, f'osm_roads_fimpact_{branch_id}.csv')
@@ -267,7 +267,7 @@ class HucDirectory(object):
             fimpact_df['threshold_hand_ft'] = fimpact_df['threshold_hand'] * 3.28084
             fimpact_df['threshold_discharge_cfs'] = fimpact_df['threshold_discharge'] * 35.3147
 
-            self.agg_road_fimpact = pd.concat([self.agg_road_fimpact, fimpact_df])
+            self.agg_road_fimpact.append(fimpact_df)
 
     def agg_function(
         self, usgs_elev_flag, hydro_table_flag, src_cross_flag, ras_elev_flag, bridge_flag, road_flag, huc_id
@@ -296,8 +296,9 @@ class HucDirectory(object):
                 if os.path.isfile(usgs_elev_table_file):
                     os.remove(usgs_elev_table_file)
 
-                if not self.agg_usgs_elev_table.empty:
-                    self.agg_usgs_elev_table.to_csv(usgs_elev_table_file, index=False)
+                if self.agg_usgs_elev_table:
+                    agg_usgs = pd.concat(self.agg_usgs_elev_table, ignore_index=True)
+                    agg_usgs.to_csv(usgs_elev_table_file, index=False)
 
             if hydro_table_flag:
 
@@ -305,8 +306,8 @@ class HucDirectory(object):
                 if os.path.isfile(hydrotable_file):
                     os.remove(hydrotable_file)
 
-                if not self.agg_hydrotable.empty:
-                    self.agg_hydrotable.to_csv(hydrotable_file, index=False)
+                if self.agg_hydrotable:
+                    agg_hydrotable = pd.concat(self.agg_hydrotable, ignore_index=True)
 
                     # TODO: Jun 2025: Rename poorly named columns like SurfaceArea (m2)
                     # and go though all tools removing csv orfeather in favour of parquet
@@ -337,7 +338,8 @@ class HucDirectory(object):
                         "LakeID",
                         "Bathymetry_source",
                     ]
-                    temp_df = self.agg_hydrotable.reset_index()
+                    agg_hydrotable.to_csv(hydrotable_file, index=False)
+                    temp_df = agg_hydrotable.reset_index()
                     temp_df = temp_df[htable_req_cols].astype(dtype)
                     temp_df.to_feather(hydrotable_file.replace('.csv', '.feather'))
 
@@ -364,25 +366,27 @@ class HucDirectory(object):
                 if os.path.isfile(src_crosswalk_file):
                     os.remove(src_crosswalk_file)
 
-                if not self.agg_src_cross.empty:
-                    self.agg_src_cross.to_csv(src_crosswalk_file, index=False)
+                if self.agg_src_cross:
+                    agg_src_cross = pd.concat(self.agg_src_cross, ignore_index=True)
+                    agg_src_cross.to_csv(src_crosswalk_file, index=False)
 
             if ras_elev_flag:
                 ras_elev_table_file = join(self.huc_dir_path, 'ras_elev_table.csv')
                 if os.path.isfile(ras_elev_table_file):
                     os.remove(ras_elev_table_file)
 
-                if not self.agg_ras_elev_table.empty:
-                    self.agg_ras_elev_table.to_csv(ras_elev_table_file, index=False)
+                if self.agg_ras_elev_table:
+                    agg_ras_elev = pd.concat(self.agg_ras_elev_table, ignore_index=True)
+                    agg_ras_elev.to_csv(ras_elev_table_file, index=False)
 
             if bridge_flag:
                 bridge_pnts_file = join(self.huc_dir_path, 'osm_bridge_centroids.gpkg')
                 if os.path.isfile(bridge_pnts_file):
                     os.remove(bridge_pnts_file)
 
-                if not self.agg_bridge_pnts.empty:
+                if self.agg_bridge_pnts:
                     # Just making things shorter so they are easier to read
-                    bridge_pnts = self.agg_bridge_pnts
+                    bridge_pnts = pd.concat(self.agg_bridge_pnts, ignore_index=True)
                     # Use branch 0 to get the feature_id each bridge crosses
                     b0 = bridge_pnts.loc[bridge_pnts.branch == '0', ['osmid', 'feature_id']]
                     b0 = b0.rename(columns={'feature_id': 'crossing_feature_id'})
@@ -414,10 +418,11 @@ class HucDirectory(object):
                 if os.path.isfile(roads_fimpact_file):
                     os.remove(roads_fimpact_file)
 
-                if not self.agg_road_fimpact.empty:
-                    self.agg_road_fimpact = self.agg_road_fimpact.astype(self.road_dtypes, errors='raise')
+                if self.agg_road_fimpact:
+                    agg_road_fimpact = pd.concat(self.agg_road_fimpact, ignore_index=True)
+                    agg_road_fimpact = agg_road_fimpact.astype(self.road_dtypes, errors='raise')
 
-                    self.agg_road_fimpact.to_csv(roads_fimpact_file, index=False)
+                    agg_road_fimpact.to_csv(roads_fimpact_file, index=False)
 
         except Exception:
             errMsg = (

--- a/src/bathymetric_adjustment.py
+++ b/src/bathymetric_adjustment.py
@@ -16,6 +16,9 @@ import pandas as pd
 # -------------------------------------------------------
 # Function to use RFC Bathymetry where available over eHydro Data
 def ohrfc_bathy_precedence(group):
+    # Re-inject the grouping column 
+    group['feature_id'] = group.name
+
     ohrfc_source = 'OHRFC provided bathymetry, compiled from USACE data'
     ohrfc_data = group['Bathymetry_source'] == ohrfc_source
     if ohrfc_data.any():
@@ -99,8 +102,8 @@ def correct_rating_for_ehydro_bathymetry(huc_dir, huc, bathy_file_ehydro):
                 bathy_data[
                     ['feature_id', 'missing_xs_area_m2', 'missing_wet_perimeter_m', 'Bathymetry_source']
                 ]
-                .groupby('feature_id', include_groups=False)
-                .apply(ohrfc_bathy_precedence)
+                .groupby('feature_id')
+                .apply(ohrfc_bathy_precedence, include_groups=False)
                 .reset_index(drop=True)
             )
 

--- a/src/bathymetric_adjustment.py
+++ b/src/bathymetric_adjustment.py
@@ -16,7 +16,7 @@ import pandas as pd
 # -------------------------------------------------------
 # Function to use RFC Bathymetry where available over eHydro Data
 def ohrfc_bathy_precedence(group):
-    # Re-inject the grouping column 
+    # Re-inject the grouping column
     group['feature_id'] = group.name
 
     ohrfc_source = 'OHRFC provided bathymetry, compiled from USACE data'

--- a/src/bathymetric_adjustment.py
+++ b/src/bathymetric_adjustment.py
@@ -99,8 +99,8 @@ def correct_rating_for_ehydro_bathymetry(huc_dir, huc, bathy_file_ehydro):
                 bathy_data[
                     ['feature_id', 'missing_xs_area_m2', 'missing_wet_perimeter_m', 'Bathymetry_source']
                 ]
-                .groupby('feature_id')
-                .apply(ohrfc_bathy_precedence)  # , include_groups=False)
+                .groupby('feature_id', include_groups=False)
+                .apply(ohrfc_bathy_precedence)
                 .reset_index(drop=True)
             )
 

--- a/src/bathymetric_adjustment.py
+++ b/src/bathymetric_adjustment.py
@@ -326,6 +326,9 @@ def correct_rating_for_ai_bathymetry(huc_dir, huc, strm_order, bathy_file_aibase
 
             mask = src_df["Bathymetry_source_x"].isna()
 
+            # Explicitly cast the Bathymetry_source_x to 'object' dtype so it can accept strings
+            src_df["Bathymetry_source_x"] = src_df["Bathymetry_source_x"].astype(object)
+
             src_df.loc[mask, "missing_xs_area_m2_x"] = src_df.loc[mask, "missing_xs_area_m2_y"]
             src_df.loc[mask, "missing_wet_perimeter_m_x"] = src_df.loc[mask, "missing_wet_perimeter_m_y"]
             src_df.loc[mask, "Bathymetry_source_x"] = src_df.loc[mask, "Bathymetry_source_y"]

--- a/src/build_stream_traversal.py
+++ b/src/build_stream_traversal.py
@@ -106,10 +106,10 @@ class build_stream_traversal_columns(object):
                 xy_dict = {}
                 bhasnullshape = False
                 for rows in streams[['geometry', from_node, to_node]].iterrows():
-                    if rows[1][0]:
+                    if rows[1]['geometry']:
                         # From Node
-                        firstx = round(rows[1][0].coords.xy[0][0], 7)
-                        firsty = round(rows[1][0].coords.xy[1][0], 7)
+                        firstx = round(rows[1]['geometry'].coords.xy[0][0], 7)
+                        firsty = round(rows[1]['geometry'].coords.xy[1][0], 7)
                         from_key = '{},{}'.format(firstx, firsty)
                         if from_key in xy_dict:
                             streams.at[rows[0], from_node] = xy_dict[from_key]
@@ -118,8 +118,8 @@ class build_stream_traversal_columns(object):
                             streams.at[rows[0], from_node] = xy_dict[from_key]
 
                         # To Node
-                        lastx = round(rows[1][0].coords.xy[0][-1], 7)
-                        lasty = round(rows[1][0].coords.xy[1][-1], 7)
+                        lastx = round(rows[1]['geometry'].coords.xy[0][-1], 7)
+                        lasty = round(rows[1]['geometry'].coords.xy[1][-1], 7)
                         to_key = '{},{}'.format(lastx, lasty)
                         # if xy_dict.has_key(to_key):
                         if to_key in xy_dict:
@@ -144,18 +144,18 @@ class build_stream_traversal_columns(object):
             dnodes = dict()
             lstHydroIDs = []
             for row in streams[[from_node, hydro_id]].iterrows():
-                if (row[1][0] in dnodes) is False:
-                    lstHydroIDs = [row[1][1]]
-                    dnodes.setdefault(row[1][0], lstHydroIDs)
+                if (row[1][from_node] in dnodes) is False:
+                    lstHydroIDs = [row[1][hydro_id]]
+                    dnodes.setdefault(row[1][from_node], lstHydroIDs)
                 else:
-                    lstHydroIDs = dnodes[row[1][0]]
-                    lstHydroIDs.append(row[1][1])
+                    lstHydroIDs = dnodes[row[1][from_node]]
+                    lstHydroIDs.append(row[1][hydro_id])
 
             # for each stream segment, search dict for HydroID downstream and
             for urow in streams[[next_down_id, to_node, from_node, hydro_id]].iterrows():
-                tonodecol = urow[1][1]
-                nextdownIDcol = urow[1][0]
-                hydroIDcol = urow[1][3]
+                tonodecol = urow[1][to_node]
+                nextdownIDcol = urow[1][next_down_id]
+                hydroIDcol = urow[1][hydro_id]
                 try:
                     next_down_ids = dnodes[tonodecol]
                 except:

--- a/src/delineate_hydros_and_produce_HAND.sh
+++ b/src/delineate_hydros_and_produce_HAND.sh
@@ -77,7 +77,9 @@ $taudemDir/flowdircond -p $tempCurrentBranchDataDir/flowdir_d8_burned_filled_flo
 echo -e $startDiv"D8 Slopes from DEM $hucNumber $current_branch_id"
 mpiexec -n $ncores_fd $taudemDir2/d8flowdir \
     -fel $tempCurrentBranchDataDir/dem_lateral_thalweg_adj_$current_branch_id.tif \
-    -sd8 $tempCurrentBranchDataDir/slopes_d8_dem_meters_$current_branch_id.tif
+    -sd8 $tempCurrentBranchDataDir/slopes_d8_dem_meters_$current_branch_id.tif \
+    2>&1 | sed -e 's/.*no output sd8 file specified.*/INFO: TauDEM d8flowdir running without optional p flowdir output./I' \
+               -e 's/.*no output p file specified.*/INFO: TauDEM d8flowdir running without optional p flowdir output./I'
 
 ## STREAMNET FOR REACHES ##
 echo -e $startDiv"Stream Net for Reaches $hucNumber $current_branch_id"

--- a/src/heal_bridges_osm.py
+++ b/src/heal_bridges_osm.py
@@ -144,7 +144,11 @@ def process_bridges_in_huc(
     # either of non_lidar_osm_gdf or lidar_osm_gdf can be None (if there are no lidar or non-lidar bridges)-- so handle it
     valid_osm_gdfs = [gdf for gdf in [non_lidar_osm_gdf, lidar_osm_gdf] if gdf is not None]
 
-    osm_gdf = pd.concat(valid_osm_gdfs, ignore_index=True)
+    if valid_osm_gdfs:
+        osm_gdf = pd.concat(valid_osm_gdfs, ignore_index=True)
+    else:
+        # Return empty GeoDataFrame if no valid bridges found
+        osm_gdf = gpd.GeoDataFrame()
 
     # # Write the new HAND grid
     with rasterio.open(source_hand_raster, 'w', **hand_grid_profile) as new_hand_grid:

--- a/src/heal_bridges_osm.py
+++ b/src/heal_bridges_osm.py
@@ -36,7 +36,7 @@ def process_non_lidar_osm(osm_gdf, hand_grid_array, hand_grid_profile, non_lidar
         all_touched=True,
     )
     # pull the values out of the geopandas columns so we can use them as floats
-    non_lidar_osm_gdf.loc[:, 'threshold_hand'] = [x.get('max') for x in stats]
+    non_lidar_osm_gdf.loc[:, 'threshold_hand'] = pd.to_numeric([x.get('max') for x in stats], errors='coerce')
     # sort in case of overlaps; display theshold hand value at any given location
     non_lidar_osm_gdf = non_lidar_osm_gdf.sort_values(by="threshold_hand", ascending=False)
 
@@ -99,7 +99,7 @@ def process_lidar_osm(osm_gdf, hand_grid_array, hand_grid_profile, lidar_buffer,
         nodata=hand_grid_profile["nodata"],
         all_touched=True,
     )
-    lidar_osm_gdf.loc[:, 'threshold_hand'] = [x.get('median') for x in stats]
+    lidar_osm_gdf.loc[:, 'threshold_hand'] = pd.to_numeric([x.get('median') for x in stats], errors='coerce')
 
     return lidar_osm_gdf, updated_hand_grid_array
 

--- a/src/identify_src_bankfull.py
+++ b/src/identify_src_bankfull.py
@@ -91,7 +91,7 @@ def src_bankfull_lookup(args):
 
         if negative_flows > 0:
             log_text += (
-                'WARNING: HUC: '
+                'INFO: HUC: '
                 + str(huc)
                 + '  branch id: '
                 + str(branch_id)

--- a/src/longitudinal_flow_adjustment.py
+++ b/src/longitudinal_flow_adjustment.py
@@ -475,7 +475,7 @@ def filter_longitudinal_discharge_jitters(huc_dir, huc, stage_interval):
             src_df['SurfaceArea (m2)'] = src_df['SurfaceArea (m2)'].astype(float)
             # Force increased SA back to default
             # Compute mean(SurfaceArea (m2)_longitudinalAdjusted - default) per HydroID
-            mean_diff = src_df.groupby('HydroID').apply(
+            mean_diff = src_df.groupby('HydroID', include_groups=False).apply(
                 lambda g: (g['SurfaceArea (m2)_longitudinalAdjusted'] - g['SurfaceArea (m2)_default']).mean()
             )
             # HydroIDs where mean difference > 0
@@ -541,7 +541,7 @@ def filter_longitudinal_discharge_jitters(huc_dir, huc, stage_interval):
             src_df['WettedPerimeter (m)'] = src_df['BedArea (m2)'] / src_df['LENGTHKM'] / 1000
             src_df['WetArea (m2)'] = src_df['Volume (m3)'] / src_df['LENGTHKM'] / 1000
             src_df['HydraulicRadius (m)'] = src_df['WetArea (m2)'] / src_df['WettedPerimeter (m)']
-            src_df['HydraulicRadius (m)'].fillna(0, inplace=True)
+            src_df['HydraulicRadius (m)'] = src_df['HydraulicRadius (m)'].fillna(0)
 
             # Recalculating the discharge
             src_df['Discharge (m3s-1)'] = (

--- a/src/longitudinal_flow_adjustment.py
+++ b/src/longitudinal_flow_adjustment.py
@@ -477,7 +477,7 @@ def filter_longitudinal_discharge_jitters(huc_dir, huc, stage_interval):
             # Compute mean(SurfaceArea (m2)_longitudinalAdjusted - default) per HydroID
             mean_diff = src_df.groupby('HydroID').apply(
                 lambda g: (g['SurfaceArea (m2)_longitudinalAdjusted'] - g['SurfaceArea (m2)_default']).mean(),
-                include_groups=False
+                include_groups=False,
             )
             # HydroIDs where mean difference > 0
             hids_to_replace = mean_diff[mean_diff > 0].index

--- a/src/longitudinal_flow_adjustment.py
+++ b/src/longitudinal_flow_adjustment.py
@@ -475,8 +475,9 @@ def filter_longitudinal_discharge_jitters(huc_dir, huc, stage_interval):
             src_df['SurfaceArea (m2)'] = src_df['SurfaceArea (m2)'].astype(float)
             # Force increased SA back to default
             # Compute mean(SurfaceArea (m2)_longitudinalAdjusted - default) per HydroID
-            mean_diff = src_df.groupby('HydroID', include_groups=False).apply(
-                lambda g: (g['SurfaceArea (m2)_longitudinalAdjusted'] - g['SurfaceArea (m2)_default']).mean()
+            mean_diff = src_df.groupby('HydroID').apply(
+                lambda g: (g['SurfaceArea (m2)_longitudinalAdjusted'] - g['SurfaceArea (m2)_default']).mean(),
+                include_groups=False
             )
             # HydroIDs where mean difference > 0
             hids_to_replace = mean_diff[mean_diff > 0].index

--- a/src/mask_dem.py
+++ b/src/mask_dem.py
@@ -3,7 +3,6 @@
 import argparse
 import os
 
-import fiona
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -60,11 +59,14 @@ def mask_dem(
     with rio.open(dem_filename) as dem:
         dem_profile = dem.profile.copy()
         nodata = dem.nodata
+        dem_crs = dem.crs
 
         if branch_id == branch_zero_id:
             # Mask if branch zero
-            with fiona.open(nld_filename) as leveed:
-                geoms = [feature["geometry"] for feature in leveed]
+            leveed = gpd.read_file(nld_filename, engine='fiona')
+            if leveed.crs != dem_crs:
+                leveed = leveed.to_crs(dem_crs)
+            geoms = [feature for feature in leveed.geometry]
 
             if len(geoms) > 0:
                 dem_masked, _ = mask(dem, geoms, invert=True)
@@ -74,6 +76,10 @@ def mask_dem(
             catchments = gpd.read_file(catchments_filename, engine='fiona')
             levee_levelpaths = pd.read_csv(levee_levelpaths)
             leveed = gpd.read_file(nld_filename, engine='fiona')
+            
+            # Reproject leveed to match DEM CRS if needed
+            if leveed.crs != dem_crs:
+                leveed = leveed.to_crs(dem_crs)
 
             # Select levees associated with branch
             levee_levelpaths = levee_levelpaths[levee_levelpaths[branch_id_attribute] == branch_id]
@@ -84,15 +90,17 @@ def mask_dem(
             if len(levelpath_levees) > 0:
                 # Get geometries of levee protected areas associated with levelpath
                 geoms = [
-                    feature['geometry']
-                    for i, feature in leveed.iterrows()
-                    if feature[levee_id_attribute] in levelpath_levees
+                    feature
+                    for i, feature in leveed[leveed[levee_id_attribute].isin(levelpath_levees)].geometry.items()
                 ]
 
                 if len(geoms) > 0:
                     dem_masked, _ = mask(dem, geoms, invert=True)
 
             # Mask levee-protected areas not protected against level path
+            # Ensure catchments have same CRS as leveed before overlay
+            if catchments.crs != dem_crs:
+                catchments = catchments.to_crs(dem_crs)
             leveed_area_catchments = gpd.overlay(catchments, leveed, how="union")
 
             # Select levee catchments not associated with level path
@@ -100,7 +108,7 @@ def mask_dem(
                 ~leveed_area_catchments[levee_id_attribute].isna() & leveed_area_catchments['ID'].isna(), :
             ]
 
-            geoms = [feature["geometry"] for i, feature in levee_catchments_to_mask.iterrows()]
+            geoms = [feature for feature in levee_catchments_to_mask.geometry]
 
             if len(geoms) > 0:
                 levee_catchments_masked, _ = mask(dem, geoms, invert=True)

--- a/src/mask_dem.py
+++ b/src/mask_dem.py
@@ -8,9 +8,38 @@ import numpy as np
 import pandas as pd
 import rasterio as rio
 from rasterio.mask import mask
+from shapely.geometry import box
 
 
 # gpd.options.io_engine = "pyogrio"
+
+
+def clip_geoms_to_raster_bounds(geoms, raster_bounds):
+    """
+    Clip geometries to raster bounds to avoid 'shapes outside bounds' warnings.
+    
+    Parameters
+    ----------
+    geoms : list
+        List of shapely geometries
+    raster_bounds : rasterio.coords.BoundingBox
+        Bounding box of the raster (from raster.bounds)
+    
+    Returns
+    -------
+    list
+        List of clipped geometries that intersect with raster bounds
+    """
+    raster_box = box(raster_bounds.left, raster_bounds.bottom, raster_bounds.right, raster_bounds.top)
+    clipped_geoms = []
+    
+    for geom in geoms:
+        if geom.is_valid and geom.intersects(raster_box):
+            clipped = geom.intersection(raster_box)
+            if not clipped.is_empty:
+                clipped_geoms.append(clipped)
+    
+    return clipped_geoms
 
 
 def mask_dem(
@@ -67,6 +96,7 @@ def mask_dem(
             if leveed.crs != dem_crs:
                 leveed = leveed.to_crs(dem_crs)
             geoms = [feature for feature in leveed.geometry]
+            geoms = clip_geoms_to_raster_bounds(geoms, dem.bounds)
 
             if len(geoms) > 0:
                 dem_masked, _ = mask(dem, geoms, invert=True)
@@ -93,6 +123,7 @@ def mask_dem(
                     feature
                     for i, feature in leveed[leveed[levee_id_attribute].isin(levelpath_levees)].geometry.items()
                 ]
+                geoms = clip_geoms_to_raster_bounds(geoms, dem.bounds)
 
                 if len(geoms) > 0:
                     dem_masked, _ = mask(dem, geoms, invert=True)
@@ -109,6 +140,7 @@ def mask_dem(
             ]
 
             geoms = [feature for feature in levee_catchments_to_mask.geometry]
+            geoms = clip_geoms_to_raster_bounds(geoms, dem.bounds)
 
             if len(geoms) > 0:
                 levee_catchments_masked, _ = mask(dem, geoms, invert=True)

--- a/src/mask_dem.py
+++ b/src/mask_dem.py
@@ -17,14 +17,14 @@ from shapely.geometry import box
 def clip_geoms_to_raster_bounds(geoms, raster_bounds):
     """
     Clip geometries to raster bounds to avoid 'shapes outside bounds' warnings.
-    
+
     Parameters
     ----------
     geoms : list
         List of shapely geometries
     raster_bounds : rasterio.coords.BoundingBox
         Bounding box of the raster (from raster.bounds)
-    
+
     Returns
     -------
     list
@@ -32,13 +32,13 @@ def clip_geoms_to_raster_bounds(geoms, raster_bounds):
     """
     raster_box = box(raster_bounds.left, raster_bounds.bottom, raster_bounds.right, raster_bounds.top)
     clipped_geoms = []
-    
+
     for geom in geoms:
         if geom.is_valid and geom.intersects(raster_box):
             clipped = geom.intersection(raster_box)
             if not clipped.is_empty:
                 clipped_geoms.append(clipped)
-    
+
     return clipped_geoms
 
 
@@ -106,7 +106,7 @@ def mask_dem(
             catchments = gpd.read_file(catchments_filename, engine='fiona')
             levee_levelpaths = pd.read_csv(levee_levelpaths)
             leveed = gpd.read_file(nld_filename, engine='fiona')
-            
+
             # Reproject leveed to match DEM CRS if needed
             if leveed.crs != dem_crs:
                 leveed = leveed.to_crs(dem_crs)
@@ -121,7 +121,9 @@ def mask_dem(
                 # Get geometries of levee protected areas associated with levelpath
                 geoms = [
                     feature
-                    for i, feature in leveed[leveed[levee_id_attribute].isin(levelpath_levees)].geometry.items()
+                    for i, feature in leveed[
+                        leveed[levee_id_attribute].isin(levelpath_levees)
+                    ].geometry.items()
                 ]
                 geoms = clip_geoms_to_raster_bounds(geoms, dem.bounds)
 

--- a/src/mitigate_branch_outlet_backpool.py
+++ b/src/mitigate_branch_outlet_backpool.py
@@ -298,7 +298,7 @@ def mitigate_branch_outlet_backpool(
         split_points_geom = gpd.read_file(split_points_filename, engine='fiona')
 
         # Subset the split flows to get the last one
-        split_flows_last_geom = split_flows_geom[split_flows_geom['NextDownID'] == '-1']
+        split_flows_last_geom = split_flows_geom[split_flows_geom['NextDownID'] == '-1'].copy()
 
         # Check whether there are multiple NextDownID's of -1
         if len(split_flows_last_geom.index) == 1:

--- a/src/nonmonotonic_src_adjustment.py
+++ b/src/nonmonotonic_src_adjustment.py
@@ -23,7 +23,7 @@ def analyze_nonmonotonic_src(srcs_df, strm_order):  # , thalweg_hydroids
     # Inject the group key back into the dataframe to maintain Pandas 3.0 compatibility
     # when include_groups=False is passed from the parent groupby
     srcs_df['HydroID'] = srcs_df.name
-    
+
     # Only apply on stream orders >= strm_order
     if srcs_df['order_'].iloc[0] < strm_order:
         return srcs_df

--- a/src/nonmonotonic_src_adjustment.py
+++ b/src/nonmonotonic_src_adjustment.py
@@ -7,6 +7,7 @@
 import datetime as dt
 import os
 import re
+import sys
 import traceback
 from argparse import ArgumentParser
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -14,7 +15,8 @@ from os.path import join
 
 import numpy as np
 import pandas as pd
-
+print(f"WARNING: Executable path is {sys.executable}")
+print(f"WARNING: Pandas version is {pd.__version__}")
 
 # -------------------------------------------------------
 # Analysing each HydroID SRC for nonmonotonic SRC

--- a/src/nonmonotonic_src_adjustment.py
+++ b/src/nonmonotonic_src_adjustment.py
@@ -167,7 +167,7 @@ def correct_nonmonotonic_src(huc_dir, huc, strm_order):  # , bankfull_flows_file
         prenonmono_discharge = src_df3['Discharge (m3s-1)']
 
         # Adjusting src tables for nonmonotonic SRCs
-        src_df4 = src_df2.groupby('HydroID', group_keys=False).apply(
+        src_df4 = src_df2.groupby('HydroID', group_keys=False, include_groups=False).apply(
             analyze_nonmonotonic_src, strm_order=strm_order
         )
 

--- a/src/nonmonotonic_src_adjustment.py
+++ b/src/nonmonotonic_src_adjustment.py
@@ -7,7 +7,6 @@
 import datetime as dt
 import os
 import re
-import sys
 import traceback
 from argparse import ArgumentParser
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -15,8 +14,7 @@ from os.path import join
 
 import numpy as np
 import pandas as pd
-print(f"WARNING: Executable path is {sys.executable}")
-print(f"WARNING: Pandas version is {pd.__version__}")
+
 
 # -------------------------------------------------------
 # Analysing each HydroID SRC for nonmonotonic SRC
@@ -169,8 +167,8 @@ def correct_nonmonotonic_src(huc_dir, huc, strm_order):  # , bankfull_flows_file
         prenonmono_discharge = src_df3['Discharge (m3s-1)']
 
         # Adjusting src tables for nonmonotonic SRCs
-        src_df4 = src_df2.groupby('HydroID', group_keys=False, include_groups=False).apply(
-            analyze_nonmonotonic_src, strm_order=strm_order
+        src_df4 = src_df2.groupby('HydroID', group_keys=False).apply(
+            analyze_nonmonotonic_src, strm_order=strm_order, include_groups=False
         )
 
         # Make sure nonmonotonic adjustment just applied within in-channel stages

--- a/src/nonmonotonic_src_adjustment.py
+++ b/src/nonmonotonic_src_adjustment.py
@@ -20,6 +20,10 @@ import pandas as pd
 # Analysing each HydroID SRC for nonmonotonic SRC
 def analyze_nonmonotonic_src(srcs_df, strm_order):  # , thalweg_hydroids
 
+    # Inject the group key back into the dataframe to maintain Pandas 3.0 safety
+    # when include_groups=False is passed from the parent groupby
+    srcs_df['HydroID'] = srcs_df.name
+    
     # Only apply on stream orders >= strm_order
     if srcs_df['order_'].iloc[0] < strm_order:
         return srcs_df

--- a/src/nonmonotonic_src_adjustment.py
+++ b/src/nonmonotonic_src_adjustment.py
@@ -20,7 +20,7 @@ import pandas as pd
 # Analysing each HydroID SRC for nonmonotonic SRC
 def analyze_nonmonotonic_src(srcs_df, strm_order):  # , thalweg_hydroids
 
-    # Inject the group key back into the dataframe to maintain Pandas 3.0 safety
+    # Inject the group key back into the dataframe to maintain Pandas 3.0 compatibility
     # when include_groups=False is passed from the parent groupby
     srcs_df['HydroID'] = srcs_df.name
     

--- a/src/nonmonotonic_src_adjustment.py
+++ b/src/nonmonotonic_src_adjustment.py
@@ -113,6 +113,7 @@ def correct_nonmonotonic_src(huc_dir, huc, strm_order):  # , bankfull_flows_file
         src_0_df = pd.read_csv(src_full_0, low_memory=False)
         ht_0_df = pd.read_csv(ht_0_path, low_memory=False)
 
+        src_0_df['Bathymetry_source'] = src_0_df['Bathymetry_source'].astype('object')
         src_0_df.loc[src_0_df['Bathymetry_source'] == str(0), 'Bathymetry_source'] = 'No Bathymetry Applied'
         src_0_df.loc[src_0_df['Bathymetry_source'] == 0, 'Bathymetry_source'] = 'No Bathymetry Applied'
         src_0_df['Bathymetry_source'] = src_0_df['Bathymetry_source'].fillna('No Bathymetry Applied')
@@ -196,6 +197,7 @@ def correct_nonmonotonic_src(huc_dir, huc, strm_order):  # , bankfull_flows_file
         # Write src back to file
         src_df = src_df4.copy()
         # Make sure there is no nan values
+        src_df['Bathymetry_source'] = src_df['Bathymetry_source'].astype('object')
         src_df.loc[src_df['Bathymetry_source'] == 0, 'Bathymetry_source'] = 'No Bathymetry Applied'
         src_df['Bathymetry_source'] = src_df['Bathymetry_source'].fillna('No Bathymetry Applied')
 

--- a/src/reset_htable_src.py
+++ b/src/reset_htable_src.py
@@ -105,17 +105,17 @@ def process_branch(sub_branch_path, branch, huc_id):
                 recalc_df = recalc_df.drop(columns=['Discharge (m3s-1)_df2'])
             else:
                 for index, segment in sml_segs.iterrows():  # Conus
-                    short_id = segment[0]
-                    update_id = segment[1]
+                    short_id = segment.iloc[0]
+                    update_id = segment.iloc[1]
                     new_values = recalc_df.loc[recalc_df['HydroID'] == update_id][
                         ['Stage', 'Discharge (m3s-1)']
                     ]
 
                     for src_index, src_stage in new_values.iterrows():
                         recalc_df.loc[
-                            (recalc_df['HydroID'] == short_id) & (recalc_df['Stage'] == src_stage[0]),
+                            (recalc_df['HydroID'] == short_id) & (recalc_df['Stage'] == src_stage.iloc[0]),
                             ['Discharge (m3s-1)'],
-                        ] = src_stage[1]
+                        ] = src_stage.iloc[1]
 
     # Update src_full & hydroTable
     input_src_full.set_index(['HydroID', 'Stage'], inplace=True)

--- a/src/reset_htable_src.py
+++ b/src/reset_htable_src.py
@@ -63,7 +63,7 @@ def process_branch(sub_branch_path, branch, huc_id):
     recalc_df['WettedPerimeter (m)'] = recalc_df['BedArea (m2)'] / recalc_df['LENGTHKM'] / 1000
     recalc_df['WetArea (m2)'] = recalc_df['Volume (m3)'] / recalc_df['LENGTHKM'] / 1000
     recalc_df['HydraulicRadius (m)'] = recalc_df['WetArea (m2)'] / recalc_df['WettedPerimeter (m)']
-    recalc_df['HydraulicRadius (m)'].fillna(0, inplace=True)
+    recalc_df['HydraulicRadius (m)'] = recalc_df['HydraulicRadius (m)'].fillna(0)
 
     recalc_df['Discharge (m3s-1)'] = (
         recalc_df['WetArea (m2)']

--- a/src/run_by_branch.sh
+++ b/src/run_by_branch.sh
@@ -128,7 +128,9 @@ fi
 echo -e $startDiv"D8 Flow Directions on Burned DEM $hucNumber $current_branch_id"
 mpiexec -n $ncores_fd $taudemDir2/d8flowdir \
     -fel $tempCurrentBranchDataDir/dem_burned_filled_$current_branch_id.tif \
-    -p $tempCurrentBranchDataDir/flowdir_d8_burned_filled_$current_branch_id.tif
+    -p $tempCurrentBranchDataDir/flowdir_d8_burned_filled_$current_branch_id.tif \
+    2>&1 | sed -e 's/.*no output sd8 file specified.*/INFO: TauDEM d8flowdir running without optional sd8 slope output./I' \
+               -e 's/.*no output p file specified.*/INFO: TauDEM d8flowdir running without optional sd8 slope output./I'
 
 ## RASTERIZE NWM Levelpath HEADWATERS (1 & 0) ##
 echo -e $startDiv"Rasterize NHD Headwaters $hucNumber $current_branch_id"

--- a/src/run_huc.sh
+++ b/src/run_huc.sh
@@ -239,7 +239,9 @@ rd_depression_filling $tempCurrentBranchDataDir/dem_burned_$branch_zero_id.tif \
 echo -e $startDiv"D8 Flow Directions on Burned DEM $hucNumber $branch_zero_id"
 mpiexec -n $ncores_fd $taudemDir2/d8flowdir \
     -fel $tempCurrentBranchDataDir/dem_burned_filled_$branch_zero_id.tif \
-    -p $tempCurrentBranchDataDir/flowdir_d8_burned_filled_$branch_zero_id.tif
+    -p $tempCurrentBranchDataDir/flowdir_d8_burned_filled_$branch_zero_id.tif \
+    2>&1 | sed -e 's/.*no output sd8 file specified.*/INFO: TauDEM d8flowdir running without optional sd8 slope output./I' \
+               -e 's/.*no output p file specified.*/INFO: TauDEM d8flowdir running without optional sd8 slope output./I'
 
 ## MAKE A COPY OF THE DEM and DEM DIFF FOR BRANCH 0
 echo -e $startDiv"Copying DEM to Branch 0"

--- a/src/src_adjust_usgs_rating_trace.py
+++ b/src/src_adjust_usgs_rating_trace.py
@@ -185,12 +185,12 @@ def create_usgs_rating_database(
         ]
         final_df = pd.concat([final_df, calc_df], ignore_index=True)
         # Log any negative HAND elev values and remove from database
-        log_text += 'Warning: Negative HAND stage values -->\n'
+        log_text += 'INFO: Negative HAND stage values -->\n'
         log_text += calc_df[calc_df['hand'] < 0].to_string() + '\n'
         final_df = final_df[final_df['hand'] > 0]
         # Log any signifant differences btw the NWM flow value and closest USGS rating flow
         # This ensures that we consistently sample the USGS rating curves at known intervals - NWM recur flow
-        log_text += 'Warning: Large variance (>10%) between NWM flow and closest USGS flow -->\n'
+        log_text += 'INFO: Large variance (>10%) between NWM flow and closest USGS flow -->\n'
         log_text += calc_df[calc_df['check_variance'] > 0.1].to_string() + '\n'
         final_df = final_df[final_df['check_variance'] < 0.1]
         final_df['submitter'] = 'usgs_rating_wrds_api_' + final_df['location_id'].astype(str)

--- a/src/src_roughness_optimization.py
+++ b/src/src_roughness_optimization.py
@@ -461,7 +461,7 @@ def update_rating_curve(
                             how='left',
                             on='HydroID',
                         )
-                        output_catchments['src_calibrated'].fillna('False', inplace=True)
+                        output_catchments['src_calibrated'] = output_catchments['src_calibrated'].fillna('False')
 
                         try:
                             output_catchments.to_file(
@@ -556,9 +556,9 @@ def update_rating_curve(
 
                 ## Replace discharge_cms with 0 or -999 if present in the original discharge
                 # (carried over from thalweg notch workaround in SRC post-processing)
-                df_htable['discharge_cms'].mask(df_htable['precalb_discharge_cms'] == 0.0, 0.0, inplace=True)
-                df_htable['discharge_cms'].mask(
-                    df_htable['precalb_discharge_cms'] == -999, -999, inplace=True
+                df_htable['discharge_cms'] = df_htable['discharge_cms'].mask(df_htable['precalb_discharge_cms'] == 0.0, 0.0)
+                df_htable['discharge_cms'] = df_htable['discharge_cms'].mask(
+                    df_htable['precalb_discharge_cms'] == -999, -999
                 )
 
                 ## Export a new hydroTable.csv and overwrite the previous version

--- a/src/src_roughness_optimization.py
+++ b/src/src_roughness_optimization.py
@@ -461,7 +461,9 @@ def update_rating_curve(
                             how='left',
                             on='HydroID',
                         )
-                        output_catchments['src_calibrated'] = output_catchments['src_calibrated'].fillna('False')
+                        output_catchments['src_calibrated'] = output_catchments['src_calibrated'].fillna(
+                            'False'
+                        )
 
                         try:
                             output_catchments.to_file(
@@ -556,7 +558,9 @@ def update_rating_curve(
 
                 ## Replace discharge_cms with 0 or -999 if present in the original discharge
                 # (carried over from thalweg notch workaround in SRC post-processing)
-                df_htable['discharge_cms'] = df_htable['discharge_cms'].mask(df_htable['precalb_discharge_cms'] == 0.0, 0.0)
+                df_htable['discharge_cms'] = df_htable['discharge_cms'].mask(
+                    df_htable['precalb_discharge_cms'] == 0.0, 0.0
+                )
                 df_htable['discharge_cms'] = df_htable['discharge_cms'].mask(
                     df_htable['precalb_discharge_cms'] == -999, -999
                 )

--- a/src/thalweg_notches_adjustment.py
+++ b/src/thalweg_notches_adjustment.py
@@ -34,7 +34,7 @@ def reset_stage(srcs_df):
 def extend_src_linear_extrapolation(srcs_df, stages_full):
     # Re-inject grouping column for hydroid
     srcs_df['HydroID'] = srcs_df.name
-    
+
     # Number of the last rows of src to include in extrapolation
     num_rows = 3
     # Identify all value columns except 'Stage'
@@ -187,7 +187,9 @@ def correct_thalweg_notches(huc_dir, huc, stage_interval):
             # Apply extend_src_linear_extrapolation to each src_df
             src_df3 = (
                 src_df3.groupby('HydroID', group_keys=False)
-                .apply(lambda src_g: extend_src_linear_extrapolation(src_g, stages_full),include_groups=False)
+                .apply(
+                    lambda src_g: extend_src_linear_extrapolation(src_g, stages_full), include_groups=False
+                )
                 .sort_values(['HydroID', 'Stage'])
                 .reset_index(drop=True)
             )

--- a/src/thalweg_notches_adjustment.py
+++ b/src/thalweg_notches_adjustment.py
@@ -167,7 +167,7 @@ def correct_thalweg_notches(huc_dir, huc, stage_interval):
         if cond_ThalwegNRows.sum() > 0:
             src_df_skipTwNRows = src_df2[~cond_ThalwegNRows].copy()
             src_df_skipTwNRows_gb = (
-                src_df_skipTwNRows.groupby('HydroID', group_keys=False)
+                src_df_skipTwNRows.groupby('HydroID', group_keys=False, include_groups=False)
                 .apply(reset_stage)
                 .reset_index(drop=True)
             )
@@ -182,7 +182,7 @@ def correct_thalweg_notches(huc_dir, huc, stage_interval):
 
             # Apply extend_src_linear_extrapolation to each src_df
             src_df3 = (
-                src_df3.groupby('HydroID', group_keys=False)
+                src_df3.groupby('HydroID', group_keys=False, include_groups=False)
                 .apply(lambda src_g: extend_src_linear_extrapolation(src_g, stages_full))
                 .sort_values(['HydroID', 'Stage'])
                 .reset_index(drop=True)

--- a/src/thalweg_notches_adjustment.py
+++ b/src/thalweg_notches_adjustment.py
@@ -18,6 +18,8 @@ import pandas as pd
 # -------------------------------------------------------
 # Reseting stage column in SRCs for fixing thalweg notches
 def reset_stage(srcs_df):
+    # Re-inject grouping column for hydroid
+    srcs_df['HydroID'] = srcs_df.name
 
     stage_interval = 0.3048  # float(os.getenv('stage_interval_meters'))
 
@@ -30,7 +32,9 @@ def reset_stage(srcs_df):
 # -------------------------------------------------------
 # Extending src_df with linear_extrapolation for missing stages in thalweg notches
 def extend_src_linear_extrapolation(srcs_df, stages_full):
-
+    # Re-inject grouping column for hydroid
+    srcs_df['HydroID'] = srcs_df.name
+    
     # Number of the last rows of src to include in extrapolation
     num_rows = 3
     # Identify all value columns except 'Stage'
@@ -167,8 +171,8 @@ def correct_thalweg_notches(huc_dir, huc, stage_interval):
         if cond_ThalwegNRows.sum() > 0:
             src_df_skipTwNRows = src_df2[~cond_ThalwegNRows].copy()
             src_df_skipTwNRows_gb = (
-                src_df_skipTwNRows.groupby('HydroID', group_keys=False, include_groups=False)
-                .apply(reset_stage)
+                src_df_skipTwNRows.groupby('HydroID', group_keys=False)
+                .apply(reset_stage, include_groups=False)
                 .reset_index(drop=True)
             )
 
@@ -182,8 +186,8 @@ def correct_thalweg_notches(huc_dir, huc, stage_interval):
 
             # Apply extend_src_linear_extrapolation to each src_df
             src_df3 = (
-                src_df3.groupby('HydroID', group_keys=False, include_groups=False)
-                .apply(lambda src_g: extend_src_linear_extrapolation(src_g, stages_full))
+                src_df3.groupby('HydroID', group_keys=False)
+                .apply(lambda src_g: extend_src_linear_extrapolation(src_g, stages_full),include_groups=False)
                 .sort_values(['HydroID', 'Stage'])
                 .reset_index(drop=True)
             )


### PR DESCRIPTION
These changes resolve the numerous pandas 3.0 FutureWarnings as well as other miscellaneous "warning" messages that we track in our logging systems. Resolves #1799

### Changes
The scripts below were updated to address warnings. There were no changes to the resulting outputs.
`src/add_crosswalk.py`
`src/aggregate_branches_to_huc.py`
`src/bathymetric_adjustment.py`
`src/build_stream_traversal.py`
`src/delineate_hydros_and_produce_HAND.sh`
`src/heal_bridges_osm.py`
`src/identify_src_bankfull.py`
`src/longitudinal_flow_adjustment.py`
`src/mask_dem.py`
`src/mitigate_branch_outlet_backpool.py`
`src/nonmonotonic_src_adjustment.py`
`src/reset_htable_src.py`
`src/run_by_branch.sh`
`src/run_huc.sh`
`src/src_adjust_usgs_rating_trace.py`
`src/src_roughness_optimization.py`
`src/thalweg_notches_adjustment.py`

### Notes
**Summary of the Pandas Future Warnings and Insights on Changes:**

_Positional Indexing Deprecation (Series.__getitem__)_
- Warning Type: `Series.__getitem__ treating keys as positions is deprecated.`
- Source Scripts: `build_stream_traversal.py`, `add_crosswalk.py`
- Summary: Pandas is moving toward treating all integer keys as labels by default, matching DataFrame behavior. Currently, if an integer key is used on a Series with a non-integer index, pandas treats it as a position. This ambiguity is being removed.
- How to Address: Positional access: Change ser[i] to ser.iloc[i].

_GroupBy Apply Behavior (include_groups)_
- Warning Type: `DataFrameGroupBy.apply operated on the grouping columns.`
- Source Scripts: `thalweg_notches_adjustment.py`, `longitudinal_flow_adjustment.py`, `bathymetric_adjustment.py`
- Summary: When using .groupby(...).apply(func), the sub-dataframes passed to func currently include the columns used for grouping. In future versions, these will be excluded to improve performance and consistency.
- How to Address:Pass include_groups=False inside the .apply() call.
- Example change: df.groupby('id').apply(my_func) → df.groupby('id').apply(my_func, include_groups=False)

_Incompatible Dtype Assignment_
- Warning Type: `Setting an item of incompatible dtype is deprecated.`
- Source Scripts: `bathymetric_adjustment.py`
- Summary: This occurs when you attempt to assign a value (like a string "No Bathymetry Applied") to a column that pandas has already typed as numeric (e.g., float or int). Future versions will raise a TypeError.
- How to Address: Explicitly cast the column to object or string type before the assignment if it must hold mixed data. Alternatively, initialize the column with a consistent type.
- Example change: df['status'] = df['status'].astype(object) followed by the assignment.

_Chained Assignment & Chained Inplace Methods_
- Warning Type: `A value is trying to be set on a copy... through chained assignment using an inplace method.`
- Source Scripts: `add_crosswalk.py`, `longitudinal_flow_adjustment.py`
- Summary: This usually happens when you perform an operation on a subset of a DataFrame (e.g., df[df['a'] > 1]['b'].fillna(0, inplace=True)). Pandas cannot guarantee that the original DataFrame will be updated.
- How to Address: Avoid inplace=True on slices. Use .loc to access and modify the data in one step.
- Example change: df[mask]['col'].fillna(0, inplace=True) → df.loc[mask, 'col'] = df.loc[mask, 'col'].fillna(0)

_Concatenation with Empty Entries_
- Warning Type: `The behavior of array/DataFrame concatenation with empty entries is deprecated.`
- Source Scripts: `add_crosswalk.py`, `heal_bridges_osm.py`, `aggregate_branches_to_huc.py`
- Summary: When concatenating objects where some are empty or all-NA, the logic for determining the resulting data type is changing.
- How to Address: Filter out empty or null items from your list before calling pd.concat().
- Example change: pd.concat(list_of_dfs) → pd.concat([d for d in list_of_dfs if not d.empty])

---------------------------------------------------------------
### Testing
Performed testing on 3 hucs (02040105, 05030202, 12090301). Compared outputs using the `hash_compare.py` tool. Example usage:
`python3 foss_fim/tools/hash_compare.py outputs/dev_futurewarn_05030202/05030202/branches/0/rem_zeroed_masked_0.tif outputs/fix_futurewarn_05030202_v7/05030202/branches/0/rem_zeroed_masked_0.tif`

---------------------------------------------------------------
### Deployment Plan (For FIM developers use)
- **Does the change impact inputs, docker or python packages?**
    - [ ] Yes
    - [x] No  (f no.. skip the rest of the Deployment Plan section)
    
-  **If you are not a FIM dev team member:  Please let us know what you need and we can help with it.**

-  **If you are a FIM Dev team member:** 
    -  Please work with the DevOps team and do not just go ahead and do it without some co-ordination.
    -  Copy where you can, assign where you can not, and it is your responsibility to ensure it is done. Please ensure it is completed before the PR is merged. 
    
    - Has new or updated python packages, PipFile, Pipefile.lock or Dockerfile changes?  DevOps can help or take care of it if you want. Just need to know if it is required.
       - [ ] Yes
       - [x] No
    - Require new or adjusted data inputs? Does it have a way to version (folder or file dates)?
       - [x] No
       - [ ] Yes
           -  Require new pre-clip set or any other data reloads, such as DEMS, osm, etc. ie.. pre-requisite re-data upstream of your input changes.
                - [ ] Yes
                - [ ] No
           -  Has the inputs been copied/exist in all four enviros:
                 - [ ] FIM EFS  
                 - [ ] FIM S3
                 - [ ] ESIP
                 - [ ] Dev1
            
- Please use caution in removing older version unless it is at least two versions ago.  Confirm with DevOps if cleanup might be involved.

- If new or updated data sets, has the FIM code, including running fim_pipeline.sh, been updated and tested with the new/adjusted data? You can dev test against subsets if you like.
    - [ ] Yes

### Notes to DevOps Team or others:
Please add any notes that are helpful for us to make sure it is all done correctly. Do not put actual server names or full true paths, just shortcut paths like 'efs..../inputs/,  or 'dev1....inputs', etc.



---------------------------------------------------------------
### Issuer Checklist (For developer use)

You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code.

- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Links are provided if this PR resolves an issue, or depends on another other PR
- [x] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [x] Changes are limited to a single goal (no scope creep)
- [x] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [x] `pre-commit` hooks were run locally
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [x] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead
- [x] Where applicable, has fim_pipeline been tested with muliple HUCs, including some other unaffected HUCs?

### Reviewer / Approver Checklist
- [ ] Where applicable, has fim_pipeline been tested with muliple HUCs, including some other unaffected HUCs?
- [ ] If there are new inputs, have you confirmed that they have been copied to all enviroments?

---------------------------------------------------------------
### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
