### PR TITLE
[1pt] PR: Pass the required file_logger to __polygonize in preprocess_nhdplus

### DIFF
--- a/data/nhdplus/preprocess_nhdplus.py
+++ b/data/nhdplus/preprocess_nhdplus.py
@@ -3,12 +3,14 @@
 import argparse
 import os
 import sys
+from datetime import datetime, timezone
 
 import geopandas as gpd
 import py7zr
 import rasterio as rio
 from osgeo import gdal
 
+import src.utils.shared_functions as sf
 from data.create_vrt_file import create_vrt_file
 from data.derive_headwaters import findHeadWaterPoints
 from data.nfhl.download_fema_nfhl import download_nfhl_wrapper
@@ -192,7 +194,11 @@ def preprocess_region(
     create_vrt_file(target_dem_folder, 'hand_seamless_3dep_dems.vrt')
 
     # Create DEM_Domain.parquet
-    __polygonize(target_dem_folder)
+    file_dt_string = datetime.now(timezone.utc).strftime("%Y_%m_%d-%H_%M_%S")
+    log_file_path = os.path.join(target_dem_folder, f"preprocess_nhdplus_{region}-{file_dt_string}.log")
+    file_logger = sf.setup_mp_file_logger(log_file_path, f"preprocess_nhdplus_{region}")
+
+    __polygonize(target_dem_folder, file_logger)
 
     # Extract and reproject NHDPlus streams
     nhd_flowline = os.path.join(nhd_path, 'NHDFlowline.shp')

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## v4.10.1.2 - 2026-09-04 - [PR#1943](https://github.com/NOAA-OWP/inundation-mapping/pull/1943)
+
+`preprocess_nhdplus()` called `__polygonize()` with one argument while that function has always
+required two (`target_output_folder_path`, `file_logger`), so the Guam / AmericanSamoa preprocessing
+run raised a `TypeError` right after the VRT was built and never produced `DEM_Domain.parquet`.
+
+### Changes
+- `data/nhdplus/preprocess_nhdplus.py`: Set up a file logger with `setup_mp_file_logger()` and pass it to
+  `__polygonize()`, matching the call in `data/usgs/acquire_and_preprocess_3dep_dems.py`.
+<br />
+
 ## v4.10.1.1 - 2026-09-03 - [PR##1942](https://github.com/NOAA-OWP/inundation-mapping/pull/1942)
 
 This PR smooths out some outstanding quirks found after merging the CatFIM reorg changes into dev and creates a new CatFIM tool for joining outputs from a secondary run (such as Guam stage-based) into the primary CatFIM outputs.


### PR DESCRIPTION
`preprocess_nhdplus()` calls `__polygonize()` with one argument, but that function has required two since it was written. The Guam / AmericanSamoa preprocessing run dies with a `TypeError` right after the VRT is built, before `DEM_Domain.parquet` is ever created.

```
data/usgs/acquire_and_preprocess_3dep_dems.py:458
    def __polygonize(target_output_folder_path, file_logger):

data/usgs/acquire_and_preprocess_3dep_dems.py:230   (the other call site)
    __polygonize(target_output_folder_path, file_logger)          # 2 args

data/nhdplus/preprocess_nhdplus.py:195               (this one)
    __polygonize(target_dem_folder)                               # 1 arg  ->  TypeError
```

Passing `None` is not a workaround: the first statement in `__polygonize` is `sf.l_print(msg, file_logger, "info")`, and `l_print` calls `file_logger.info(msg)` unconditionally, so `None` just moves the failure one line down into an `AttributeError`. `preprocess_nhdplus.py` has no logger of its own today — it prints everything — so the fix sets one up the same way `acquire_and_preprocess_3dep_dems.py` does (lines 183-187) and hands it over.

### Changes

- `data/nhdplus/preprocess_nhdplus.py`: Create a file logger with `sf.setup_mp_file_logger()` before polygonizing and pass it to `__polygonize()`, which has always required it. The log is written next to the DEMs as `preprocess_nhdplus_<region>-<timestamp>.log`.
- `docs/CHANGELOG.md`: Version bump.

---------------------------------------------------------------
### Testing

I have no access to the NHDPlus / 3DEP inputs, so this was verified against the repository sources rather than by a live run. Both functions were lifted verbatim out of the checked-in files (`ast` + `exec`, no hand-copying) and exercised directly:

```
__polygonize signature : (target_output_folder_path, file_logger)

=== 1. arity replay via inspect.Signature.bind ===
  preprocess_nhdplus.py  (unpatched): line 195, 1 arg(s) -> TypeError: missing a required argument: 'file_logger'
  preprocess_nhdplus.py  (patched)  : line 201, 2 arg(s) -> OK
  acquire_..._3dep_dems.py (existing, correct): line 230, 2 arg(s) -> OK

=== 2. what the very first statement of __polygonize does with file_logger=None ===
  source : sf.l_print(msg, file_logger, 'info')
  result : AttributeError: 'NoneType' object has no attribute 'info'

=== 3. patched path: logger really gets built and written to ===
  log file exists: True
  contents       : 2026-09-04 12:11:50,925 - INFO -  - Polygonizing -- DEM_Domain.parquet - Started
```

`isort` 7.0.0, `black` 25.12.0 and `flake8` 7.3.0 were run at the versions pinned in `.pre-commit-config.yaml` with the repo's `pyproject.toml`; the changed file is clean.

Nothing else in the polygonize path is touched, and no other call site of `__polygonize` exists in the repo.

---------------------------------------------------------------
### Developer checklist

- [x] If there are any new or updated inputs, docker file changes, pipfile, or python changes, did you fill out the deployment plan section below? (no input/docker/package changes)
- [x] Informative and human-readable title, using the format: `[_pt] PR: <description>`
- [x] Descriptive feature branch name using the format `dev-<description-of-change>`
- [x] The feature branch is up to date with the latest `dev` branch
- [x] Have the linting tools be run?
- [x] Any _change_ in functionality is tested
- [x] [CHANGELOG](/docs/CHANGELOG.md) updated with template version number

### Deployment Plan

- **Does the change impact inputs, docker or python packages?**
    - [ ] Yes
    - [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
