### PR TITLE
[1pt] PR: Fix usgs_gage_unit_setup int column bug

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,16 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.9.x.x - 2026-06-27 - [PR#1873](https://github.com/NOAA-OWP/inundation-mapping/pull/1873)
+
+Fixes an error in the usgs_gage_unit_setup.py file for an error while casting to int on a column.
+
+Previously the 'feature_id' column could be Null, but a recent change when creating the usgs_gage file accidently changed that column default value from Null to "None" (str).  Compensated for it here.
+
+### Changes
+- `src\usgs_gage_unit_setup.py`: as described above.
+<br/>
+
 ## v4.9.17.1 - 2026-06-26 - [PR#1843](https://github.com/NOAA-OWP/inundation-mapping/pull/1843)
 
 Adds improved logging, datum correction, and error handling to the USGS curves retrieval script (and supporting functions). Fixed and updated the NWS LID Geopackage script. Resolved the Pandas FutureWarnings (previously present in USGS rating curve retrieval and CatFIM processing) that were caused by joining tables with missing column data types (caused by NA values in the input metadata).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,8 +7,14 @@ Fixes an error in the usgs_gage_unit_setup.py file for an error while casting to
 
 Previously the 'feature_id' column could be Null, but a recent change when creating the usgs_gage file accidently changed that column default value from Null to "None" (str).  Compensated for it here.
 
+During a full UAT test with this fix, it bubbled up another problem of alpha scores for usgs and nws dropping significantly.  I reverted the three lines in bash_variables to the earlier usgs gage files to the previous Sept 2025 set, then re-ran UAT. Results are now good. That suggests that there is data problems with the new usgs gage data. 
+
+bash_variables file reverted to the Sept 2025 set of usgs files.
+
 ### Changes
-- `src\usgs_gage_unit_setup.py`: as described above.
+- `src'
+    - `usgs_gage_unit_setup.py`: as described above.
+    - `bash_variables.env`: as described above.
 <br/>
 
 ## v4.9.17.1 - 2026-06-26 - [PR#1843](https://github.com/NOAA-OWP/inundation-mapping/pull/1843)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## v4.9.x.x - 2026-06-27 - [PR#1873](https://github.com/NOAA-OWP/inundation-mapping/pull/1873)
+## v4.9.17.2 - 2026-07-01 - [PR#1873](https://github.com/NOAA-OWP/inundation-mapping/pull/1873)
 
 Fixes an error in the usgs_gage_unit_setup.py file for an error while casting to int on a column.
 

--- a/src/bash_variables.env
+++ b/src/bash_variables.env
@@ -125,9 +125,12 @@ export                      vmann_input_file=${inputsDir}/rating_curve/variable_
 export                         nwm_recur_file=${inputsDir}/rating_curve/nwm_recur_flows/nwm3_17C_recurrence_flows_cfs.csv
 
 # input file location with usgs rating curve database and acceptable USGS sites CSV
-export                        usgs_gages_file=${inputsDir}/usgs_gages/20260624/usgs_gages.gpkg
-export                  usgs_rating_curve_csv=${inputsDir}/usgs_gages/20260624/usgs_rating_curves.csv
-export             usgs_acceptable_gages_path=${inputsDir}/usgs_gages/20260624/acceptable_sites_for_rating_curves.csv
+export                        usgs_gages_file=${inputsDir}/usgs_gages/20250914/usgs_gages.gpkg
+export                  usgs_rating_curve_csv=${inputsDir}/usgs_gages/20250914/usgs_rating_curves.csv
+export             usgs_acceptable_gages_path=${inputsDir}/usgs_gages/20250914/acceptable_sites_for_rating_curves.csv
+# export                        usgs_gages_file=${inputsDir}/usgs_gages/20260624/usgs_gages.gpkg
+# export                  usgs_rating_curve_csv=${inputsDir}/usgs_gages/20260624/usgs_rating_curves.csv
+# export             usgs_acceptable_gages_path=${inputsDir}/usgs_gages/20260624/acceptable_sites_for_rating_curves.csv
 
 # input file locations for ras2fim locations and rating curve data
 export                      ras2fim_input_dir=${inputsDir}/rating_curve/ras2fim_exports/v2_0

--- a/src/usgs_gage_unit_setup.py
+++ b/src/usgs_gage_unit_setup.py
@@ -7,6 +7,7 @@ import warnings
 from posixpath import dirname
 
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 from shapely.geometry import Point
 
@@ -62,6 +63,8 @@ class Gage2Branch(object):
 
         # Filter USGS gages and RAS locations to huc
         self.gages = gages_locs[(gages_locs.HUC8 == self.huc8)]
+        # Jun 2026: Use to have Null in that column, now it has the string of "None"
+        self.gages["feature_id"].replace("None", np.nan, inplace=True)
 
         # Get AHPS sites within the HUC and add them to the USGS dataset
         if self.ahps_filename:
@@ -86,7 +89,7 @@ class Gage2Branch(object):
 
         # Create gages attribute
         self.gages.location_id.fillna(self.gages.nws_lid, inplace=True)
-        self.gages.loc[self.gages['nws_lid'] == 'Bogus_ID', 'nws_lid'] = None
+        # self.gages.loc[self.gages['nws_lid'] == 'Bogus_ID', 'nws_lid'] = None
 
     def sort_into_branch(self, nwm_subset_streams_levelPaths):
         nwm_reaches = gpd.read_file(nwm_subset_streams_levelPaths)
@@ -105,6 +108,8 @@ class Gage2Branch(object):
             del nwm_reaches_union
 
         # Left join gages with NWM streams to get the level path
+        # If the feature_id is Null, change it to a large neg so it won't won't merge
+        self.gages.feature_id.replace(np.nan, "-999999999", inplace=True)
         self.gages.feature_id = self.gages.feature_id.astype(int)
         self.gages = self.gages.merge(
             nwm_reaches[['feature_id', 'levpa_id', 'order_']], on='feature_id', how='left'


### PR DESCRIPTION
Fixes an error in the usgs_gage_unit_setup.py file for an error while casting to int on a column.

Previously the 'feature_id' column could be Null, but a recent change when creating the usgs_gage file accidently changed that column default value from Null to "None" (str).  Compensated for it here.

During a full UAT test with this fix, it bubbled up another problem of alpha scores for usgs and nws dropping significantly.  I reverted the three lines in bash_variables to the earlier usgs gage files to the previous Sept 2025 set, then re-ran UAT. Results are now good. That suggests that there is data problems with the new usgs gage data. Card [1847](https://github.com/NOAA-OWP/inundation-mapping/issues/1874) has been created for a future release and prod version.

bash_variables file reverted to the Sept 2025 set of usgs files.

Closes #1872 

### Changes
- `src'
    - `usgs_gage_unit_setup.py`: as described above.
    - `bash_variables.env`: as described above.

---------------------------------------------------------------
### Testing

Not all HUCs trigger this problem, but was seen in at least 03020203, 02050107 and likely the bulk of the HUCs before the run was aborted. Fix was tested via pipeline against 03020203.


---------------------------------------------------------------
### Deployment Plan (For FIM developers use)
- **Does the change impact inputs, docker or python packages?**
    - [ ] Yes
    - [x] No  (f no.. skip the rest of the Deployment Plan section)
    
-  **If you are not a FIM dev team member:  Please let us know what you need and we can help with it.**

-  **If you are a FIM Dev team member:** 
    -  Please work with the DevOps team and do not just go ahead and do it without some co-ordination.
    -  Copy where you can, assign where you can not, and it is your responsibility to ensure it is done. Please ensure it is completed before the PR is merged. 
    
    - Has new or updated python packages, PipFile, Pipefile.lock or Dockerfile changes?  DevOps can help or take care of it if you want. Just need to know if it is required.
       - [ ] Yes
       - [ ] No
    - Require new or adjusted data inputs? Does it have a way to version (folder or file dates)?
       - [ ] No
       - [ ] Yes
           -  Require new pre-clip set or any other data reloads, such as DEMS, osm, etc. ie.. pre-requisite re-data upstream of your input changes.
                - [ ] Yes
                - [ ] No
           -  Has the inputs been copied/exist in all four enviros:
                 - [ ] FIM EFS  
                 - [ ] FIM S3
                 - [ ] ESIP
                 - [ ] Dev1
            
- Please use caution in removing older version unless it is at least two versions ago.  Confirm with DevOps if cleanup might be involved.

- If new or updated data sets, has the FIM code, including running fim_pipeline.sh, been updated and tested with the new/adjusted data? You can dev test against subsets if you like.
    - [ ] Yes

### Notes to DevOps Team or others:
Please add any notes that are helpful for us to make sure it is all done correctly. Do not put actual server names or full true paths, just shortcut paths like 'efs..../inputs/,  or 'dev1....inputs', etc.

---------------------------------------------------------------
### Issuer Checklist (For developer use)

You may update this checklist before and/or after creating the PR. If you're unsure about any of them, please ask, we're here to help! These items are what we are going to look for before merging your code.

- [ ] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [ ] Links are provided if this PR resolves an issue, or depends on another other PR
- [ ] If submitting a PR to the `dev` branch (the default branch), you have a descriptive [Feature Branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) name using the format: `dev-<description-of-change>` (e.g. `dev-revise-levee-masking`)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] The feature branch you're submitting as a PR is up to date (merged) with the latest `dev` branch
- [ ] `pre-commit` hooks were run locally
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number, e.g. `4.x.x.x`
- [ ] Add yourself as an [assignee](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the PR  as well as the FIM Technical Lead
- [ ] Where applicable, has fim_pipeline been tested with muliple HUCs, including some other unaffected HUCs?

### Reviewer / Approver Checklist
- [ ] Where applicable, has fim_pipeline been tested with muliple HUCs, including some other unaffected HUCs?
- [ ] If there are new inputs, have you confirmed that they have been copied to all enviroments?

---------------------------------------------------------------
### Merge Checklist (For Technical Lead use only)

- [ ] Update [CHANGELOG](/docs/CHANGELOG.md) with latest version number and merge date
- [ ] Update the [Citation.cff](/CITATION.cff) file to reflect the latest version number in the [CHANGELOG](/docs/CHANGELOG.md)
- [ ] If applicable, update [README](/README.md) with major alterations
