### PR TITLE
Refactor manning subdivision

### DIFF
--- a/src/utils/shared_functions.py
+++ b/src/utils/shared_functions.py
@@ -8,6 +8,7 @@ import os
 # import pathlib
 import re
 import shutil
+from contextlib import contextmanager
 
 # import sys
 import threading
@@ -31,6 +32,18 @@ _LOGGER_REGISTRY = {}
 
 gp.options.io_engine = "pyogrio"
 
+
+@contextmanager
+def use_pandas_3_behavior():
+    """Enable pandas 3.0 behavior temporarily.
+    1. Enable Copy-on-Write behavior for improved memory management.
+    2. Use PyArrow strings for better performance/memory usage.
+    3. Disable silent downcasting with fillna, replace, and clip.
+    """
+    with pd.option_context("mode.copy_on_write", True,
+                           "future.infer_string", True,
+                           "future.no_silent_downcasting", True):
+        yield
 
 # #################################
 # log file tools

--- a/tools/lofi/probabilistic_bayesian_update.py
+++ b/tools/lofi/probabilistic_bayesian_update.py
@@ -243,8 +243,8 @@ def run_bayesian_updates(
     parameter_names = ["channel_manning_roughness", "overbank_manning_roughness", "slope_adjustment"]
 
     # Apply transformations
-    channel_manning_data = channel_manning_data * 100
-    overbank_manning_data = overbank_manning_data * 100
+    channel_manning_data = np.asarray(channel_manning_data) * 100
+    overbank_manning_data = np.asarray(overbank_manning_data) * 100
     slope_adjustment_data = np.interp(slope_adjustment_data, [-0.1, 0, 0.1], [0.852, 1.648, 2.5])
 
     n_shp, n_scale, n_loc = bayesian_update_for_channel_manning_roughness(channel_manning_data)

--- a/tools/lofi/probabilistic_inundation.py
+++ b/tools/lofi/probabilistic_inundation.py
@@ -30,7 +30,7 @@ from scipy.stats import (
 from shapely.geometry import shape
 from tqdm import tqdm
 
-from utils.shared_functions import s3_or_local_glob
+from utils.shared_functions import s3_or_local_glob, use_pandas_3_behavior
 
 
 def get_fim_probability_distributions(
@@ -201,6 +201,142 @@ def generate_streamflow_percentiles(
         return rv
 
 
+@use_pandas_3_behavior()
+def compute_manning_subdivision(df_src, channel_manning, overbank_manning, slope_adj, eps=1e-5):
+    # Extract columns as numpy arrays. Ordering must not change during computation
+    # The following variables should be views (ie memory not owned by this function)
+    vstage = df_src['Stage'].to_numpy()
+    vstage_bf = df_src['Stage_bankfull'].to_numpy()
+    vvol = df_src['Volume (m3)'].to_numpy()
+    vvol_bf = df_src['Volume_bankfull'].to_numpy()
+    vsurf_area_bf = df_src['SurfArea_bankfull'].to_numpy()
+    vbedarea = df_src['BedArea (m2)'].to_numpy()
+    vbedarea_bf = df_src['BedArea_bankfull'].to_numpy()
+    vlengthkm = df_src['LENGTHKM'].to_numpy()
+    vslope_rise = df_src['SLOPE_RISE_RUN'].to_numpy()
+    vslope_main = df_src['SLOPE'].to_numpy()
+    vq_orig = df_src['Discharge (m3s-1)'].to_numpy()
+
+    # The memory buffers in the following code are allocated and managed very carefully.
+    # Please understand how memory is allocated and used before making *any* changes.
+    # References to arrays are cleared when they are no longer needed in order
+    # to keep each array referenced by only 1 reference.
+    lengthm = vlengthkm * 1000
+    mask = vstage <= vstage_bf
+    delta_stage = vstage - vstage_bf
+
+    vol_chan = delta_stage * vsurf_area_bf
+    np.add(vol_chan, vvol_bf, out=vol_chan) # Estimated channel volume
+    np.minimum(vol_chan, vvol, out=vol_chan) # ensure that estimated doesn't exceed actual volume
+    np.copyto(vol_chan, vvol, where=mask) # Use actual volume where stage is below bankfull
+
+    # Compute volume overbank
+    vol_obank = vvol - vol_chan
+    np.maximum(vol_obank, 0.0, out=vol_obank) # Ensure that vol_obank is always positive
+    np.putmask(vol_obank, mask, 0.0) # Set overbank to 0 where stage doesn't exceed bankfull
+
+    wetarea_chan = np.divide(vol_chan, lengthm, out=vol_chan)
+    del vol_chan
+
+    # Compute channel bedarea
+    bedarea_chan = np.where(mask, vbedarea, vbedarea_bf)
+    np.minimum(bedarea_chan, vbedarea_bf, out=bedarea_chan, where=mask)
+
+    bedarea_obank = vbedarea - bedarea_chan
+    np.maximum(bedarea_obank, 0.0, out=bedarea_obank)
+    np.putmask(bedarea_obank, mask, 0.0)
+
+    wettedperim_chan = bedarea_chan / lengthm
+    np.multiply(delta_stage, 2, out=delta_stage)
+    np.add(wettedperim_chan, delta_stage, out=wettedperim_chan, where=mask)
+    del delta_stage, bedarea_chan
+
+    np.maximum(wettedperim_chan, eps, out=wettedperim_chan)
+    hydraulicrad_chan = np.divide(wetarea_chan, wettedperim_chan, out=wettedperim_chan)
+    del wettedperim_chan
+
+    hydraulicrad_chan = np.maximum(hydraulicrad_chan, 0.0, out=hydraulicrad_chan)
+    np.power(hydraulicrad_chan, 2/3, out=hydraulicrad_chan)
+
+    # Compute channel discharge
+    q_chan = np.multiply(wetarea_chan, hydraulicrad_chan, out=wetarea_chan)
+    del wetarea_chan
+
+    slope = np.add(vslope_rise, slope_adj, out=hydraulicrad_chan)
+    np.maximum(slope, eps, out=slope)
+    np.sqrt(slope, out=slope)
+    del hydraulicrad_chan
+
+    np.multiply(q_chan, slope, out=q_chan)
+    np.multiply(q_chan, 1/np.float64(channel_manning), out=q_chan)
+
+    wetarea_obank = np.divide(vol_obank, lengthm, out=vol_obank)
+    del vol_obank
+
+    wettedperim_obank = np.divide(bedarea_obank, lengthm, out=bedarea_obank)
+    np.maximum(wettedperim_obank, eps, out=wettedperim_obank)
+    del bedarea_obank
+
+    hydraulicrad_obank = np.divide(wetarea_obank, wettedperim_obank, out=wettedperim_obank)
+    np.maximum(hydraulicrad_obank, 0.0, out=hydraulicrad_obank)
+    np.power(hydraulicrad_obank, 2/3, out=hydraulicrad_obank)
+
+    q_obank = np.multiply(wetarea_obank, hydraulicrad_obank, out=wetarea_obank)
+    del wetarea_obank, hydraulicrad_obank
+
+    np.add(vslope_main, slope_adj, out=slope)
+    np.maximum(slope, eps, out=slope)
+    np.sqrt(slope, out=slope)
+
+    np.multiply(q_obank, slope, out=q_obank)
+    np.multiply(q_obank, 1/np.float64(overbank_manning), out=q_obank)
+    del slope
+
+    # Compute total discharge
+    q_total = np.add(q_chan, q_obank, out=q_chan)
+    del q_chan, q_obank
+    np.equal(vstage, 0, out=mask)
+    np.putmask(q_total, mask, 0.0)
+
+    subdiv_applied = np.isnan(vstage_bf, out=mask)
+    np.putmask(q_total, subdiv_applied, vq_orig)
+    np.logical_not(subdiv_applied, out=subdiv_applied)
+    return subdiv_applied, q_total
+
+
+@use_pandas_3_behavior()
+def read_crosswalk(hydrofabric_dir, huc, branch):
+    read_cols = [
+            'Stage', 'Stage_bankfull', 'Volume (m3)', 'Volume_bankfull',
+            'SurfArea_bankfull', 'BedArea (m2)', 'BedArea_bankfull',
+            'LENGTHKM', 'SLOPE_RISE_RUN', 'SLOPE', 'Bathymetry_source',
+            'HydroID', 'Discharge (m3s-1)'
+    ]
+    path = os.path.join(hydrofabric_dir, huc, 'branches', branch, f"src_full_crosswalked_{branch}.csv")
+    df_src = pd.read_csv(path, engine='pyarrow', usecols=read_cols)
+    return df_src
+
+
+@use_pandas_3_behavior()
+def get_computed_subdivisions(df_src, channel_manning, overbank_manning, slope_adj):
+    subdiv_applied, final_discharge = compute_manning_subdivision(df_src, channel_manning, overbank_manning, slope_adj)
+
+    # We copy because we want to release df_src afterward
+    df_computed = pd.DataFrame({
+            'HydroID': df_src['HydroID'],
+            'stage': df_src['Stage'],
+            'Bathymetry_source': df_src['Bathymetry_source'],
+            'subdiv_applied': subdiv_applied,
+            'channel_n': channel_manning,
+            'overbank_n': overbank_manning,
+            'subdiv_discharge_cms': final_discharge,
+            'discharge_cms': final_discharge  # create a copy of vmann modified discharge (used to track future changes)
+        }, copy=False)
+
+    return df_computed
+
+
+@use_pandas_3_behavior()
 def get_subdivided_src(
     hydrofabric_dir,
     huc,
@@ -234,171 +370,32 @@ def get_subdivided_src(
         To get synthetic rating curve
 
     """
-
-    with fsspec.open(
-        os.path.join(hydrofabric_dir, huc, 'branches', branch, f"src_full_crosswalked_{branch}.csv"),
-        mode='rt',
-        encoding='utf-8',
-    ) as f:  # Use 'rt' for text mode, and specify encoding
-        df_src = pd.read_csv(f)
-
-    df_src = df_src.drop(
-        [
-            'channel_n',
-            'overbank_n',
-            'subdiv_applied',
-            'Discharge (m3s-1)_subdiv',
-            'Volume_chan (m3)',
-            'Volume_obank (m3)',
-            'BedArea_chan (m2)',
-            'BedArea_obank (m2)',
-            'WettedPerimeter_chan (m)',
-            'WettedPerimeter_obank (m)',
-        ],
-        axis=1,
-        errors='ignore',
-    )
-
-    with fsspec.open(
-        os.path.join(hydrofabric_dir, huc, "hydrotable.parquet"), mode='rb'
-    ) as f:  # Use 'rt' for text mode, and specify encoding
-        df_htable = pd.read_parquet(f, filters=[('branch_id', '==', int(branch))])
-    df_htable = df_htable.reset_index()
-    df_htable = df_htable.astype({'HUC': str, 'HydroID': int})
-
-    # Subdivide Geometry ----------------------------------------------------------------------------------
-    df_src['Volume_chan (m3)'] = np.where(
-        df_src['Stage'] <= df_src['Stage_bankfull'],
-        df_src['Volume (m3)'],
-        (
-            df_src['Volume_bankfull']
-            + ((df_src['Stage'] - df_src['Stage_bankfull']) * df_src['SurfArea_bankfull'])
-        ),
-    )
-    df_src['BedArea_chan (m2)'] = np.where(
-        df_src['Stage'] <= df_src['Stage_bankfull'], df_src['BedArea (m2)'], df_src['BedArea_bankfull']
-    )
-    df_src['WettedPerimeter_chan (m)'] = np.where(
-        df_src['Stage'] <= df_src['Stage_bankfull'],
-        (df_src['BedArea_chan (m2)'] / df_src['LENGTHKM'] / 1000),
-        (df_src['BedArea_chan (m2)'] / df_src['LENGTHKM'] / 1000)
-        + ((df_src['Stage'] - df_src['Stage_bankfull']) * 2),
-    )
-
-    # Calculate overbank volume & bed area
-    df_src['Volume_obank (m3)'] = np.where(
-        df_src['Stage'] > df_src['Stage_bankfull'], (df_src['Volume (m3)'] - df_src['Volume_chan (m3)']), 0.0
-    )
-    df_src['BedArea_obank (m2)'] = np.where(
-        df_src['Stage'] > df_src['Stage_bankfull'],
-        (df_src['BedArea (m2)'] - df_src['BedArea_chan (m2)']),
-        0.0,
-    )
-    df_src['WettedPerimeter_obank (m)'] = df_src['BedArea_obank (m2)'] / df_src['LENGTHKM'] / 1000
-
-    # Subdivide Geometry ----------------------------------------------------------------------------------
-    df_src['channel_n'] = channel_manning
-    df_src['overbank_n'] = overbank_manning
-    df_src['subdiv_applied'] = ~df_src['Stage_bankfull'].isnull()  # creat
-
-    # Subdivide Manning Eq --------------------------------------------------------------------------------
-    df_src = df_src.drop(
-        ['WetArea_chan (m2)', 'HydraulicRadius_chan (m)', 'Discharge_chan (m3s-1)', 'Velocity_chan (m/s)'],
-        axis=1,
-        errors='ignore',
-    )  # drop these cols (in case subdiv was previously performed)
-    df_src['WetArea_chan (m2)'] = df_src['Volume_chan (m3)'] / df_src['LENGTHKM'] / 1000
-    df_src['HydraulicRadius_chan (m)'] = df_src['WetArea_chan (m2)'] / df_src['WettedPerimeter_chan (m)']
-    df_src['HydraulicRadius_chan (m)'] = df_src['HydraulicRadius_chan (m)'].fillna(0)
-    df_src['Discharge_chan (m3s-1)'] = (
-        df_src['WetArea_chan (m2)']
-        * pow(df_src['HydraulicRadius_chan (m)'], 2.0 / 3)
-        * pow(np.max([df_src['SLOPE_RISE_RUN'] + slope_adj, np.repeat(1e-5, df_src.shape[0])], axis=0), 0.5)
-        / df_src['channel_n']
-    )
-    df_src['Velocity_chan (m/s)'] = df_src['Discharge_chan (m3s-1)'] / df_src['WetArea_chan (m2)']
-    df_src['Velocity_chan (m/s)'] = df_src['Velocity_chan (m/s)'].fillna(0)
-
-    # Calculate discharge (overbank) using Manning's equation
-    df_src = df_src.drop(
-        [
-            'WetArea_obank (m2)',
-            'HydraulicRadius_obank (m)',
-            'Discharge_obank (m3s-1)',
-            'Velocity_obank (m/s)',
-        ],
-        axis=1,
-        errors='ignore',
-    )  # drop these cols (in case subdiv was previously performed)
-    df_src['WetArea_obank (m2)'] = df_src['Volume_obank (m3)'] / df_src['LENGTHKM'] / 1000
-    df_src['HydraulicRadius_obank (m)'] = df_src['WetArea_obank (m2)'] / df_src['WettedPerimeter_obank (m)']
-    df_src = df_src.replace([np.inf, -np.inf], np.nan)  # need to replace inf instances (divide by 0)
-    df_src['HydraulicRadius_obank (m)'] = df_src['HydraulicRadius_obank (m)'].fillna(0)
-    df_src['Discharge_obank (m3s-1)'] = (
-        df_src['WetArea_obank (m2)']
-        * pow(df_src['HydraulicRadius_obank (m)'], 2.0 / 3)
-        * pow(np.max([df_src['SLOPE'] + slope_adj, np.repeat(1e-5, df_src.shape[0])], axis=0), 0.5)
-        / df_src['overbank_n']
-    )
-    df_src['Velocity_obank (m/s)'] = df_src['Discharge_obank (m3s-1)'] / df_src['WetArea_obank (m2)']
-    df_src['Velocity_obank (m/s)'] = df_src['Velocity_obank (m/s)'].fillna(0)
-
-    # Calcuate the total of the subdivided discharge (channel + overbank)
-    df_src = df_src.drop(
-        ['Discharge (m3s-1)_subdiv'], axis=1, errors='ignore'
-    )  # drop these cols (in case subdiv was previously performed)
-    df_src['Discharge (m3s-1)_subdiv'] = df_src['Discharge_chan (m3s-1)'] + df_src['Discharge_obank (m3s-1)']
-    df_src.loc[df_src['Stage'] == 0, ['Discharge (m3s-1)_subdiv']] = 0
-
-    # Subdivide Manning Eq --------------------------------------------------------------------------------
-
-    # Use the default discharge column when vmann is not being applied
-    df_src['Discharge (m3s-1)_subdiv'] = np.where(
-        df_src['subdiv_applied'] is False, df_src['Discharge (m3s-1)'], df_src['Discharge (m3s-1)_subdiv']
-    )  # reset the discharge value back to the original if vmann=false
-
-    df_src = df_src[
-        [
-            'HydroID',
-            'Stage',
-            'Bathymetry_source',
-            'subdiv_applied',
-            'channel_n',
-            'overbank_n',
-            'Discharge (m3s-1)_subdiv',
-        ]
-    ]
-
-    df_src = df_src.rename(columns={'Stage': 'stage', 'Discharge (m3s-1)_subdiv': 'subdiv_discharge_cms'})
-    df_src['discharge_cms'] = df_src[
-        'subdiv_discharge_cms'
-    ]  # create a copy of vmann modified discharge (used to track future changes)
-
+    df_src = read_crosswalk(hydrofabric_dir, huc, branch)
+    df_computed = get_computed_subdivisions(df_src, channel_manning, overbank_manning, slope_adj)
+    del df_src
+    
     # drop the previously modified discharge column to be replaced with updated version
-    df_htable = df_htable.drop(
-        [
-            'subdiv_applied',
-            'discharge_cms',
-            'overbank_n',
-            'channel_n',
-            'subdiv_discharge_cms',
-            'Bathymetry_source',
-        ],
-        axis=1,
-        errors='ignore',
-    )
+    path = os.path.join(hydrofabric_dir, huc, "hydrotable.parquet")
+
+    htable_cols = ['HydroID', 'feature_id', 
+                   'HUC', 'branch_id', 'stage',
+                   'SurfaceArea (m2)', 'LakeID']
+    df_htable = pd.read_parquet(path, engine='pyarrow', filters=[('branch_id', '==', int(branch))],
+                               columns=htable_cols)
+    df_htable = df_htable.reset_index()
+    df_htable = df_htable.astype({'HUC': "string[pyarrow]", 'HydroID': int, 'feature_id': "string[pyarrow]"})
+
     df_htable = df_htable.merge(
-        df_src, how='left', left_on=['HydroID', 'stage'], right_on=['HydroID', 'stage']
+        df_computed, how='left', left_on=['HydroID', 'stage'], right_on=['HydroID', 'stage']
     )
 
     df_htable['branch_id'] = int(branch)
     df_htable['LakeID'] = -999
-    df_htable['HydroID'] = df_htable['HydroID'].astype(str)
-    df_htable['feature_id'] = df_htable['feature_id'].astype(str)
     df_htable['precalb_discharge_cms'] = 0
 
     output_table = os.path.join(htable_directory, htable_output.format(branch))
     df_htable.to_feather(output_table)
+    return output_table
 
 
 def inundate_probabilistic(


### PR DESCRIPTION
Significantly improves performance and memory usage of the manning subdivision code.

### Additions
* Streamline manning subdivision. Almost all the computation happens within numpy/C layer. For 19020104 huc, branch 0, the manning subdivision is computed in 525ms. Reusing memory buffers within numpy results in significantly reduced memory usage.
* Add `use_pandas_3_behavior` decorator. This enables current pandas 3.0 behavior in pandas 2.2+ within a scoped block (function or context).

### Changes
* Several parts of the computation were modified to improve numerical stability and enforce physical constraints.

I observed that the bottleneck of the original function is actually reading files. I split the file I/O and the computation into separate pieces. Switching to a faster csv parser (pyarrow) halved the runtime.

ping @RobHanna-NOAA 