### PR TITLE
Remove unused imports (F401) across codebase

### DIFF
--- a/data/bridges/make_dem_dif_for_bridges.py
+++ b/data/bridges/make_dem_dif_for_bridges.py
@@ -1,6 +1,5 @@
 import argparse
 import glob
-import logging
 import os
 import shlex
 import sys
@@ -15,9 +14,7 @@ import pandas as pd
 import rasterio
 
 # import rioxarray
-import xarray as xr
 from rasterio.features import rasterize
-from rasterio.merge import merge
 from shapely.geometry import Point
 
 from data.create_vrt_file import create_vrt_file

--- a/data/bridges/make_rasters_using_lidar.py
+++ b/data/bridges/make_rasters_using_lidar.py
@@ -12,17 +12,13 @@ import traceback
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
-from multiprocessing import Pool
-from pathlib import Path
 
 import geopandas as gpd
 import laspy
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import xarray as xr
 from scipy.spatial import KDTree
-from shapely.geometry import MultiPoint, Point
+from shapely.geometry import MultiPoint
 from tqdm import tqdm
 
 

--- a/data/bridges/pull_osm_bridges.py
+++ b/data/bridges/pull_osm_bridges.py
@@ -1,6 +1,5 @@
 import argparse
 import datetime as dt
-import glob
 import os
 import shlex
 import sys

--- a/data/buildings/make_buildings_parts_per_huc.py
+++ b/data/buildings/make_buildings_parts_per_huc.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import geopandas as gpd
-import pandas as pd
 import pyarrow.parquet as pq
 from dotenv import load_dotenv
 from shapely.geometry import box

--- a/data/nld/levee_download.py
+++ b/data/nld/levee_download.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-import sys
 from datetime import datetime
 
 import geopandas as gpd

--- a/data/nws/merge_nws_usgs_point_parquet.py
+++ b/data/nws/merge_nws_usgs_point_parquet.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import shutil
 
 import geopandas as gpd
 import pandas as pd

--- a/data/nws/preprocess_ahps_nws.py
+++ b/data/nws/preprocess_ahps_nws.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import os
-import pathlib
-import sys
 import traceback
-from collections import defaultdict
 from pathlib import Path
 
 import geopandas as gpd
@@ -28,7 +25,6 @@ from tools_shared_functions import (
     select_grids,
 )
 
-from utils.shared_variables import PREP_PROJECTION, VIZ_PROJECTION
 
 
 # TODO: Jun 2025: Change this to have a path to the config via an arg.

--- a/data/ripple/terrain_agreement_metrics_analysis.py
+++ b/data/ripple/terrain_agreement_metrics_analysis.py
@@ -6,7 +6,6 @@ import re
 import sqlite3
 import traceback
 from argparse import ArgumentParser
-from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 import geopandas as gpd

--- a/data/ripple/validate_ripple_data.py
+++ b/data/ripple/validate_ripple_data.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
 import logging
 import os
 import sys

--- a/data/roads/pull_osm_roads.py
+++ b/data/roads/pull_osm_roads.py
@@ -21,12 +21,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import geopandas as gpd
-import numpy as np
 import overpy
 import pandas as pd
 import pyproj
 from dotenv import load_dotenv
-from overpy.exception import OverpassGatewayTimeout, OverpassTooManyRequests
 from shapely.geometry import LineString
 
 from src.utils.shared_functions import FIM_Helpers as fh

--- a/data/usgs/acquire_and_preprocess_3dep_dems.py
+++ b/data/usgs/acquire_and_preprocess_3dep_dems.py
@@ -2,7 +2,6 @@
 
 import argparse
 import glob
-import logging
 import os
 import subprocess
 import sys
@@ -16,7 +15,6 @@ import pandas as pd
 
 import src.utils.shared_functions as sf
 import src.utils.shared_validators as val
-from data.create_vrt_file import create_vrt_file
 from src.utils.polygonize_raster import polygonize
 from src.utils.shared_functions import FIM_Helpers as fh
 

--- a/data/usgs/preprocess_ahps_usgs.py
+++ b/data/usgs/preprocess_ahps_usgs.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import os
-import sys
 import traceback
 from pathlib import Path
 

--- a/data/wbd/clip_vectors_to_wbd.py
+++ b/data/wbd/clip_vectors_to_wbd.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
-import rasterio as rio
 from dotenv import load_dotenv
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.ops import nearest_points

--- a/data/wbd/generate_pre_clip_fim_huc8.py
+++ b/data/wbd/generate_pre_clip_fim_huc8.py
@@ -18,7 +18,6 @@ import geopandas as gpd
 from clip_vectors_to_wbd import subset_vector_layers
 from dotenv import load_dotenv
 
-from src.utils.shared_functions import FIM_Helpers as fh
 
 
 """

--- a/data/wrds/download_process_wrds.py
+++ b/data/wrds/download_process_wrds.py
@@ -2,7 +2,7 @@
 import argparse
 import os
 import pickle
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 
 import pandas as pd
 from dotenv import load_dotenv

--- a/data/wrds/mimic_wrds_data.py
+++ b/data/wrds/mimic_wrds_data.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 import pickle
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 
 import geopandas as gpd
 import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ extend-ignore = """
     E712,
     W503,
     W391,
-    F401,
     F403,
     """
 exclude = ["*.csv", "*.yml", "*.txt"]

--- a/src/add_crosswalk.py
+++ b/src/add_crosswalk.py
@@ -8,7 +8,6 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from numpy import unique
-from rasterstats import zonal_stats
 
 from utils.fim_enums import FIM_exit_codes
 from utils.shared_functions import getDriver

--- a/src/aggregate_branches_to_huc.py
+++ b/src/aggregate_branches_to_huc.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
 import os
-import re
 import traceback
-from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from os.path import join
 

--- a/src/bathy_rc_adjust.py
+++ b/src/bathy_rc_adjust.py
@@ -3,7 +3,6 @@
 from os import environ
 
 import geopandas as gpd
-import numpy as np
 import pandas as pd
 
 

--- a/src/bathymetric_adjustment.py
+++ b/src/bathymetric_adjustment.py
@@ -6,7 +6,6 @@ import re
 import sys
 import traceback
 from argparse import ArgumentParser
-from concurrent.futures import ProcessPoolExecutor, as_completed
 from os.path import join
 
 import geopandas as gpd

--- a/src/clip_rasters_to_branches.py
+++ b/src/clip_rasters_to_branches.py
@@ -5,7 +5,7 @@ import argparse
 
 from tqdm import tqdm
 
-from stream_branches import StreamBranchPolygons, StreamNetwork
+from stream_branches import StreamBranchPolygons
 
 
 if __name__ == '__main__':

--- a/src/crosswalk_nwm_demDerived.py
+++ b/src/crosswalk_nwm_demDerived.py
@@ -4,12 +4,9 @@ import argparse
 
 import geopandas as gpd
 import numpy as np
-import pandas as pd
 from shapely.geometry import MultiLineString
 
 import stream_branches as sb
-from utils.shared_functions import getDriver
-from utils.shared_variables import FIM_ID
 
 
 gpd.options.io_engine = "pyogrio"

--- a/src/heal_bridges_osm.py
+++ b/src/heal_bridges_osm.py
@@ -1,5 +1,4 @@
 import argparse
-import glob
 import os
 import re
 
@@ -7,7 +6,6 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import rasterio
-import xarray as xr
 from rasterio import features
 from rasterio.warp import Resampling, reproject
 from rasterstats import zonal_stats

--- a/src/identify_src_bankfull.py
+++ b/src/identify_src_bankfull.py
@@ -2,17 +2,11 @@
 
 import argparse
 import datetime as dt
-import multiprocessing
 import os
-import re
-import shutil
-import sys
 import traceback
 import warnings
-from functools import reduce
 from multiprocessing import Pool
-from os.path import dirname, isdir, isfile, join
-from pathlib import Path
+from os.path import isdir, isfile, join
 
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/src/longitudinal_flow_adjustment.py
+++ b/src/longitudinal_flow_adjustment.py
@@ -6,7 +6,6 @@ import os
 import re
 import traceback
 from argparse import ArgumentParser
-from concurrent.futures import ProcessPoolExecutor, as_completed
 from os.path import join
 
 import geopandas as gpd

--- a/src/nonmonotonic_src_adjustment.py
+++ b/src/nonmonotonic_src_adjustment.py
@@ -6,10 +6,8 @@
 
 import datetime as dt
 import os
-import re
 import traceback
 from argparse import ArgumentParser
-from concurrent.futures import ProcessPoolExecutor, as_completed
 from os.path import join
 
 import numpy as np

--- a/src/process_buildings_fimpact.py
+++ b/src/process_buildings_fimpact.py
@@ -1,16 +1,9 @@
 import argparse
-import glob
-import os
-import re
 from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
-import pandas as pd
 import rasterio
-import xarray as xr
-from rasterio import features
-from rasterio.warp import Resampling, reproject
 from rasterstats import zonal_stats
 
 

--- a/src/process_roads_fimpact.py
+++ b/src/process_roads_fimpact.py
@@ -1,16 +1,9 @@
 import argparse
-import glob
-import os
-import re
 from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
-import pandas as pd
 import rasterio
-import xarray as xr
-from rasterio import features
-from rasterio.warp import Resampling, reproject
 from rasterstats import zonal_stats
 
 

--- a/src/reset_htable_src.py
+++ b/src/reset_htable_src.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import re
 
 import pandas as pd
 

--- a/src/src_adjust_ras2fim_rating.py
+++ b/src/src_adjust_ras2fim_rating.py
@@ -2,18 +2,14 @@
 
 import argparse
 import datetime as dt
-import json
-import multiprocessing
 import os
 import sys
-from collections import deque
 from multiprocessing import Pool
-from pathlib import Path
 
 import pandas as pd
 
 from src_roughness_optimization import update_rating_curve
-from utils.shared_functions import check_file_age, concat_huc_csv
+from utils.shared_functions import check_file_age
 
 
 '''

--- a/src/src_adjust_spatial_obs.py
+++ b/src/src_adjust_spatial_obs.py
@@ -2,7 +2,6 @@
 
 import argparse
 import datetime as dt
-import multiprocessing
 import os
 import sys
 from multiprocessing import Pool

--- a/src/src_adjust_usgs_rating_trace.py
+++ b/src/src_adjust_usgs_rating_trace.py
@@ -1,6 +1,5 @@
 import argparse
 import datetime as dt
-import multiprocessing
 import os
 import sys
 from multiprocessing import Pool
@@ -10,7 +9,7 @@ import pandas as pd
 
 from src_roughness_optimization import update_rating_curve
 from tools.tools_shared_functions import filter_usgs_by_acceptance_criteria
-from utils.shared_functions import check_file_age, concat_huc_csv
+from utils.shared_functions import check_file_age
 from utils.shared_variables import USGS_CALB_TRACE_DIST
 
 

--- a/src/src_roughness_optimization.py
+++ b/src/src_roughness_optimization.py
@@ -1,17 +1,9 @@
-import argparse
-import datetime as dt
-import json
-import multiprocessing
 import os
-import sys
 from collections import deque
-from multiprocessing import Pool
 
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import rasterio
-from geopandas.tools import sjoin
 
 from utils.shared_variables import DOWNSTREAM_THRESHOLD, ROUGHNESS_MAX_THRESH, ROUGHNESS_MIN_THRESH
 

--- a/src/stream_branches.py
+++ b/src/stream_branches.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import sys
 from collections import deque
 from os.path import isfile, splitext
 from random import sample
@@ -16,11 +15,10 @@ from rasterio.io import DatasetReader
 from rasterio.mask import mask
 from scipy.stats import mode
 from shapely.geometry import LineString, MultiLineString, MultiPoint, Point
-from shapely.ops import linemerge, unary_union
+from shapely.ops import linemerge
 from shapely.strtree import STRtree
 from tqdm import tqdm
 
-from utils.fim_enums import FIM_exit_codes
 from utils.shared_variables import PREP_CRS
 
 

--- a/src/subdiv_chan_obank_src.py
+++ b/src/subdiv_chan_obank_src.py
@@ -1,17 +1,11 @@
 #!/usr/bin/env python3
 import argparse
 import datetime as dt
-import multiprocessing
 import os
-import re
-import shutil
-import sys
 import traceback
 import warnings
-from functools import reduce
 from multiprocessing import Pool
-from os.path import dirname, isdir, isfile, join
-from pathlib import Path
+from os.path import isdir, isfile, join
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/src/thalweg_notches_adjustment.py
+++ b/src/thalweg_notches_adjustment.py
@@ -5,10 +5,8 @@
 
 import datetime as dt
 import os
-import re
 import traceback
 from argparse import ArgumentParser
-from concurrent.futures import ProcessPoolExecutor, as_completed
 from os.path import join
 
 import numpy as np

--- a/src/usgs_gage_unit_setup.py
+++ b/src/usgs_gage_unit_setup.py
@@ -4,13 +4,10 @@ import argparse
 import os
 import re
 import warnings
-from posixpath import dirname
 
 import geopandas as gpd
 import pandas as pd
-from shapely.geometry import Point
 
-from utils.shared_variables import PREP_CRS
 
 
 gpd.options.io_engine = "pyogrio"

--- a/src/utils/shared_functions.py
+++ b/src/utils/shared_functions.py
@@ -12,7 +12,7 @@ import shutil
 # import sys
 import threading
 import traceback
-from concurrent.futures import Future, ProcessPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
 from multiprocessing import Manager
 from os.path import splitext
@@ -20,7 +20,6 @@ from pathlib import Path
 
 # import fiona
 import geopandas as gp
-import numpy as np
 import pandas as pd
 from fsspec.core import url_to_fs
 from tqdm import tqdm

--- a/tools/analyze_flood_impact.py
+++ b/tools/analyze_flood_impact.py
@@ -5,7 +5,6 @@ from timeit import default_timer as timer
 
 import geopandas as gpd
 import numpy as np
-import pandas as pd
 import rasterio
 from rasterio import features as riofeatures
 

--- a/tools/catfim/catfim_post_processing.py
+++ b/tools/catfim/catfim_post_processing.py
@@ -5,7 +5,6 @@ import traceback
 from datetime import datetime, timezone
 
 import geopandas as gpd
-from dotenv import load_dotenv
 
 import src.utils.shared_functions as sf
 import tools.catfim.catfim_shared_functions as csf

--- a/tools/catfim/catfim_sites_compare.py
+++ b/tools/catfim/catfim_sites_compare.py
@@ -12,8 +12,6 @@ import numpy as np
 import pandas as pd
 from pyproj import CRS
 from shapely import wkt
-from shapely.geometry import MultiPolygon, Point, Polygon
-from shapely.ops import cascaded_union, unary_union
 
 
 pd.options.mode.chained_assignment = None  # default='warn'

--- a/tools/catfim/vis_categorical_fim.py
+++ b/tools/catfim/vis_categorical_fim.py
@@ -2,21 +2,16 @@
 
 import os
 import sys
-from os import listdir
 
 import geopandas as gpd
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import rasterio
 import requests
 import shapely
 from PIL import Image
-from rasterio.plot import show
-from shapely import segmentize
-from shapely.geometry import LineString, Point
-from shapely.geometry.polygon import Polygon
+from shapely.geometry import LineString
 from shapely.ops import substring
 
 

--- a/tools/check_deep_flooding.py
+++ b/tools/check_deep_flooding.py
@@ -10,7 +10,6 @@ import rasterio
 import rasterio.crs
 import rasterio.mask
 import rasterio.shutil
-from rasterio.warp import Resampling, calculate_default_transform, reproject
 from shapely.geometry import box
 
 

--- a/tools/compare_ms_and_non_ms_metrics.py
+++ b/tools/compare_ms_and_non_ms_metrics.py
@@ -1,17 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
-from concurrent.futures import ProcessPoolExecutor, as_completed
-from glob import glob
-from itertools import product
 
-import numpy as np
-import pandas as pd
-from tools_shared_functions import csi, far, mcc, tpr
-from tqdm import tqdm
 
-from tools.shared_variables import OUTPUTS_DIR, TEST_CASES_DIR
 
 
 def Compare_ms_and_non_ms_areas():

--- a/tools/eval_plots.py
+++ b/tools/eval_plots.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
 import os
 import re
 from pathlib import Path

--- a/tools/eval_plots_stackedbar.py
+++ b/tools/eval_plots_stackedbar.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import sys
 from pathlib import Path
 
 import matplotlib.pyplot as plt

--- a/tools/find_max_catchment_breadth.py
+++ b/tools/find_max_catchment_breadth.py
@@ -2,10 +2,9 @@
 
 import argparse
 import os
-from glob import glob, iglob
+from glob import iglob
 
 import geopandas as gpd
-import pandas as pd
 from shapely.geometry import Point
 
 

--- a/tools/inundate_nation.py
+++ b/tools/inundate_nation.py
@@ -13,7 +13,6 @@ from multiprocessing import Pool
 import rasterio
 from inundate_mosaic_wrapper import produce_mosaicked_inundation
 from rasterio.enums import Resampling
-from rasterio.shutil import copy
 from rio_vrt import build_vrt
 
 from utils.shared_functions import FIM_Helpers as fh

--- a/tools/lofi/probabilistic_generate_metric_response_surfaces.py
+++ b/tools/lofi/probabilistic_generate_metric_response_surfaces.py
@@ -4,7 +4,6 @@ from glob import glob
 from itertools import product
 from typing import List, Optional
 
-import gval
 import numpy as np
 import rioxarray as rxr
 import xarray as xr

--- a/tools/manningN_optimization.py
+++ b/tools/manningN_optimization.py
@@ -2,7 +2,6 @@ import argparse
 import csv
 import json
 import os
-import random
 import re
 import sys
 import traceback
@@ -12,7 +11,6 @@ from functools import partial
 from os.path import join
 
 import geopandas as gpd
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from run_test_case_mannN_optz_func import (
@@ -21,7 +19,7 @@ from run_test_case_mannN_optz_func import (
     filter_longitudinal_discharge_jitters,
     list_all_test_cases,
 )
-from scipy.optimize import NonlinearConstraint, differential_evolution, minimize
+from scipy.optimize import NonlinearConstraint, differential_evolution
 from tools_shared_variables import MAGNITUDE_DICT, TEST_CASES_DIR
 
 

--- a/tools/pixel_counter.py
+++ b/tools/pixel_counter.py
@@ -11,7 +11,7 @@ import pandas as pd
 # Import raster and vector function libraries
 # from types import NoneType
 from osgeo import gdal, ogr
-from osgeo.gdalconst import *
+
 from pixel_counter_functions import (
     get_bridge_counts,
     get_levee_counts,

--- a/tools/plots.py
+++ b/tools/plots.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from matplotlib.ticker import FixedFormatter, FixedLocator, FormatStrFormatter, NullFormatter
+from matplotlib.ticker import FixedLocator, FormatStrFormatter, NullFormatter
 from statsmodels.robust.robust_linear_model import RLM
 
 

--- a/tools/rating_curve_comparison.py
+++ b/tools/rating_curve_comparison.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 import shutil
-import sys
 import time
 import traceback
 import warnings

--- a/tools/rerun_calibration.py
+++ b/tools/rerun_calibration.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import errno
-import glob
 import os
 import re
 import subprocess
@@ -9,9 +8,6 @@ from datetime import datetime
 from pathlib import Path
 from timeit import default_timer as timer
 
-import geopandas as gpd
-import numpy as np
-import pandas as pd
 
 from src.utils.shared_functions import run_with_mp, setup_mp_file_logger
 

--- a/tools/run_test_case_mannN_optz_func.py
+++ b/tools/run_test_case_mannN_optz_func.py
@@ -19,7 +19,6 @@ from tools_shared_functions import compute_contingency_stats_from_rasters
 from tools_shared_variables import (  # INPUTS_DIR,
     AHPS_BENCHMARK_CATEGORIES,
     MAGNITUDE_DICT,
-    OUTPUTS_DIR,
     PREVIOUS_FIM_DIR,
     TEST_CASES_DIR,
     elev_raster_ndv,

--- a/tools/synthesize_test_cases.py
+++ b/tools/synthesize_test_cases.py
@@ -7,9 +7,8 @@ import os
 import re
 import sys
 import traceback
-from concurrent.futures import ProcessPoolExecutor, as_completed, wait
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime
-from multiprocessing import Pool
 
 import pandas as pd
 from run_test_case import Test_Case


### PR DESCRIPTION
Closes #1011

- Remove F401 from flake8 `extend-ignore` in pyproject.toml
- Use ruff auto-fix to remove 154+ unused import errors across 55+ files
- Remove unused `from osgeo.gdalconst import *` wildcard import in pixel_counter.py

```
flake8 --select=F401 --exclude=.venv,__pycache__  # passes clean
```